### PR TITLE
Move FRE warning glyphs into XAML

### DIFF
--- a/src/cascadia/TerminalApp/FreOverlay.xaml
+++ b/src/cascadia/TerminalApp/FreOverlay.xaml
@@ -581,10 +581,24 @@
                                 HorizontalAlignment="Left" VerticalAlignment="Center"
                                 MaxWidth="440" Spacing="2"
                                 Visibility="Collapsed">
-                        <TextBlock x:Name="ErrorText"
-                                   Foreground="#FFFF6B6B" FontSize="13"
-                                   TextWrapping="Wrap"
-                                   AutomationProperties.LiveSetting="Assertive" />
+                        <Grid ColumnSpacing="6">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <FontIcon Grid.Column="0"
+                                      Glyph="&#xE7BA;"
+                                      FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                      FontSize="13"
+                                      Foreground="#FFFF6B6B"
+                                      VerticalAlignment="Top"
+                                      Margin="0,1,0,0" />
+                            <TextBlock Grid.Column="1"
+                                       x:Name="ErrorText"
+                                       Foreground="#FFFF6B6B" FontSize="13"
+                                       TextWrapping="Wrap"
+                                       AutomationProperties.LiveSetting="Assertive" />
+                        </Grid>
                         <TextBlock FontSize="12" TextWrapping="Wrap">
                             <Hyperlink x:Name="ErrorHelpLink"
                                        NavigateUri="https://aka.ms/intelligent-terminal-dependency"

--- a/src/cascadia/TerminalApp/FreOverlay.xaml
+++ b/src/cascadia/TerminalApp/FreOverlay.xaml
@@ -582,6 +582,10 @@
                                 MaxWidth="440" Spacing="2"
                                 Visibility="Collapsed">
                         <Grid ColumnSpacing="6">
+                            <Grid.Resources>
+                                <SolidColorBrush x:Key="ErrorForegroundBrush"
+                                                 Color="#FFFF6B6B" />
+                            </Grid.Resources>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto" />
                                 <ColumnDefinition Width="*" />
@@ -590,12 +594,13 @@
                                       Glyph="&#xE7BA;"
                                       FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                       FontSize="13"
-                                      Foreground="#FFFF6B6B"
+                                      Foreground="{StaticResource ErrorForegroundBrush}"
                                       VerticalAlignment="Top"
                                       Margin="0,1,0,0" />
                             <TextBlock Grid.Column="1"
                                        x:Name="ErrorText"
-                                       Foreground="#FFFF6B6B" FontSize="13"
+                                       Foreground="{StaticResource ErrorForegroundBrush}"
+                                       FontSize="13"
                                        TextWrapping="Wrap"
                                        AutomationProperties.LiveSetting="Assertive" />
                         </Grid>

--- a/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/af-ZA/Resources.resw
@@ -110,39 +110,39 @@
     <value>Word opgestel...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Installering van {0} is deur 'n Windows-pakketbestuurderbeleid geblokkeer. As jy op 'n bestuurde toestel is, kontak jou IT-administrateur.</value>
+    <value>Installering van {0} is deur 'n Windows-pakketbestuurderbeleid geblokkeer. As jy op 'n bestuurde toestel is, kontak jou IT-administrateur.</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Kon nie {0} installeer nie (foutkode {1}). Sien die logboek vir besonderhede, of installeer {0} handmatig.</value>
+    <value>Kon nie {0} installeer nie (foutkode {1}). Sien die logboek vir besonderhede, of installeer {0} handmatig.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Kon nie {0} installeer nie. Sien die logboek vir besonderhede, of installeer {0} handmatig.</value>
+    <value>Kon nie {0} installeer nie. Sien die logboek vir besonderhede, of installeer {0} handmatig.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Die {0}-installeerder het ’n fout gerapporteer (kode {1}). Gaan die logboek na vir besonderhede, of installeer {0} handmatig.</value>
+    <value>Die {0}-installeerder het ’n fout gerapporteer (kode {1}). Gaan die logboek na vir besonderhede, of installeer {0} handmatig.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Kon nie die Windows-pakketbestuurder bereik terwyl {0} geïnstalleer is nie. Kontroleer jou internetverbinding (VPN, instaanbediener of brandmuur blokkeer dit dalk) en probeer weer.</value>
+    <value>Kon nie die Windows-pakketbestuurder bereik terwyl {0} geïnstalleer is nie. Kontroleer jou internetverbinding (VPN, instaanbediener of brandmuur blokkeer dit dalk) en probeer weer.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Geen versoenbare installeerder vir {0} is op hierdie stelsel beskikbaar nie (OS-weergawe of argitektuur word dalk nie ondersteun nie). Installeer {0} handmatig.</value>
+    <value>Geen versoenbare installeerder vir {0} is op hierdie stelsel beskikbaar nie (OS-weergawe of argitektuur word dalk nie ondersteun nie). Installeer {0} handmatig.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} is nie in die Windows-pakketbestuurderkatalogus gevind nie. Probeer winget-bronne verfris, of installeer {0} handmatig.</value>
+    <value>{0} is nie in die Windows-pakketbestuurderkatalogus gevind nie. Probeer winget-bronne verfris, of installeer {0} handmatig.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Installering van {0} het langer as 20 minute geneem. Intelligent Terminal het opgehou wag, maar die installeerder loop dalk nog in die agtergrond. Gaan Task Manager na, of probeer later weer.</value>
+    <value>Installering van {0} het langer as 20 minute geneem. Intelligent Terminal het opgehou wag, maar die installeerder loop dalk nog in die agtergrond. Gaan Task Manager na, of probeer later weer.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows-pakketbestuurder (winget) is nie geïnstalleer nie of is nie beskikbaar nie. Installeer dit eers en probeer dan weer.</value>
+    <value>Windows-pakketbestuurder (winget) is nie geïnstalleer nie of is nie beskikbaar nie. Installeer dit eers en probeer dan weer.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -234,9 +234,9 @@
     <value>Gee Intelligent Terminal toestemming om toegang tot jou dop te verkry en foute outomaties op te spoor.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Kon nie dop-integrasie installeer nie. Foutopsporing is afgeskakel. Jy kan dit weer aktiveer en weer probeer, of stoor om sonder dit voort te gaan.</value>
+    <value>Kon nie dop-integrasie installeer nie. Foutopsporing is afgeskakel. Jy kan dit weer aktiveer en weer probeer, of stoor om sonder dit voort te gaan.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Kon nie session hooks installeer nie. Sessiebestuur is afgeskakel. Jy kan dit weer aktiveer en weer probeer, of stoor om sonder dit voort te gaan.</value>
+    <value>Kon nie session hooks installeer nie. Sessiebestuur is afgeskakel. Jy kan dit weer aktiveer en weer probeer, of stoor om sonder dit voort te gaan.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Leer hoe om dit handmatig reg te stel</value>
@@ -252,7 +252,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell-uitvoeringsbeleid blokkeer skripte. Foutopsporing afgeskakel.</value>
+    <value>PowerShell-uitvoeringsbeleid blokkeer skripte. Foutopsporing afgeskakel.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Gebruik</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/am-ET/Resources.resw
@@ -110,39 +110,39 @@
     <value>በማያቄር ላይ...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ የ{0} ጭነት በWindows Package Manager ፖሊሲ ታግዷል። በሚተዳደር መሣሪያ ላይ ከሆኑ፣ የIT አስተዳዳሪዎን ያግኙ።</value>
+    <value>የ{0} ጭነት በWindows Package Manager ፖሊሲ ታግዷል። በሚተዳደር መሣሪያ ላይ ከሆኑ፣ የIT አስተዳዳሪዎን ያግኙ።</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0}ን መጫን አልተቻለም (የስህተት ኮድ {1})። ለዝርዝሮች ሎጉን ይመልከቱ፣ ወይም {0}ን በእጅ ይጫኑ።</value>
+    <value>{0}ን መጫን አልተቻለም (የስህተት ኮድ {1})። ለዝርዝሮች ሎጉን ይመልከቱ፣ ወይም {0}ን በእጅ ይጫኑ።</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0}ን መጫን አልተቻለም። ለዝርዝሮች ሎጉን ይመልከቱ፣ ወይም {0}ን በእጅ ይጫኑ።</value>
+    <value>{0}ን መጫን አልተቻለም። ለዝርዝሮች ሎጉን ይመልከቱ፣ ወይም {0}ን በእጅ ይጫኑ።</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ የ{0} ጫኚ ስህተት አሳውቋል (ኮድ {1})። ለዝርዝሮች ሎጉን ይመልከቱ፣ ወይም {0}ን በእጅ ይጫኑ።</value>
+    <value>የ{0} ጫኚ ስህተት አሳውቋል (ኮድ {1})። ለዝርዝሮች ሎጉን ይመልከቱ፣ ወይም {0}ን በእጅ ይጫኑ።</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0}ን በመጫን ላይ ሳለ Windows Package Managerን መድረስ አልተቻለም። የኢንተርኔት ግንኙነትዎን ይፈትሹ (VPN፣ ፕሮክሲ ወይም ፋየርዎል ሊከለክለው ይችላል) እና እንደገና ይሞክሩ።</value>
+    <value>{0}ን በመጫን ላይ ሳለ Windows Package Managerን መድረስ አልተቻለም። የኢንተርኔት ግንኙነትዎን ይፈትሹ (VPN፣ ፕሮክሲ ወይም ፋየርዎል ሊከለክለው ይችላል) እና እንደገና ይሞክሩ።</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ በዚህ ስርዓት ላይ ለ{0} ተኳኋኝ ጫኚ አይገኝም (የOS ስሪት ወይም አርክቴክቸር ላይደገፍ ይችላል)። {0}ን በእጅ ይጫኑ።</value>
+    <value>በዚህ ስርዓት ላይ ለ{0} ተኳኋኝ ጫኚ አይገኝም (የOS ስሪት ወይም አርክቴክቸር ላይደገፍ ይችላል)። {0}ን በእጅ ይጫኑ።</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} በWindows Package Manager ካታሎግ ውስጥ አልተገኘም። የwinget ምንጮችን ለማደስ ይሞክሩ፣ ወይም {0}ን በእጅ ይጫኑ።</value>
+    <value>{0} በWindows Package Manager ካታሎግ ውስጥ አልተገኘም። የwinget ምንጮችን ለማደስ ይሞክሩ፣ ወይም {0}ን በእጅ ይጫኑ።</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0}ን መጫን ከ20 ደቂቃ በላይ ወሰደ። Intelligent Terminal መጠበቁን አቁሟል፣ ግን ጫኚው አሁንም ከበስተጀርባ እየሰራ ሊሆን ይችላል። Task Managerን ይፈትሹ፣ ወይም በኋላ እንደገና ይሞክሩ።</value>
+    <value>{0}ን መጫን ከ20 ደቂቃ በላይ ወሰደ። Intelligent Terminal መጠበቁን አቁሟል፣ ግን ጫኚው አሁንም ከበስተጀርባ እየሰራ ሊሆን ይችላል። Task Managerን ይፈትሹ፣ ወይም በኋላ እንደገና ይሞክሩ።</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) አልተጫነም ወይም አይገኝም። መጀመሪያ ይጫኑት፣ ከዚያ እንደገና ይሞክሩ።</value>
+    <value>Windows Package Manager (winget) አልተጫነም ወይም አይገኝም። መጀመሪያ ይጫኑት፣ ከዚያ እንደገና ይሞክሩ።</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -234,9 +234,9 @@
     <value>Intelligent Terminal ወደ ሼልዎ መድረስ እና ስህተቶችን ራስ-ሰር እንዲያውቅ ይፍቀዱ።</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ የሼል ውህደት መጫን አልተሳካም። የስህተት ማወቂያ ጠፍቷል። እንደገና ማንቃት እና መሞከር ይችላሉ፣ ወይም ያለ እሱ ለመቀጠል ያስቀምጡ።</value>
+    <value>የሼል ውህደት መጫን አልተሳካም። የስህተት ማወቂያ ጠፍቷል። እንደገና ማንቃት እና መሞከር ይችላሉ፣ ወይም ያለ እሱ ለመቀጠል ያስቀምጡ።</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks መጫን አልተሳካም። የክፍለ ጊዜ አስተዳደር ጠፍቷል። እንደገና ማንቃት እና መሞከር ይችላሉ፣ ወይም ያለ እሱ ለመቀጠል ያስቀምጡ።</value>
+    <value>session hooks መጫን አልተሳካም። የክፍለ ጊዜ አስተዳደር ጠፍቷል። እንደገና ማንቃት እና መሞከር ይችላሉ፣ ወይም ያለ እሱ ለመቀጠል ያስቀምጡ።</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>ይህንን በእጅ እንዴት እንደሚያስተካክሉ ይወቁ</value>
@@ -252,7 +252,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ የPowerShell ማስፈጸሚያ ፖሊሲ ስክሪፕቶችን እያገደ ነው። የስህተት ማወቂያ ጠፍቷል።</value>
+    <value>የPowerShell ማስፈጸሚያ ፖሊሲ ስክሪፕቶችን እያገደ ነው። የስህተት ማወቂያ ጠፍቷል።</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>አጠቃቀም</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ar-SA/Resources.resw
@@ -224,39 +224,39 @@
     <value>جارٍ الإعداد...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ تم حظر تثبيت {0} بواسطة نهج مدير حزم Windows. إذا كنت تستخدم جهازًا مُدارًا، فاتصل بمسؤول تكنولوجيا المعلومات لديك.</value>
+    <value>تم حظر تثبيت {0} بواسطة نهج مدير حزم Windows. إذا كنت تستخدم جهازًا مُدارًا، فاتصل بمسؤول تكنولوجيا المعلومات لديك.</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ تعذر تثبيت {0} (رمز الخطأ {1}). راجع السجل للحصول على التفاصيل، أو ثبّت {0} يدويًا.</value>
+    <value>تعذر تثبيت {0} (رمز الخطأ {1}). راجع السجل للحصول على التفاصيل، أو ثبّت {0} يدويًا.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ تعذر تثبيت {0}. راجع السجل للحصول على التفاصيل، أو ثبّت {0} يدويًا.</value>
+    <value>تعذر تثبيت {0}. راجع السجل للحصول على التفاصيل، أو ثبّت {0} يدويًا.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ أبلغ مُثبّت {0} عن خطأ (الرمز {1}). راجع السجل للحصول على التفاصيل، أو ثبّت {0} يدويًا.</value>
+    <value>أبلغ مُثبّت {0} عن خطأ (الرمز {1}). راجع السجل للحصول على التفاصيل، أو ثبّت {0} يدويًا.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ تعذر الوصول إلى مدير حزم Windows أثناء تثبيت {0}. تحقق من اتصالك بالإنترنت (قد يكون VPN أو الوكيل أو جدار الحماية يحظره) ثم أعد المحاولة.</value>
+    <value>تعذر الوصول إلى مدير حزم Windows أثناء تثبيت {0}. تحقق من اتصالك بالإنترنت (قد يكون VPN أو الوكيل أو جدار الحماية يحظره) ثم أعد المحاولة.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ لا يتوفر مُثبّت متوافق لـ {0} على هذا النظام (قد لا يكون إصدار نظام التشغيل أو البنية مدعومًا). ثبّت {0} يدويًا.</value>
+    <value>لا يتوفر مُثبّت متوافق لـ {0} على هذا النظام (قد لا يكون إصدار نظام التشغيل أو البنية مدعومًا). ثبّت {0} يدويًا.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ لم يتم العثور على {0} في كتالوج مدير حزم Windows. حاول تحديث مصادر winget، أو ثبّت {0} يدويًا.</value>
+    <value>لم يتم العثور على {0} في كتالوج مدير حزم Windows. حاول تحديث مصادر winget، أو ثبّت {0} يدويًا.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ استغرق تثبيت {0} أكثر من 20 دقيقة. توقف Intelligent Terminal عن الانتظار، ولكن قد يظل المُثبّت قيد التشغيل في الخلفية. تحقق من Task Manager، أو حاول مرة أخرى لاحقًا.</value>
+    <value>استغرق تثبيت {0} أكثر من 20 دقيقة. توقف Intelligent Terminal عن الانتظار، ولكن قد يظل المُثبّت قيد التشغيل في الخلفية. تحقق من Task Manager، أو حاول مرة أخرى لاحقًا.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ مدير حزم Windows (winget) غير مثبت أو غير متوفر. قم بتثبيته أولاً، ثم أعد المحاولة.</value>
+    <value>مدير حزم Windows (winget) غير مثبت أو غير متوفر. قم بتثبيته أولاً، ثم أعد المحاولة.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>امنح Intelligent Terminal إذنًا بالوصول إلى الصدفة واكتشاف الأخطاء تلقائيًا.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ فشل تثبيت تكامل الصدفة. تم إيقاف اكتشاف الأخطاء. يمكنك إعادة تمكينه والمحاولة مرة أخرى، أو الحفظ للمتابعة بدونه.</value>
+    <value>فشل تثبيت تكامل الصدفة. تم إيقاف اكتشاف الأخطاء. يمكنك إعادة تمكينه والمحاولة مرة أخرى، أو الحفظ للمتابعة بدونه.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ فشل تثبيت session hooks. تم إيقاف إدارة الجلسات. يمكنك إعادة تمكينها والمحاولة مرة أخرى، أو الحفظ للمتابعة بدونها.</value>
+    <value>فشل تثبيت session hooks. تم إيقاف إدارة الجلسات. يمكنك إعادة تمكينها والمحاولة مرة أخرى، أو الحفظ للمتابعة بدونها.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>تعرف على كيفية إصلاح ذلك يدويًا</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ نهج تنفيذ PowerShell يحظر البرامج النصية. تم إيقاف اكتشاف الأخطاء.</value>
+    <value>نهج تنفيذ PowerShell يحظر البرامج النصية. تم إيقاف اكتشاف الأخطاء.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>الاستخدام</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/as-IN/Resources.resw
@@ -224,50 +224,50 @@
     <value>ছেটআপ হৈ আছে...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager নীতিৰ দ্বাৰা {0} ইনষ্টলেশ্বন অৱৰোধ কৰা হৈছে। যদি আপুনি পৰিচালিত ডিভাইচত আছে, আপোনাৰ IT এডমিনৰ সৈতে যোগাযোগ কৰক।</value>
+    <value>Windows Package Manager নীতিৰ দ্বাৰা {0} ইনষ্টলেশ্বন অৱৰোধ কৰা হৈছে। যদি আপুনি পৰিচালিত ডিভাইচত আছে, আপোনাৰ IT এডমিনৰ সৈতে যোগাযোগ কৰক।</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} ইনষ্টল কৰিব পৰা নগ'ল (ত্ৰুটি কোড {1})। বিৱৰণৰ বাবে ল'গ চাওক, বা {0} মেনুৱেলি ইনষ্টল কৰক।</value>
+    <value>{0} ইনষ্টল কৰিব পৰা নগ'ল (ত্ৰুটি কোড {1})। বিৱৰণৰ বাবে ল'গ চাওক, বা {0} মেনুৱেলি ইনষ্টল কৰক।</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} ইনষ্টল কৰিব পৰা নগ'ল। বিৱৰণৰ বাবে ল'গ চাওক, বা {0} মেনুৱেলি ইনষ্টল কৰক।</value>
+    <value>{0} ইনষ্টল কৰিব পৰা নগ'ল। বিৱৰণৰ বাবে ল'গ চাওক, বা {0} মেনুৱেলি ইনষ্টল কৰক।</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} ইনষ্টলাৰে এটা ত্ৰুটি জনাইছে (কোড {1})। বিৱৰণৰ বাবে ল'গ পৰীক্ষা কৰক, বা {0} মেনুৱেলি ইনষ্টল কৰক।</value>
+    <value>{0} ইনষ্টলাৰে এটা ত্ৰুটি জনাইছে (কোড {1})। বিৱৰণৰ বাবে ল'গ পৰীক্ষা কৰক, বা {0} মেনুৱেলি ইনষ্টল কৰক।</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} ইনষ্টল কৰোঁতে Windows Package Manager-ৰ সৈতে যোগাযোগ কৰিব পৰা নগ'ল। আপোনাৰ ইণ্টাৰনেট সংযোগ পৰীক্ষা কৰক (VPN, proxy, বা firewall-এ ইয়াক অৱৰোধ কৰি থাকিব পাৰে) আৰু পুনৰ চেষ্টা কৰক।</value>
+    <value>{0} ইনষ্টল কৰোঁতে Windows Package Manager-ৰ সৈতে যোগাযোগ কৰিব পৰা নগ'ল। আপোনাৰ ইণ্টাৰনেট সংযোগ পৰীক্ষা কৰক (VPN, proxy, বা firewall-এ ইয়াক অৱৰোধ কৰি থাকিব পাৰে) আৰু পুনৰ চেষ্টা কৰক।</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ এই ছিষ্টেমত {0}-ৰ বাবে কোনো সুসংগত ইনষ্টলাৰ উপলব্ধ নহয় (OS সংস্কৰণ বা আর্কিটেকচাৰ সমৰ্থিত নহ'ব পাৰে)। {0} মেনুৱেলি ইনষ্টল কৰক।</value>
+    <value>এই ছিষ্টেমত {0}-ৰ বাবে কোনো সুসংগত ইনষ্টলাৰ উপলব্ধ নহয় (OS সংস্কৰণ বা আর্কিটেকচাৰ সমৰ্থিত নহ'ব পাৰে)। {0} মেনুৱেলি ইনষ্টল কৰক।</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager কেটালগত {0} পোৱা নগ'ল। winget উৎসসমূহ refresh কৰিবলৈ চেষ্টা কৰক, বা {0} মেনুৱেলি ইনষ্টল কৰক।</value>
+    <value>Windows Package Manager কেটালগত {0} পোৱা নগ'ল। winget উৎসসমূহ refresh কৰিবলৈ চেষ্টা কৰক, বা {0} মেনুৱেলি ইনষ্টল কৰক।</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} ইনষ্টল কৰাত 20 মিনিটতকৈ অধিক সময় লাগিল। Intelligent Terminal-এ অপেক্ষা কৰা বন্ধ কৰিলে, কিন্তু ইনষ্টলাৰটো এতিয়াও পটভূমিত চলি থাকিব পাৰে। Task Manager পৰীক্ষা কৰক, বা পাছত পুনৰ চেষ্টা কৰক।</value>
+    <value>{0} ইনষ্টল কৰাত 20 মিনিটতকৈ অধিক সময় লাগিল। Intelligent Terminal-এ অপেক্ষা কৰা বন্ধ কৰিলে, কিন্তু ইনষ্টলাৰটো এতিয়াও পটভূমিত চলি থাকিব পাৰে। Task Manager পৰীক্ষা কৰক, বা পাছত পুনৰ চেষ্টা কৰক।</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks ইনষ্টল কৰাত বিফল হ'ল। ছেছন ব্যৱস্থাপনা বন্ধ কৰা হৈছে। আপুনি ইয়াক পুনৰ সক্ৰিয় কৰি পুনৰ চেষ্টা কৰিব পাৰে, বা ইয়াৰ অবিহনে আগবাঢ়িবলৈ সংৰক্ষণ কৰক।</value>
+    <value>session hooks ইনষ্টল কৰাত বিফল হ'ল। ছেছন ব্যৱস্থাপনা বন্ধ কৰা হৈছে। আপুনি ইয়াক পুনৰ সক্ৰিয় কৰি পুনৰ চেষ্টা কৰিব পাৰে, বা ইয়াৰ অবিহনে আগবাঢ়িবলৈ সংৰক্ষণ কৰক।</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ শ্বেল সংহতি ইনষ্টল কৰাত বিফল হ'ল। ত্ৰুটি চিনাক্তকৰণ বন্ধ কৰা হৈছে। আপুনি ইয়াক পুনৰ সক্ৰিয় কৰি পুনৰ চেষ্টা কৰিব পাৰে, বা ইয়াৰ অবিহনে আগবাঢ়িবলৈ সংৰক্ষণ কৰক।</value>
+    <value>শ্বেল সংহতি ইনষ্টল কৰাত বিফল হ'ল। ত্ৰুটি চিনাক্তকৰণ বন্ধ কৰা হৈছে। আপুনি ইয়াক পুনৰ সক্ৰিয় কৰি পুনৰ চেষ্টা কৰিব পাৰে, বা ইয়াৰ অবিহনে আগবাঢ়িবলৈ সংৰক্ষণ কৰক।</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell এক্সিকিউচন নীতিয়ে স্ক্ৰিপ্ট অৱৰোধ কৰি আছে। ত্ৰুটি চিনাক্তকৰণ বন্ধ কৰা হ’ল।</value>
+    <value>PowerShell এক্সিকিউচন নীতিয়ে স্ক্ৰিপ্ট অৱৰোধ কৰি আছে। ত্ৰুটি চিনাক্তকৰণ বন্ধ কৰা হ’ল।</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) ইনষ্টল কৰা নাই বা উপলব্ধ নহয়। প্ৰথমে ইয়াক ইনষ্টল কৰক, তাৰ পিছত পুনৰ চেষ্টা কৰক।</value>
+    <value>Windows Package Manager (winget) ইনষ্টল কৰা নাই বা উপলব্ধ নহয়। প্ৰথমে ইয়াক ইনষ্টল কৰক, তাৰ পিছত পুনৰ চেষ্টা কৰক।</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/az-Latn-AZ/Resources.resw
@@ -223,39 +223,39 @@
     <value>Qurulur...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ {0} quraşdırılması Windows Paket Meneceri siyasəti tərəfindən bloklandı. İdarə olunan cihazdasınızsa, IT administratorunuzla əlaqə saxlayın.</value>
+    <value>{0} quraşdırılması Windows Paket Meneceri siyasəti tərəfindən bloklandı. İdarə olunan cihazdasınızsa, IT administratorunuzla əlaqə saxlayın.</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} quraşdırıla bilmədi (xəta kodu {1}). Təfərrüatlar üçün jurnala baxın və ya {0} paketini əl ilə quraşdırın.</value>
+    <value>{0} quraşdırıla bilmədi (xəta kodu {1}). Təfərrüatlar üçün jurnala baxın və ya {0} paketini əl ilə quraşdırın.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} quraşdırıla bilmədi. Təfərrüatlar üçün jurnala baxın və ya {0} paketini əl ilə quraşdırın.</value>
+    <value>{0} quraşdırıla bilmədi. Təfərrüatlar üçün jurnala baxın və ya {0} paketini əl ilə quraşdırın.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} quraşdırıcısı xəta bildirdi (kod {1}). Təfərrüatlar üçün jurnalı yoxlayın və ya {0} paketini əl ilə quraşdırın.</value>
+    <value>{0} quraşdırıcısı xəta bildirdi (kod {1}). Təfərrüatlar üçün jurnalı yoxlayın və ya {0} paketini əl ilə quraşdırın.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} quraşdırılarkən Windows Paket Menecerinə qoşulmaq mümkün olmadı. İnternet bağlantınızı yoxlayın (VPN, proksi və ya təhlükəsizlik divarı onu bloklaya bilər) və yenidən cəhd edin.</value>
+    <value>{0} quraşdırılarkən Windows Paket Menecerinə qoşulmaq mümkün olmadı. İnternet bağlantınızı yoxlayın (VPN, proksi və ya təhlükəsizlik divarı onu bloklaya bilər) və yenidən cəhd edin.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Bu sistemdə {0} üçün uyğun quraşdırıcı mövcud deyil (OS versiyası və ya arxitektura dəstəklənməyə bilər). {0} paketini əl ilə quraşdırın.</value>
+    <value>Bu sistemdə {0} üçün uyğun quraşdırıcı mövcud deyil (OS versiyası və ya arxitektura dəstəklənməyə bilər). {0} paketini əl ilə quraşdırın.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} Windows Paket Meneceri kataloqunda tapılmadı. winget mənbələrini yeniləməyi sınayın və ya {0} paketini əl ilə quraşdırın.</value>
+    <value>{0} Windows Paket Meneceri kataloqunda tapılmadı. winget mənbələrini yeniləməyi sınayın və ya {0} paketini əl ilə quraşdırın.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} quraşdırılması 20 dəqiqədən çox çəkdi. Intelligent Terminal gözləməyi dayandırdı, lakin quraşdırıcı hələ də arxa planda işləyə bilər. Task Manager-i yoxlayın və ya sonra yenidən cəhd edin.</value>
+    <value>{0} quraşdırılması 20 dəqiqədən çox çəkdi. Intelligent Terminal gözləməyi dayandırdı, lakin quraşdırıcı hələ də arxa planda işləyə bilər. Task Manager-i yoxlayın və ya sonra yenidən cəhd edin.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Paket Meneceri (winget) quraşdırılmayıb və ya əlçatan deyil. Əvvəlcə onu quraşdırın, sonra yenidən cəhd edin.</value>
+    <value>Windows Paket Meneceri (winget) quraşdırılmayıb və ya əlçatan deyil. Əvvəlcə onu quraşdırın, sonra yenidən cəhd edin.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -347,9 +347,9 @@
     <value>Intelligent Terminal-ə qabığınıza daxil olmaq və səhvləri avtomatik aşkarlamaq icazəsi verin.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Shell inteqrasiyasını quraşdırmaq alınmadı. Xəta aşkarlanması söndürülüb. Onu yenidən aktivləşdirib təkrar cəhd edə bilərsiniz və ya onsuz davam etmək üçün saxlaya bilərsiniz.</value>
+    <value>Shell inteqrasiyasını quraşdırmaq alınmadı. Xəta aşkarlanması söndürülüb. Onu yenidən aktivləşdirib təkrar cəhd edə bilərsiniz və ya onsuz davam etmək üçün saxlaya bilərsiniz.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Session hooks quraşdırmaq alınmadı. Sessiya idarəetməsi söndürülüb. Onu yenidən aktivləşdirib təkrar cəhd edə bilərsiniz və ya onsuz davam etmək üçün saxlaya bilərsiniz.</value>
+    <value>Session hooks quraşdırmaq alınmadı. Sessiya idarəetməsi söndürülüb. Onu yenidən aktivləşdirib təkrar cəhd edə bilərsiniz və ya onsuz davam etmək üçün saxlaya bilərsiniz.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Bunu necə əl ilə düzəltməyi öyrənin</value>
@@ -365,7 +365,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell icra siyasəti skriptləri bloklayır. Xəta aşkarlanması söndürüldü.</value>
+    <value>PowerShell icra siyasəti skriptləri bloklayır. Xəta aşkarlanması söndürüldü.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>İstifadə</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bg-BG/Resources.resw
@@ -223,39 +223,39 @@
     <value>Настройване...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Инсталирането на {0} е блокирано от правила на Диспечера на пакети на Windows. Ако използвате управлявано устройство, свържете се с ИТ администратора.</value>
+    <value>Инсталирането на {0} е блокирано от правила на Диспечера на пакети на Windows. Ако използвате управлявано устройство, свържете се с ИТ администратора.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Неуспешно инсталиране на {0} (код на грешка {1}). Вижте регистрационния файл за подробности или инсталирайте {0} ръчно.</value>
+    <value>Неуспешно инсталиране на {0} (код на грешка {1}). Вижте регистрационния файл за подробности или инсталирайте {0} ръчно.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Неуспешно инсталиране на {0}. Вижте регистрационния файл за подробности или инсталирайте {0} ръчно.</value>
+    <value>Неуспешно инсталиране на {0}. Вижте регистрационния файл за подробности или инсталирайте {0} ръчно.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Инсталаторът на {0} съобщи за грешка (код {1}). Вижте регистрационния файл за подробности или инсталирайте {0} ръчно.</value>
+    <value>Инсталаторът на {0} съобщи за грешка (код {1}). Вижте регистрационния файл за подробности или инсталирайте {0} ръчно.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Неуспешна връзка с Диспечера на пакети на Windows при инсталиране на {0}. Проверете интернет връзката (VPN, прокси или защитна стена може да я блокира) и опитайте отново.</value>
+    <value>Неуспешна връзка с Диспечера на пакети на Windows при инсталиране на {0}. Проверете интернет връзката (VPN, прокси или защитна стена може да я блокира) и опитайте отново.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Няма съвместим инсталатор за {0} на тази система (версията на ОС или архитектурата може да не се поддържат). Инсталирайте {0} ръчно.</value>
+    <value>Няма съвместим инсталатор за {0} на тази система (версията на ОС или архитектурата може да не се поддържат). Инсталирайте {0} ръчно.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} не беше намерен в каталога на Диспечера на пакети на Windows. Опитайте да обновите източниците на winget или инсталирайте {0} ръчно.</value>
+    <value>{0} не беше намерен в каталога на Диспечера на пакети на Windows. Опитайте да обновите източниците на winget или инсталирайте {0} ръчно.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Инсталирането на {0} отне повече от 20 минути. Intelligent Terminal спря да чака, но инсталаторът може все още да работи във фонов режим. Проверете Task Manager или опитайте отново по-късно.</value>
+    <value>Инсталирането на {0} отне повече от 20 минути. Intelligent Terminal спря да чака, но инсталаторът може все още да работи във фонов режим. Проверете Task Manager или опитайте отново по-късно.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Диспечерът на пакети на Windows (winget) не е инсталиран или не е наличен. Първо го инсталирайте, след което опитайте отново.</value>
+    <value>Диспечерът на пакети на Windows (winget) не е инсталиран или не е наличен. Първо го инсталирайте, след което опитайте отново.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>Разрешете на Intelligent Terminal достъп до вашата обвивка и автоматично откриване на грешки.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Неуспешно инсталиране на интеграция с обвивката. Откриването на грешки е изключено. Можете да го включите отново и да опитате пак, или да запазите, за да продължите без него.</value>
+    <value>Неуспешно инсталиране на интеграция с обвивката. Откриването на грешки е изключено. Можете да го включите отново и да опитате пак, или да запазите, за да продължите без него.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Неуспешно инсталиране на session hooks. Управлението на сесиите е изключено. Можете да го включите отново и да опитате пак, или да запазите, за да продължите без него.</value>
+    <value>Неуспешно инсталиране на session hooks. Управлението на сесиите е изключено. Можете да го включите отново и да опитате пак, или да запазите, за да продължите без него.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Научете как да поправите това ръчно</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Правилата за изпълнение на PowerShell блокират скриптовете. Откриването на грешки е изключено.</value>
+    <value>Правилата за изпълнение на PowerShell блокират скриптовете. Откриването на грешки е изключено.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Използване</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bn-IN/Resources.resw
@@ -223,50 +223,50 @@
     <value>সেট আপ হচ্ছে...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager পলিসির কারণে {0} ইনস্টলেশন ব্লক করা হয়েছে। আপনি যদি পরিচালিত ডিভাইসে থাকেন, আপনার IT অ্যাডমিনের সঙ্গে যোগাযোগ করুন।</value>
+    <value>Windows Package Manager পলিসির কারণে {0} ইনস্টলেশন ব্লক করা হয়েছে। আপনি যদি পরিচালিত ডিভাইসে থাকেন, আপনার IT অ্যাডমিনের সঙ্গে যোগাযোগ করুন।</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} ইনস্টল করা যায়নি (ত্রুটি কোড {1})। বিস্তারিত জানতে লগ দেখুন, অথবা {0} ম্যানুয়ালি ইনস্টল করুন।</value>
+    <value>{0} ইনস্টল করা যায়নি (ত্রুটি কোড {1})। বিস্তারিত জানতে লগ দেখুন, অথবা {0} ম্যানুয়ালি ইনস্টল করুন।</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} ইনস্টল করা যায়নি। বিস্তারিত জানতে লগ দেখুন, অথবা {0} ম্যানুয়ালি ইনস্টল করুন।</value>
+    <value>{0} ইনস্টল করা যায়নি। বিস্তারিত জানতে লগ দেখুন, অথবা {0} ম্যানুয়ালি ইনস্টল করুন।</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} ইনস্টলার একটি ত্রুটি রিপোর্ট করেছে (কোড {1})। বিস্তারিত জানতে লগ পরীক্ষা করুন, অথবা {0} ম্যানুয়ালি ইনস্টল করুন।</value>
+    <value>{0} ইনস্টলার একটি ত্রুটি রিপোর্ট করেছে (কোড {1})। বিস্তারিত জানতে লগ পরীক্ষা করুন, অথবা {0} ম্যানুয়ালি ইনস্টল করুন।</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} ইনস্টল করার সময় Windows Package Manager-এ পৌঁছানো যায়নি। আপনার ইন্টারনেট সংযোগ পরীক্ষা করুন (VPN, proxy, বা firewall এটি ব্লক করতে পারে) এবং আবার চেষ্টা করুন।</value>
+    <value>{0} ইনস্টল করার সময় Windows Package Manager-এ পৌঁছানো যায়নি। আপনার ইন্টারনেট সংযোগ পরীক্ষা করুন (VPN, proxy, বা firewall এটি ব্লক করতে পারে) এবং আবার চেষ্টা করুন।</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ এই সিস্টেমে {0}-এর জন্য কোনো সামঞ্জস্যপূর্ণ ইনস্টলার উপলভ্য নেই (OS সংস্করণ বা আর্কিটেকচার সমর্থিত নাও হতে পারে)। {0} ম্যানুয়ালি ইনস্টল করুন।</value>
+    <value>এই সিস্টেমে {0}-এর জন্য কোনো সামঞ্জস্যপূর্ণ ইনস্টলার উপলভ্য নেই (OS সংস্করণ বা আর্কিটেকচার সমর্থিত নাও হতে পারে)। {0} ম্যানুয়ালি ইনস্টল করুন।</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager ক্যাটালগে {0} পাওয়া যায়নি। winget উৎসগুলি রিফ্রেশ করার চেষ্টা করুন, অথবা {0} ম্যানুয়ালি ইনস্টল করুন।</value>
+    <value>Windows Package Manager ক্যাটালগে {0} পাওয়া যায়নি। winget উৎসগুলি রিফ্রেশ করার চেষ্টা করুন, অথবা {0} ম্যানুয়ালি ইনস্টল করুন।</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} ইনস্টল করতে 20 মিনিটের বেশি সময় লেগেছে। Intelligent Terminal অপেক্ষা করা বন্ধ করেছে, কিন্তু ইনস্টলারটি এখনও ব্যাকগ্রাউন্ডে চলতে পারে। Task Manager পরীক্ষা করুন, অথবা পরে আবার চেষ্টা করুন।</value>
+    <value>{0} ইনস্টল করতে 20 মিনিটের বেশি সময় লেগেছে। Intelligent Terminal অপেক্ষা করা বন্ধ করেছে, কিন্তু ইনস্টলারটি এখনও ব্যাকগ্রাউন্ডে চলতে পারে। Task Manager পরীক্ষা করুন, অথবা পরে আবার চেষ্টা করুন।</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks ইনস্টল করতে ব্যর্থ। সেশন ব্যবস্থাপনা বন্ধ করা হয়েছে। আপনি এটি পুনরায় সক্রিয় করে আবার চেষ্টা করতে পারেন, অথবা এটি ছাড়া চালিয়ে যেতে সংরক্ষণ করুন।</value>
+    <value>session hooks ইনস্টল করতে ব্যর্থ। সেশন ব্যবস্থাপনা বন্ধ করা হয়েছে। আপনি এটি পুনরায় সক্রিয় করে আবার চেষ্টা করতে পারেন, অথবা এটি ছাড়া চালিয়ে যেতে সংরক্ষণ করুন।</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ শেল ইন্টিগ্রেশন ইনস্টল করতে ব্যর্থ। ত্রুটি শনাক্তকরণ বন্ধ করা হয়েছে। আপনি এটি পুনরায় সক্রিয় করে আবার চেষ্টা করতে পারেন, অথবা এটি ছাড়া চালিয়ে যেতে সংরক্ষণ করুন।</value>
+    <value>শেল ইন্টিগ্রেশন ইনস্টল করতে ব্যর্থ। ত্রুটি শনাক্তকরণ বন্ধ করা হয়েছে। আপনি এটি পুনরায় সক্রিয় করে আবার চেষ্টা করতে পারেন, অথবা এটি ছাড়া চালিয়ে যেতে সংরক্ষণ করুন।</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell এক্সিকিউশন পলিসি স্ক্রিপ্ট ব্লক করছে। ত্রুটি শনাক্তকরণ বন্ধ করা হয়েছে।</value>
+    <value>PowerShell এক্সিকিউশন পলিসি স্ক্রিপ্ট ব্লক করছে। ত্রুটি শনাক্তকরণ বন্ধ করা হয়েছে।</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) ইনস্টল করা নেই বা উপলভ্য নয়। প্রথমে এটি ইনস্টল করুন, তারপর আবার চেষ্টা করুন।</value>
+    <value>Windows Package Manager (winget) ইনস্টল করা নেই বা উপলভ্য নয়। প্রথমে এটি ইনস্টল করুন, তারপর আবার চেষ্টা করুন।</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/bs-Latn-BA/Resources.resw
@@ -110,39 +110,39 @@
     <value>Postavljanje...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Instalaciju {0} blokirala je politika Windows Package Managera. Ako koristite upravljani uređaj, obratite se IT administratoru.</value>
+    <value>Instalaciju {0} blokirala je politika Windows Package Managera. Ako koristite upravljani uređaj, obratite se IT administratoru.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Instalacija {0} nije uspjela (kod greške {1}). Detalje potražite u evidenciji ili ručno instalirajte {0}.</value>
+    <value>Instalacija {0} nije uspjela (kod greške {1}). Detalje potražite u evidenciji ili ručno instalirajte {0}.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Instalacija {0} nije uspjela. Detalje potražite u evidenciji ili ručno instalirajte {0}.</value>
+    <value>Instalacija {0} nije uspjela. Detalje potražite u evidenciji ili ručno instalirajte {0}.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Instalator za {0} prijavio je grešku (kod {1}). Detalje potražite u evidenciji ili ručno instalirajte {0}.</value>
+    <value>Instalator za {0} prijavio je grešku (kod {1}). Detalje potražite u evidenciji ili ručno instalirajte {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Nije bilo moguće pristupiti Windows Package Manageru tokom instalacije {0}. Provjerite internetsku vezu (VPN, proksi ili vatrozid je možda blokiraju) i pokušajte ponovo.</value>
+    <value>Nije bilo moguće pristupiti Windows Package Manageru tokom instalacije {0}. Provjerite internetsku vezu (VPN, proksi ili vatrozid je možda blokiraju) i pokušajte ponovo.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Na ovom sistemu nije dostupan kompatibilan instalator za {0} (verzija OS-a ili arhitektura možda nisu podržani). Ručno instalirajte {0}.</value>
+    <value>Na ovom sistemu nije dostupan kompatibilan instalator za {0} (verzija OS-a ili arhitektura možda nisu podržani). Ručno instalirajte {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} nije pronađen u katalogu Windows Package Managera. Pokušajte osvježiti izvore winget ili ručno instalirajte {0}.</value>
+    <value>{0} nije pronađen u katalogu Windows Package Managera. Pokušajte osvježiti izvore winget ili ručno instalirajte {0}.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Instalacija {0} trajala je duže od 20 minuta. Intelligent Terminal je prestao čekati, ali instalator možda još radi u pozadini. Provjerite Task Manager ili pokušajte ponovo kasnije.</value>
+    <value>Instalacija {0} trajala je duže od 20 minuta. Intelligent Terminal je prestao čekati, ali instalator možda još radi u pozadini. Provjerite Task Manager ili pokušajte ponovo kasnije.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) nije instaliran ili nije dostupan. Prvo ga instalirajte, a zatim pokušajte ponovo.</value>
+    <value>Windows Package Manager (winget) nije instaliran ili nije dostupan. Prvo ga instalirajte, a zatim pokušajte ponovo.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -235,9 +235,9 @@
     <value>Dozvolite aplikaciji Intelligent Terminal pristup vašoj ljusci i automatsko otkrivanje grešaka.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Instalacija integracije ljuske nije uspjela. Otkrivanje grešaka je isključeno. Možete ga ponovo omogućiti i pokušati ponovo, ili sačuvati da biste nastavili bez toga.</value>
+    <value>Instalacija integracije ljuske nije uspjela. Otkrivanje grešaka je isključeno. Možete ga ponovo omogućiti i pokušati ponovo, ili sačuvati da biste nastavili bez toga.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Instalacija session hooks nije uspjela. Upravljanje sesijama je isključeno. Možete ih ponovo omogućiti i pokušati ponovo, ili sačuvati da biste nastavili bez toga.</value>
+    <value>Instalacija session hooks nije uspjela. Upravljanje sesijama je isključeno. Možete ih ponovo omogućiti i pokušati ponovo, ili sačuvati da biste nastavili bez toga.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Naučite kako ovo ručno popraviti</value>
@@ -253,7 +253,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell pravila izvršavanja blokiraju skripte. Otkrivanje grešaka je isključeno.</value>
+    <value>PowerShell pravila izvršavanja blokiraju skripte. Otkrivanje grešaka je isključeno.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Upotreba</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-ES/Resources.resw
@@ -110,39 +110,39 @@
     <value>S'està configurant...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ La instal·lació de {0} l'ha bloquejada una directiva de l'Administrador de paquets del Windows. Si feu servir un dispositiu administrat, poseu-vos en contacte amb l'administrador de TI.</value>
+    <value>La instal·lació de {0} l'ha bloquejada una directiva de l'Administrador de paquets del Windows. Si feu servir un dispositiu administrat, poseu-vos en contacte amb l'administrador de TI.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ No s'ha pogut instal·lar {0} (codi d'error {1}). Consulteu el registre per obtenir més detalls, o instal·leu {0} manualment.</value>
+    <value>No s'ha pogut instal·lar {0} (codi d'error {1}). Consulteu el registre per obtenir més detalls, o instal·leu {0} manualment.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ No s'ha pogut instal·lar {0}. Consulteu el registre per obtenir més detalls, o instal·leu {0} manualment.</value>
+    <value>No s'ha pogut instal·lar {0}. Consulteu el registre per obtenir més detalls, o instal·leu {0} manualment.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ L'instal·lador de {0} ha notificat un error (codi {1}). Consulteu el registre per obtenir més detalls, o instal·leu {0} manualment.</value>
+    <value>L'instal·lador de {0} ha notificat un error (codi {1}). Consulteu el registre per obtenir més detalls, o instal·leu {0} manualment.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ No s'ha pogut contactar amb l'Administrador de paquets del Windows mentre s'instal·lava {0}. Comproveu la connexió a Internet (VPN, proxy o tallafoc poden estar bloquejant-la) i torneu-ho a provar.</value>
+    <value>No s'ha pogut contactar amb l'Administrador de paquets del Windows mentre s'instal·lava {0}. Comproveu la connexió a Internet (VPN, proxy o tallafoc poden estar bloquejant-la) i torneu-ho a provar.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ No hi ha cap instal·lador compatible per a {0} disponible en aquest sistema (pot ser que la versió del sistema operatiu o l'arquitectura no siguin compatibles). Instal·leu {0} manualment.</value>
+    <value>No hi ha cap instal·lador compatible per a {0} disponible en aquest sistema (pot ser que la versió del sistema operatiu o l'arquitectura no siguin compatibles). Instal·leu {0} manualment.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} no s'ha trobat al catàleg de l'Administrador de paquets del Windows. Proveu d'actualitzar les fonts del winget, o instal·leu {0} manualment.</value>
+    <value>{0} no s'ha trobat al catàleg de l'Administrador de paquets del Windows. Proveu d'actualitzar les fonts del winget, o instal·leu {0} manualment.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ La instal·lació de {0} ha trigat més de 20 minuts. Intelligent Terminal ha deixat d'esperar, però pot ser que l'instal·lador encara s'estigui executant en segon pla. Consulteu Task Manager, o torneu-ho a provar més tard.</value>
+    <value>La instal·lació de {0} ha trigat més de 20 minuts. Intelligent Terminal ha deixat d'esperar, però pot ser que l'instal·lador encara s'estigui executant en segon pla. Consulteu Task Manager, o torneu-ho a provar més tard.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ L'Administrador de paquets del Windows (winget) no està instal·lat o no està disponible. Instal·leu-lo primer i torneu-ho a provar.</value>
+    <value>L'Administrador de paquets del Windows (winget) no està instal·lat o no està disponible. Instal·leu-lo primer i torneu-ho a provar.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -166,9 +166,9 @@
     <value>Permet que l'Intelligent Terminal accedeixi a l'intèrpret d'ordres i detecti errors automàticament.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ No s'ha pogut instal·lar la integració de l'intèrpret d'ordres. La detecció d'errors s'ha desactivat. Podeu tornar-la a activar i tornar-ho a provar, o desar per continuar sense ella.</value>
+    <value>No s'ha pogut instal·lar la integració de l'intèrpret d'ordres. La detecció d'errors s'ha desactivat. Podeu tornar-la a activar i tornar-ho a provar, o desar per continuar sense ella.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ No s'han pogut instal·lar els hooks de sessió. La gestió de sessions s'ha desactivat. Podeu tornar-la a activar i tornar-ho a provar, o desar per continuar sense ella.</value>
+    <value>No s'han pogut instal·lar els hooks de sessió. La gestió de sessions s'ha desactivat. Podeu tornar-la a activar i tornar-ho a provar, o desar per continuar sense ella.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Apreneu com solucionar-ho manualment</value>
@@ -184,7 +184,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ La directiva d'execució de PowerShell està bloquejant els scripts. Detecció d'errors desactivada.</value>
+    <value>La directiva d'execució de PowerShell està bloquejant els scripts. Detecció d'errors desactivada.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Ús</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ca-Es-VALENCIA/Resources.resw
@@ -110,39 +110,39 @@
     <value>S'està configurant...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ La instal·lació de {0} l'ha bloquejada una directiva de l'Administrador de paquets de Windows. Si feu servir un dispositiu administrat, poseu-vos en contacte amb l'administrador de TI.</value>
+    <value>La instal·lació de {0} l'ha bloquejada una directiva de l'Administrador de paquets de Windows. Si feu servir un dispositiu administrat, poseu-vos en contacte amb l'administrador de TI.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ No s'ha pogut instal·lar {0} (codi d'error {1}). Consulteu el registre per a obtindre més detalls, o instal·leu {0} manualment.</value>
+    <value>No s'ha pogut instal·lar {0} (codi d'error {1}). Consulteu el registre per a obtindre més detalls, o instal·leu {0} manualment.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ No s'ha pogut instal·lar {0}. Consulteu el registre per a obtindre més detalls, o instal·leu {0} manualment.</value>
+    <value>No s'ha pogut instal·lar {0}. Consulteu el registre per a obtindre més detalls, o instal·leu {0} manualment.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ L'instal·lador de {0} ha notificat un error (codi {1}). Consulteu el registre per a obtindre més detalls, o instal·leu {0} manualment.</value>
+    <value>L'instal·lador de {0} ha notificat un error (codi {1}). Consulteu el registre per a obtindre més detalls, o instal·leu {0} manualment.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ No s'ha pogut contactar amb l'Administrador de paquets de Windows mentre s'instal·lava {0}. Comproveu la connexió a Internet (VPN, proxy o tallafoc poden estar bloquejant-la) i torneu a provar.</value>
+    <value>No s'ha pogut contactar amb l'Administrador de paquets de Windows mentre s'instal·lava {0}. Comproveu la connexió a Internet (VPN, proxy o tallafoc poden estar bloquejant-la) i torneu a provar.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ No hi ha cap instal·lador compatible per a {0} disponible en este sistema (pot ser que la versió del sistema operatiu o l'arquitectura no siguen compatibles). Instal·leu {0} manualment.</value>
+    <value>No hi ha cap instal·lador compatible per a {0} disponible en este sistema (pot ser que la versió del sistema operatiu o l'arquitectura no siguen compatibles). Instal·leu {0} manualment.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} no s'ha trobat al catàleg de l'Administrador de paquets de Windows. Proveu d'actualitzar les fonts del winget, o instal·leu {0} manualment.</value>
+    <value>{0} no s'ha trobat al catàleg de l'Administrador de paquets de Windows. Proveu d'actualitzar les fonts del winget, o instal·leu {0} manualment.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ La instal·lació de {0} ha tardat més de 20 minuts. Intelligent Terminal ha deixat d'esperar, però pot ser que l'instal·lador encara s'estiga executant en segon pla. Consulteu Task Manager, o torneu a provar més tard.</value>
+    <value>La instal·lació de {0} ha tardat més de 20 minuts. Intelligent Terminal ha deixat d'esperar, però pot ser que l'instal·lador encara s'estiga executant en segon pla. Consulteu Task Manager, o torneu a provar més tard.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ L'Administrador de paquets de Windows (winget) no està instal·lat o no està disponible. Instal·leu-lo primer i torneu a provar.</value>
+    <value>L'Administrador de paquets de Windows (winget) no està instal·lat o no està disponible. Instal·leu-lo primer i torneu a provar.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -166,9 +166,9 @@
     <value>Permet que l'Intelligent Terminal accedisca a l'intèrpret d'ordres i detecte errors automàticament.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ No s'ha pogut instal·lar la integració de l'intèrpret d'ordres. La detecció d'errors s'ha desactivat. Podeu tornar-la a activar i tornar a provar, o guardar per a continuar sense ella.</value>
+    <value>No s'ha pogut instal·lar la integració de l'intèrpret d'ordres. La detecció d'errors s'ha desactivat. Podeu tornar-la a activar i tornar a provar, o guardar per a continuar sense ella.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ No s'han pogut instal·lar els hooks de sessió. La gestió de sessions s'ha desactivat. Podeu tornar-la a activar i tornar a provar, o guardar per a continuar sense ella.</value>
+    <value>No s'han pogut instal·lar els hooks de sessió. La gestió de sessions s'ha desactivat. Podeu tornar-la a activar i tornar a provar, o guardar per a continuar sense ella.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Apreneu com solucionar-ho manualment</value>
@@ -184,7 +184,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ La directiva d'execució de PowerShell està bloquejant els scripts. Detecció d'errors desactivada.</value>
+    <value>La directiva d'execució de PowerShell està bloquejant els scripts. Detecció d'errors desactivada.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Ús</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cs-CZ/Resources.resw
@@ -223,39 +223,39 @@
     <value>Nastavování...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Instalace {0} byla zablokována zásadami Správce balíčků systému Windows. Pokud používáte spravované zařízení, kontaktujte správce IT.</value>
+    <value>Instalace {0} byla zablokována zásadami Správce balíčků systému Windows. Pokud používáte spravované zařízení, kontaktujte správce IT.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Nepodařilo se nainstalovat {0} (kód chyby {1}). Podrobnosti najdete v protokolu, nebo nainstalujte {0} ručně.</value>
+    <value>Nepodařilo se nainstalovat {0} (kód chyby {1}). Podrobnosti najdete v protokolu, nebo nainstalujte {0} ručně.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Nepodařilo se nainstalovat {0}. Podrobnosti najdete v protokolu, nebo nainstalujte {0} ručně.</value>
+    <value>Nepodařilo se nainstalovat {0}. Podrobnosti najdete v protokolu, nebo nainstalujte {0} ručně.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Instalační program {0} oznámil chybu (kód {1}). Podrobnosti najdete v protokolu, nebo nainstalujte {0} ručně.</value>
+    <value>Instalační program {0} oznámil chybu (kód {1}). Podrobnosti najdete v protokolu, nebo nainstalujte {0} ručně.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Při instalaci {0} se nepodařilo spojit se Správcem balíčků systému Windows. Zkontrolujte připojení k internetu (VPN, proxy server nebo brána firewall ho můžou blokovat) a zkuste to znovu.</value>
+    <value>Při instalaci {0} se nepodařilo spojit se Správcem balíčků systému Windows. Zkontrolujte připojení k internetu (VPN, proxy server nebo brána firewall ho můžou blokovat) a zkuste to znovu.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ V tomto systému není k dispozici žádný kompatibilní instalační program pro {0} (verze operačního systému nebo architektura nemusí být podporovaná). Nainstalujte {0} ručně.</value>
+    <value>V tomto systému není k dispozici žádný kompatibilní instalační program pro {0} (verze operačního systému nebo architektura nemusí být podporovaná). Nainstalujte {0} ručně.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} se nenašel v katalogu Správce balíčků systému Windows. Zkuste aktualizovat zdroje winget nebo nainstalujte {0} ručně.</value>
+    <value>{0} se nenašel v katalogu Správce balíčků systému Windows. Zkuste aktualizovat zdroje winget nebo nainstalujte {0} ručně.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Instalace {0} trvala déle než 20 minut. Intelligent Terminal přestal čekat, ale instalační program může stále běžet na pozadí. Zkontrolujte Task Manager, nebo to zkuste znovu později.</value>
+    <value>Instalace {0} trvala déle než 20 minut. Intelligent Terminal přestal čekat, ale instalační program může stále běžet na pozadí. Zkontrolujte Task Manager, nebo to zkuste znovu později.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Správce balíčků systému Windows (winget) není nainstalovaný nebo není dostupný. Nejdřív ho nainstalujte a pak to zkuste znovu.</value>
+    <value>Správce balíčků systému Windows (winget) není nainstalovaný nebo není dostupný. Nejdřív ho nainstalujte a pak to zkuste znovu.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>Povolte aplikaci Intelligent Terminal přístup k prostředí shell a automatickou detekci chyb.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Nepodařilo se nainstalovat integraci prostředí. Detekce chyb byla vypnuta. Můžete ji znovu zapnout a zkusit to znovu, nebo uložit a pokračovat bez ní.</value>
+    <value>Nepodařilo se nainstalovat integraci prostředí. Detekce chyb byla vypnuta. Můžete ji znovu zapnout a zkusit to znovu, nebo uložit a pokračovat bez ní.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Nepodařilo se nainstalovat session hooks. Správa relací byla vypnuta. Můžete ji znovu zapnout a zkusit to znovu, nebo uložit a pokračovat bez ní.</value>
+    <value>Nepodařilo se nainstalovat session hooks. Správa relací byla vypnuta. Můžete ji znovu zapnout a zkusit to znovu, nebo uložit a pokračovat bez ní.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Zjistěte, jak to opravit ručně</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Zásady spouštění PowerShellu blokují skripty. Detekce chyb byla vypnuta.</value>
+    <value>Zásady spouštění PowerShellu blokují skripty. Detekce chyb byla vypnuta.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Použití</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/cy-GB/Resources.resw
@@ -110,39 +110,39 @@
     <value>Yn gosod...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Cafodd gosod {0} ei rwystro gan bolisi Rheolwr Pecynnau Windows. Os ydych ar ddyfais a reolir, cysylltwch â'ch gweinyddwr TG.</value>
+    <value>Cafodd gosod {0} ei rwystro gan bolisi Rheolwr Pecynnau Windows. Os ydych ar ddyfais a reolir, cysylltwch â'ch gweinyddwr TG.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Methu gosod {0} (cod gwall {1}). Gweler y log am fanylion, neu gosodwch {0} â llaw.</value>
+    <value>Methu gosod {0} (cod gwall {1}). Gweler y log am fanylion, neu gosodwch {0} â llaw.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Methu gosod {0}. Gweler y log am fanylion, neu gosodwch {0} â llaw.</value>
+    <value>Methu gosod {0}. Gweler y log am fanylion, neu gosodwch {0} â llaw.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Adroddodd gosodwr {0} wall (cod {1}). Gwiriwch y log am fanylion, neu gosodwch {0} â llaw.</value>
+    <value>Adroddodd gosodwr {0} wall (cod {1}). Gwiriwch y log am fanylion, neu gosodwch {0} â llaw.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Methu cyrraedd Rheolwr Pecynnau Windows wrth osod {0}. Gwiriwch eich cysylltiad â'r rhyngrwyd (gallai VPN, dirprwy neu fur gwarchod fod yn ei rwystro) a cheisiwch eto.</value>
+    <value>Methu cyrraedd Rheolwr Pecynnau Windows wrth osod {0}. Gwiriwch eich cysylltiad â'r rhyngrwyd (gallai VPN, dirprwy neu fur gwarchod fod yn ei rwystro) a cheisiwch eto.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Nid oes gosodwr cydnaws ar gyfer {0} ar gael ar y system hon (efallai nad yw fersiwn y system weithredu neu'r bensaernïaeth yn cael ei chefnogi). Gosodwch {0} â llaw.</value>
+    <value>Nid oes gosodwr cydnaws ar gyfer {0} ar gael ar y system hon (efallai nad yw fersiwn y system weithredu neu'r bensaernïaeth yn cael ei chefnogi). Gosodwch {0} â llaw.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Ni chafwyd hyd i {0} yng nghatalog Rheolwr Pecynnau Windows. Ceisiwch adnewyddu ffynonellau winget, neu gosodwch {0} â llaw.</value>
+    <value>Ni chafwyd hyd i {0} yng nghatalog Rheolwr Pecynnau Windows. Ceisiwch adnewyddu ffynonellau winget, neu gosodwch {0} â llaw.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Cymerodd gosod {0} fwy na 20 munud. Rhoddodd Intelligent Terminal y gorau i aros, ond gallai'r gosodwr fod yn rhedeg yn y cefndir o hyd. Gwiriwch Task Manager, neu ceisiwch eto'n nes ymlaen.</value>
+    <value>Cymerodd gosod {0} fwy na 20 munud. Rhoddodd Intelligent Terminal y gorau i aros, ond gallai'r gosodwr fod yn rhedeg yn y cefndir o hyd. Gwiriwch Task Manager, neu ceisiwch eto'n nes ymlaen.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Nid yw Rheolwr Pecynnau Windows (winget) wedi'i osod neu nid yw ar gael. Gosodwch ef yn gyntaf, ac yna ceisiwch eto.</value>
+    <value>Nid yw Rheolwr Pecynnau Windows (winget) wedi'i osod neu nid yw ar gael. Gosodwch ef yn gyntaf, ac yna ceisiwch eto.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -234,9 +234,9 @@
     <value>Rhowch ganiatâd i Intelligent Terminal gael mynediad i'ch cragen a chanfod gwallau yn awtomatig.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Methodd gosod integreiddio plisgyn. Mae canfod gwallau wedi'i ddiffodd. Gallwch ei ail-alluogi a rhoi cynnig arall arni, neu gadw i barhau hebddo.</value>
+    <value>Methodd gosod integreiddio plisgyn. Mae canfod gwallau wedi'i ddiffodd. Gallwch ei ail-alluogi a rhoi cynnig arall arni, neu gadw i barhau hebddo.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Methodd gosod session hooks. Mae rheoli sesiynau wedi'i ddiffodd. Gallwch ei ail-alluogi a rhoi cynnig arall arni, neu gadw i barhau hebddo.</value>
+    <value>Methodd gosod session hooks. Mae rheoli sesiynau wedi'i ddiffodd. Gallwch ei ail-alluogi a rhoi cynnig arall arni, neu gadw i barhau hebddo.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Dysgwch sut i drwsio hyn â llaw</value>
@@ -252,7 +252,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Mae polisi gweithredu PowerShell yn rhwystro sgriptiau. Canfod gwallau wedi'i ddiffodd.</value>
+    <value>Mae polisi gweithredu PowerShell yn rhwystro sgriptiau. Canfod gwallau wedi'i ddiffodd.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Defnydd</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/da-DK/Resources.resw
@@ -224,39 +224,39 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Konfigurerer...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Installation af {0} blev blokeret af en Windows Package Manager-politik. Hvis du bruger en administreret enhed, skal du kontakte din it-administrator.</value>
+    <value>Installation af {0} blev blokeret af en Windows Package Manager-politik. Hvis du bruger en administreret enhed, skal du kontakte din it-administrator.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Kunne ikke installere {0} (fejlkode {1}). Kontroller loggen for detaljer, eller installer {0} manuelt.</value>
+    <value>Kunne ikke installere {0} (fejlkode {1}). Kontroller loggen for detaljer, eller installer {0} manuelt.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Kunne ikke installere {0}. Kontroller loggen for detaljer, eller installer {0} manuelt.</value>
+    <value>Kunne ikke installere {0}. Kontroller loggen for detaljer, eller installer {0} manuelt.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Installationsprogrammet til {0} rapporterede en fejl (kode {1}). Kontroller loggen for detaljer, eller installer {0} manuelt.</value>
+    <value>Installationsprogrammet til {0} rapporterede en fejl (kode {1}). Kontroller loggen for detaljer, eller installer {0} manuelt.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Kunne ikke oprette forbindelse til Windows Package Manager under installation af {0}. Kontroller din internetforbindelse (VPN, proxy eller firewall blokerer den muligvis), og prøv igen.</value>
+    <value>Kunne ikke oprette forbindelse til Windows Package Manager under installation af {0}. Kontroller din internetforbindelse (VPN, proxy eller firewall blokerer den muligvis), og prøv igen.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Der findes ikke et kompatibelt installationsprogram til {0} på dette system (OS-versionen eller arkitekturen understøttes muligvis ikke). Installer {0} manuelt.</value>
+    <value>Der findes ikke et kompatibelt installationsprogram til {0} på dette system (OS-versionen eller arkitekturen understøttes muligvis ikke). Installer {0} manuelt.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} blev ikke fundet i Windows Package Manager-kataloget. Prøv at opdatere winget-kilderne, eller installer {0} manuelt.</value>
+    <value>{0} blev ikke fundet i Windows Package Manager-kataloget. Prøv at opdatere winget-kilderne, eller installer {0} manuelt.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Installation af {0} tog mere end 20 minutter. Intelligent Terminal holdt op med at vente, men installationsprogrammet kører muligvis stadig i baggrunden. Kontroller Task Manager, eller prøv igen senere.</value>
+    <value>Installation af {0} tog mere end 20 minutter. Intelligent Terminal holdt op med at vente, men installationsprogrammet kører muligvis stadig i baggrunden. Kontroller Task Manager, eller prøv igen senere.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) er ikke installeret eller er ikke tilgængelig. Installer den først, og prøv igen.</value>
+    <value>Windows Package Manager (winget) er ikke installeret eller er ikke tilgængelig. Installer den først, og prøv igen.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Giv Intelligent Terminal tilladelse til at få adgang til din shell og automatisk registrere fejl.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Installation af shell-integration mislykkedes. Fejlregistrering er blevet deaktiveret. Du kan genaktivere den og prøve igen, eller gemme for at fortsætte uden den.</value>
+    <value>Installation af shell-integration mislykkedes. Fejlregistrering er blevet deaktiveret. Du kan genaktivere den og prøve igen, eller gemme for at fortsætte uden den.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Installation af session hooks mislykkedes. Sessionsstyring er blevet deaktiveret. Du kan genaktivere den og prøve igen, eller gemme for at fortsætte uden den.</value>
+    <value>Installation af session hooks mislykkedes. Sessionsstyring er blevet deaktiveret. Du kan genaktivere den og prøve igen, eller gemme for at fortsætte uden den.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Få mere at vide om, hvordan du løser dette manuelt</value>
@@ -366,7 +366,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell-udførelsespolitikken blokerer scripts. Fejlregistrering deaktiveret.</value>
+    <value>PowerShell-udførelsespolitikken blokerer scripts. Fejlregistrering deaktiveret.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Brug</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/de-DE/Resources.resw
@@ -1120,39 +1120,39 @@
     <value>Wird eingerichtet...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Die Installation von {0} wurde durch eine Windows-Paket-Manager-Richtlinie blockiert. Wenn Sie ein verwaltetes Gerät verwenden, wenden Sie sich an Ihren IT-Administrator.</value>
+    <value>Die Installation von {0} wurde durch eine Windows-Paket-Manager-Richtlinie blockiert. Wenn Sie ein verwaltetes Gerät verwenden, wenden Sie sich an Ihren IT-Administrator.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} konnte nicht installiert werden (Fehlercode {1}). Überprüfen Sie das Protokoll auf Details, oder installieren Sie {0} manuell.</value>
+    <value>{0} konnte nicht installiert werden (Fehlercode {1}). Überprüfen Sie das Protokoll auf Details, oder installieren Sie {0} manuell.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} konnte nicht installiert werden. Überprüfen Sie das Protokoll auf Details, oder installieren Sie {0} manuell.</value>
+    <value>{0} konnte nicht installiert werden. Überprüfen Sie das Protokoll auf Details, oder installieren Sie {0} manuell.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Das Installationsprogramm für {0} hat einen Fehler gemeldet (Code {1}). Überprüfen Sie das Protokoll auf Details, oder installieren Sie {0} manuell.</value>
+    <value>Das Installationsprogramm für {0} hat einen Fehler gemeldet (Code {1}). Überprüfen Sie das Protokoll auf Details, oder installieren Sie {0} manuell.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Der Windows-Paket-Manager konnte während der Installation von {0} nicht erreicht werden. Überprüfen Sie Ihre Internetverbindung (VPN, Proxy oder Firewall blockieren sie möglicherweise), und versuchen Sie es erneut.</value>
+    <value>Der Windows-Paket-Manager konnte während der Installation von {0} nicht erreicht werden. Überprüfen Sie Ihre Internetverbindung (VPN, Proxy oder Firewall blockieren sie möglicherweise), und versuchen Sie es erneut.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Auf diesem System ist kein kompatibles Installationsprogramm für {0} verfügbar (Betriebssystemversion oder Architektur wird möglicherweise nicht unterstützt). Installieren Sie {0} manuell.</value>
+    <value>Auf diesem System ist kein kompatibles Installationsprogramm für {0} verfügbar (Betriebssystemversion oder Architektur wird möglicherweise nicht unterstützt). Installieren Sie {0} manuell.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} wurde im Katalog des Windows-Paket-Managers nicht gefunden. Versuchen Sie, die winget-Quellen zu aktualisieren, oder installieren Sie {0} manuell.</value>
+    <value>{0} wurde im Katalog des Windows-Paket-Managers nicht gefunden. Versuchen Sie, die winget-Quellen zu aktualisieren, oder installieren Sie {0} manuell.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Die Installation von {0} hat länger als 20 Minuten gedauert. Intelligent Terminal wartet nicht mehr, aber das Installationsprogramm wird möglicherweise noch im Hintergrund ausgeführt. Überprüfen Sie Task Manager, oder versuchen Sie es später erneut.</value>
+    <value>Die Installation von {0} hat länger als 20 Minuten gedauert. Intelligent Terminal wartet nicht mehr, aber das Installationsprogramm wird möglicherweise noch im Hintergrund ausgeführt. Überprüfen Sie Task Manager, oder versuchen Sie es später erneut.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Der Windows-Paket-Manager (winget) ist nicht installiert oder nicht verfügbar. Installieren Sie ihn zuerst, und versuchen Sie es dann erneut.</value>
+    <value>Der Windows-Paket-Manager (winget) ist nicht installiert oder nicht verfügbar. Installieren Sie ihn zuerst, und versuchen Sie es dann erneut.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1164,11 +1164,11 @@
     <comment>{Locked="Node.js","LTS"} Product display name substituted into the FreOverlay_InstallError_* templates when reporting a winget install failure for the Node.js prerequisite.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Sitzungs-hooks konnten nicht installiert werden. Die Sitzungsverwaltung wurde deaktiviert. Sie können sie erneut aktivieren und es noch einmal versuchen, oder speichern, um ohne sie fortzufahren.</value>
+    <value>Sitzungs-hooks konnten nicht installiert werden. Die Sitzungsverwaltung wurde deaktiviert. Sie können sie erneut aktivieren und es noch einmal versuchen, oder speichern, um ohne sie fortzufahren.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Die Shell-Integration konnte nicht installiert werden. Die Fehlererkennung wurde deaktiviert. Sie können sie erneut aktivieren und es noch einmal versuchen, oder speichern, um ohne sie fortzufahren.</value>
+    <value>Die Shell-Integration konnte nicht installiert werden. Die Fehlererkennung wurde deaktiviert. Sie können sie erneut aktivieren und es noch einmal versuchen, oder speichern, um ohne sie fortzufahren.</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Erfahren Sie, wie Sie dies manuell beheben</value>
@@ -1273,7 +1273,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Die PowerShell-Ausführungsrichtlinie blockiert Skripts. Fehlererkennung deaktiviert.</value>
+    <value>Die PowerShell-Ausführungsrichtlinie blockiert Skripts. Fehlererkennung deaktiviert.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Nutzung</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/el-GR/Resources.resw
@@ -110,39 +110,39 @@
     <value>Ρύθμιση...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Η εγκατάσταση του {0} αποκλείστηκε από πολιτική της Διαχείρισης πακέτων των Windows. Αν χρησιμοποιείτε διαχειριζόμενη συσκευή, επικοινωνήστε με τον διαχειριστή IT.</value>
+    <value>Η εγκατάσταση του {0} αποκλείστηκε από πολιτική της Διαχείρισης πακέτων των Windows. Αν χρησιμοποιείτε διαχειριζόμενη συσκευή, επικοινωνήστε με τον διαχειριστή IT.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Δεν ήταν δυνατή η εγκατάσταση του {0} (κωδικός σφάλματος {1}). Ανατρέξτε στο αρχείο καταγραφής για λεπτομέρειες ή εγκαταστήστε το {0} με μη αυτόματο τρόπο.</value>
+    <value>Δεν ήταν δυνατή η εγκατάσταση του {0} (κωδικός σφάλματος {1}). Ανατρέξτε στο αρχείο καταγραφής για λεπτομέρειες ή εγκαταστήστε το {0} με μη αυτόματο τρόπο.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Δεν ήταν δυνατή η εγκατάσταση του {0}. Ανατρέξτε στο αρχείο καταγραφής για λεπτομέρειες ή εγκαταστήστε το {0} με μη αυτόματο τρόπο.</value>
+    <value>Δεν ήταν δυνατή η εγκατάσταση του {0}. Ανατρέξτε στο αρχείο καταγραφής για λεπτομέρειες ή εγκαταστήστε το {0} με μη αυτόματο τρόπο.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Το πρόγραμμα εγκατάστασης του {0} ανέφερε σφάλμα (κωδικός {1}). Ανατρέξτε στο αρχείο καταγραφής για λεπτομέρειες ή εγκαταστήστε το {0} με μη αυτόματο τρόπο.</value>
+    <value>Το πρόγραμμα εγκατάστασης του {0} ανέφερε σφάλμα (κωδικός {1}). Ανατρέξτε στο αρχείο καταγραφής για λεπτομέρειες ή εγκαταστήστε το {0} με μη αυτόματο τρόπο.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Δεν ήταν δυνατή η επικοινωνία με τη Διαχείριση πακέτων των Windows κατά την εγκατάσταση του {0}. Ελέγξτε τη σύνδεσή σας στο Internet (VPN, διακομιστής μεσολάβησης ή τείχος προστασίας ενδέχεται να την αποκλείει) και δοκιμάστε ξανά.</value>
+    <value>Δεν ήταν δυνατή η επικοινωνία με τη Διαχείριση πακέτων των Windows κατά την εγκατάσταση του {0}. Ελέγξτε τη σύνδεσή σας στο Internet (VPN, διακομιστής μεσολάβησης ή τείχος προστασίας ενδέχεται να την αποκλείει) και δοκιμάστε ξανά.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Δεν υπάρχει διαθέσιμο συμβατό πρόγραμμα εγκατάστασης για το {0} σε αυτό το σύστημα (η έκδοση του OS ή η αρχιτεκτονική ενδέχεται να μην υποστηρίζεται). Εγκαταστήστε το {0} με μη αυτόματο τρόπο.</value>
+    <value>Δεν υπάρχει διαθέσιμο συμβατό πρόγραμμα εγκατάστασης για το {0} σε αυτό το σύστημα (η έκδοση του OS ή η αρχιτεκτονική ενδέχεται να μην υποστηρίζεται). Εγκαταστήστε το {0} με μη αυτόματο τρόπο.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Το {0} δεν βρέθηκε στον κατάλογο της Διαχείρισης πακέτων των Windows. Δοκιμάστε να ανανεώσετε τις προελεύσεις winget ή εγκαταστήστε το {0} με μη αυτόματο τρόπο.</value>
+    <value>Το {0} δεν βρέθηκε στον κατάλογο της Διαχείρισης πακέτων των Windows. Δοκιμάστε να ανανεώσετε τις προελεύσεις winget ή εγκαταστήστε το {0} με μη αυτόματο τρόπο.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Η εγκατάσταση του {0} διήρκεσε περισσότερο από 20 λεπτά. Το Intelligent Terminal σταμάτησε να περιμένει, αλλά το πρόγραμμα εγκατάστασης μπορεί να εξακολουθεί να εκτελείται στο παρασκήνιο. Ελέγξτε το Task Manager ή δοκιμάστε ξανά αργότερα.</value>
+    <value>Η εγκατάσταση του {0} διήρκεσε περισσότερο από 20 λεπτά. Το Intelligent Terminal σταμάτησε να περιμένει, αλλά το πρόγραμμα εγκατάστασης μπορεί να εξακολουθεί να εκτελείται στο παρασκήνιο. Ελέγξτε το Task Manager ή δοκιμάστε ξανά αργότερα.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Η Διαχείριση πακέτων των Windows (winget) δεν είναι εγκατεστημένη ή δεν είναι διαθέσιμη. Εγκαταστήστε την πρώτα και, στη συνέχεια, δοκιμάστε ξανά.</value>
+    <value>Η Διαχείριση πακέτων των Windows (winget) δεν είναι εγκατεστημένη ή δεν είναι διαθέσιμη. Εγκαταστήστε την πρώτα και, στη συνέχεια, δοκιμάστε ξανά.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -235,9 +235,9 @@
     <value>Επιτρέψτε στο Intelligent Terminal να αποκτήσει πρόσβαση στο κέλυφος και να εντοπίζει αυτόματα σφάλματα.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Αποτυχία εγκατάστασης της ενσωμάτωσης κελύφους. Ο εντοπισμός σφαλμάτων απενεργοποιήθηκε. Μπορείτε να τον ενεργοποιήσετε ξανά και να δοκιμάσετε ξανά, ή να αποθηκεύσετε για να συνεχίσετε χωρίς αυτόν.</value>
+    <value>Αποτυχία εγκατάστασης της ενσωμάτωσης κελύφους. Ο εντοπισμός σφαλμάτων απενεργοποιήθηκε. Μπορείτε να τον ενεργοποιήσετε ξανά και να δοκιμάσετε ξανά, ή να αποθηκεύσετε για να συνεχίσετε χωρίς αυτόν.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Αποτυχία εγκατάστασης των session hooks. Η διαχείριση περιόδων λειτουργίας απενεργοποιήθηκε. Μπορείτε να την ενεργοποιήσετε ξανά και να δοκιμάσετε ξανά, ή να αποθηκεύσετε για να συνεχίσετε χωρίς αυτήν.</value>
+    <value>Αποτυχία εγκατάστασης των session hooks. Η διαχείριση περιόδων λειτουργίας απενεργοποιήθηκε. Μπορείτε να την ενεργοποιήσετε ξανά και να δοκιμάσετε ξανά, ή να αποθηκεύσετε για να συνεχίσετε χωρίς αυτήν.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Μάθετε πώς να το διορθώσετε με μη αυτόματο τρόπο</value>
@@ -253,7 +253,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Η πολιτική εκτέλεσης του PowerShell αποκλείει τα σενάρια. Ο εντοπισμός σφαλμάτων απενεργοποιήθηκε.</value>
+    <value>Η πολιτική εκτέλεσης του PowerShell αποκλείει τα σενάρια. Ο εντοπισμός σφαλμάτων απενεργοποιήθηκε.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Χρήση</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-GB/Resources.resw
@@ -218,39 +218,39 @@
     <value>Setting up...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Installation of {0} was blocked by a Windows Package Manager policy. If you're on a managed device, contact your IT admin.</value>
+    <value>Installation of {0} was blocked by a Windows Package Manager policy. If you're on a managed device, contact your IT admin.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Couldn't install {0} (error code {1}). See the log for details, or install {0} manually.</value>
+    <value>Couldn't install {0} (error code {1}). See the log for details, or install {0} manually.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Couldn't install {0}. See the log for details, or install {0} manually.</value>
+    <value>Couldn't install {0}. See the log for details, or install {0} manually.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ The {0} installer reported an error (code {1}). Check the log for details, or install {0} manually.</value>
+    <value>The {0} installer reported an error (code {1}). Check the log for details, or install {0} manually.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Couldn't reach the Windows Package Manager while installing {0}. Check your internet connection (VPN, proxy, or firewall may be blocking it) and try again.</value>
+    <value>Couldn't reach the Windows Package Manager while installing {0}. Check your internet connection (VPN, proxy, or firewall may be blocking it) and try again.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ No compatible installer for {0} is available on this system (OS version or architecture may not be supported). Install {0} manually.</value>
+    <value>No compatible installer for {0} is available on this system (OS version or architecture may not be supported). Install {0} manually.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} wasn't found in the Windows Package Manager catalog. Try refreshing winget sources, or install {0} manually.</value>
+    <value>{0} wasn't found in the Windows Package Manager catalog. Try refreshing winget sources, or install {0} manually.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Installing {0} took longer than 20 minutes. Intelligent Terminal stopped waiting, but the installer may still be running in the background. Check Task Manager, or try again later.</value>
+    <value>Installing {0} took longer than 20 minutes. Intelligent Terminal stopped waiting, but the installer may still be running in the background. Check Task Manager, or try again later.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) is not installed or not available. Install it first, then try again.</value>
+    <value>Windows Package Manager (winget) is not installed or not available. Install it first, then try again.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -342,9 +342,9 @@
     <value>Give Intelligent Terminal permission to access your shell and automatically detect errors.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Failed to install shell integration. Error detection has been turned off. You can re-enable it and try again, or save to continue without it.</value>
+    <value>Failed to install shell integration. Error detection has been turned off. You can re-enable it and try again, or save to continue without it.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Failed to install session hooks. Session management has been turned off. You can re-enable it and try again, or save to continue without it.</value>
+    <value>Failed to install session hooks. Session management has been turned off. You can re-enable it and try again, or save to continue without it.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Learn how to fix this manually</value>
@@ -360,7 +360,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell execution policy is blocking scripts. Error detection turned off.</value>
+    <value>PowerShell execution policy is blocking scripts. Error detection turned off.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Usage</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/en-US/Resources.resw
@@ -1203,7 +1203,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Setting up...</value>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) is not installed or not available. Install it first, then try again.</value>
+    <value>Windows Package Manager (winget) is not installed or not available. Install it first, then try again.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1215,46 +1215,46 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>{Locked="Node.js","LTS"} Product display name substituted into the FreOverlay_InstallError_* templates when reporting a winget install failure for the Node.js prerequisite.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Couldn't reach the Windows Package Manager while installing {0}. Check your internet connection (VPN, proxy, or firewall may be blocking it) and try again.</value>
+    <value>Couldn't reach the Windows Package Manager while installing {0}. Check your internet connection (VPN, proxy, or firewall may be blocking it) and try again.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Installation of {0} was blocked by a Windows Package Manager policy. If you're on a managed device, contact your IT admin.</value>
+    <value>Installation of {0} was blocked by a Windows Package Manager policy. If you're on a managed device, contact your IT admin.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} wasn't found in the Windows Package Manager catalog. Try refreshing winget sources, or install {0} manually.</value>
+    <value>{0} wasn't found in the Windows Package Manager catalog. Try refreshing winget sources, or install {0} manually.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ No compatible installer for {0} is available on this system (OS version or architecture may not be supported). Install {0} manually.</value>
+    <value>No compatible installer for {0} is available on this system (OS version or architecture may not be supported). Install {0} manually.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ The {0} installer reported an error (code {1}). Check the log for details, or install {0} manually.</value>
+    <value>The {0} installer reported an error (code {1}). Check the log for details, or install {0} manually.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Installing {0} took longer than 20 minutes. Intelligent Terminal stopped waiting, but the installer may still be running in the background. Check Task Manager, or try again later.</value>
+    <value>Installing {0} took longer than 20 minutes. Intelligent Terminal stopped waiting, but the installer may still be running in the background. Check Task Manager, or try again later.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Couldn't install {0} (error code {1}). See the log for details, or install {0} manually.</value>
+    <value>Couldn't install {0} (error code {1}). See the log for details, or install {0} manually.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Couldn't install {0}. See the log for details, or install {0} manually.</value>
+    <value>Couldn't install {0}. See the log for details, or install {0} manually.</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Failed to install session hooks. Session management has been turned off. You can re-enable it and try again, or save to continue without it.</value>
+    <value>Failed to install session hooks. Session management has been turned off. You can re-enable it and try again, or save to continue without it.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Failed to install shell integration. Error detection has been turned off. You can re-enable it and try again, or save to continue without it.</value>
+    <value>Failed to install shell integration. Error detection has been turned off. You can re-enable it and try again, or save to continue without it.</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell execution policy is blocking scripts. Error detection turned off.</value>
+    <value>PowerShell execution policy is blocking scripts. Error detection turned off.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-ES/Resources.resw
@@ -1117,39 +1117,39 @@
     <value>Configurando...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ La instalación de {0} fue bloqueada por una directiva del Administrador de paquetes de Windows. Si estás en un dispositivo administrado, ponte en contacto con tu administrador de TI.</value>
+    <value>La instalación de {0} fue bloqueada por una directiva del Administrador de paquetes de Windows. Si estás en un dispositivo administrado, ponte en contacto con tu administrador de TI.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ No se pudo instalar {0} (código de error {1}). Consulta el registro para obtener más detalles o instala {0} manualmente.</value>
+    <value>No se pudo instalar {0} (código de error {1}). Consulta el registro para obtener más detalles o instala {0} manualmente.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ No se pudo instalar {0}. Consulta el registro para obtener más detalles o instala {0} manualmente.</value>
+    <value>No se pudo instalar {0}. Consulta el registro para obtener más detalles o instala {0} manualmente.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ El instalador de {0} notificó un error (código {1}). Consulta el registro para obtener más detalles o instala {0} manualmente.</value>
+    <value>El instalador de {0} notificó un error (código {1}). Consulta el registro para obtener más detalles o instala {0} manualmente.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ No se pudo acceder al Administrador de paquetes de Windows al instalar {0}. Comprueba tu conexión a Internet (VPN, proxy o firewall podrían estar bloqueándola) e inténtalo de nuevo.</value>
+    <value>No se pudo acceder al Administrador de paquetes de Windows al instalar {0}. Comprueba tu conexión a Internet (VPN, proxy o firewall podrían estar bloqueándola) e inténtalo de nuevo.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ No hay disponible ningún instalador compatible para {0} en este sistema (es posible que la versión del sistema operativo o la arquitectura no sean compatibles). Instala {0} manualmente.</value>
+    <value>No hay disponible ningún instalador compatible para {0} en este sistema (es posible que la versión del sistema operativo o la arquitectura no sean compatibles). Instala {0} manualmente.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} no se encontró en el catálogo del Administrador de paquetes de Windows. Intenta actualizar las fuentes de winget o instala {0} manualmente.</value>
+    <value>{0} no se encontró en el catálogo del Administrador de paquetes de Windows. Intenta actualizar las fuentes de winget o instala {0} manualmente.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ La instalación de {0} ha tardado más de 20 minutos. Intelligent Terminal dejó de esperar, pero es posible que el instalador siga ejecutándose en segundo plano. Consulta Task Manager o inténtalo de nuevo más tarde.</value>
+    <value>La instalación de {0} ha tardado más de 20 minutos. Intelligent Terminal dejó de esperar, pero es posible que el instalador siga ejecutándose en segundo plano. Consulta Task Manager o inténtalo de nuevo más tarde.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ El Administrador de paquetes de Windows (winget) no está instalado o no está disponible. Instálalo primero y vuelve a intentarlo.</value>
+    <value>El Administrador de paquetes de Windows (winget) no está instalado o no está disponible. Instálalo primero y vuelve a intentarlo.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1161,11 +1161,11 @@
     <comment>{Locked="Node.js","LTS"} Product display name substituted into the FreOverlay_InstallError_* templates when reporting a winget install failure for the Node.js prerequisite.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Error al instalar los hooks de sesión. La gestión de sesiones se ha desactivado. Puedes volver a activarla e intentarlo de nuevo, o guardar para continuar sin ella.</value>
+    <value>Error al instalar los hooks de sesión. La gestión de sesiones se ha desactivado. Puedes volver a activarla e intentarlo de nuevo, o guardar para continuar sin ella.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Error al instalar la integración del shell. La detección de errores se ha desactivado. Puedes volver a activarla e intentarlo de nuevo, o guardar para continuar sin ella.</value>
+    <value>Error al instalar la integración del shell. La detección de errores se ha desactivado. Puedes volver a activarla e intentarlo de nuevo, o guardar para continuar sin ella.</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Obtenga información sobre cómo solucionar esto manualmente</value>
@@ -1270,7 +1270,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ La directiva de ejecución de PowerShell está bloqueando los scripts. Detección de errores desactivada.</value>
+    <value>La directiva de ejecución de PowerShell está bloqueando los scripts. Detección de errores desactivada.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Uso</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/es-MX/Resources.resw
@@ -218,39 +218,39 @@
     <value>Configurando...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ La instalación de {0} fue bloqueada por una directiva del Administrador de paquetes de Windows. Si estás en un dispositivo administrado, ponte en contacto con tu administrador de TI.</value>
+    <value>La instalación de {0} fue bloqueada por una directiva del Administrador de paquetes de Windows. Si estás en un dispositivo administrado, ponte en contacto con tu administrador de TI.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ No se pudo instalar {0} (código de error {1}). Consulta el registro para obtener más detalles o instala {0} manualmente.</value>
+    <value>No se pudo instalar {0} (código de error {1}). Consulta el registro para obtener más detalles o instala {0} manualmente.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ No se pudo instalar {0}. Consulta el registro para obtener más detalles o instala {0} manualmente.</value>
+    <value>No se pudo instalar {0}. Consulta el registro para obtener más detalles o instala {0} manualmente.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ El instalador de {0} notificó un error (código {1}). Consulta el registro para obtener más detalles o instala {0} manualmente.</value>
+    <value>El instalador de {0} notificó un error (código {1}). Consulta el registro para obtener más detalles o instala {0} manualmente.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ No se pudo acceder al Administrador de paquetes de Windows al instalar {0}. Verifica tu conexión a Internet (VPN, proxy o firewall podrían estar bloqueándola) e inténtalo de nuevo.</value>
+    <value>No se pudo acceder al Administrador de paquetes de Windows al instalar {0}. Verifica tu conexión a Internet (VPN, proxy o firewall podrían estar bloqueándola) e inténtalo de nuevo.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ No hay disponible ningún instalador compatible para {0} en este sistema (es posible que la versión del sistema operativo o la arquitectura no sean compatibles). Instala {0} manualmente.</value>
+    <value>No hay disponible ningún instalador compatible para {0} en este sistema (es posible que la versión del sistema operativo o la arquitectura no sean compatibles). Instala {0} manualmente.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} no se encontró en el catálogo del Administrador de paquetes de Windows. Intenta actualizar las fuentes de winget o instala {0} manualmente.</value>
+    <value>{0} no se encontró en el catálogo del Administrador de paquetes de Windows. Intenta actualizar las fuentes de winget o instala {0} manualmente.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ La instalación de {0} tardó más de 20 minutos. Intelligent Terminal dejó de esperar, pero es posible que el instalador siga ejecutándose en segundo plano. Consulta Task Manager o inténtalo de nuevo más tarde.</value>
+    <value>La instalación de {0} tardó más de 20 minutos. Intelligent Terminal dejó de esperar, pero es posible que el instalador siga ejecutándose en segundo plano. Consulta Task Manager o inténtalo de nuevo más tarde.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ El Administrador de paquetes de Windows (winget) no está instalado o no está disponible. Instálalo primero y vuelve a intentarlo.</value>
+    <value>El Administrador de paquetes de Windows (winget) no está instalado o no está disponible. Instálalo primero y vuelve a intentarlo.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -342,9 +342,9 @@
     <value>Permita que Intelligent Terminal acceda a su shell y detecte errores automáticamente.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Error al instalar la integración del shell. La detección de errores se ha desactivado. Puedes volver a activarla e intentarlo de nuevo, o guardar para continuar sin ella.</value>
+    <value>Error al instalar la integración del shell. La detección de errores se ha desactivado. Puedes volver a activarla e intentarlo de nuevo, o guardar para continuar sin ella.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Error al instalar los hooks de sesión. La administración de sesiones se ha desactivado. Puedes volver a activarla e intentarlo de nuevo, o guardar para continuar sin ella.</value>
+    <value>Error al instalar los hooks de sesión. La administración de sesiones se ha desactivado. Puedes volver a activarla e intentarlo de nuevo, o guardar para continuar sin ella.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Obtenga información sobre cómo solucionar esto manualmente</value>
@@ -360,7 +360,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ La directiva de ejecución de PowerShell está bloqueando los scripts. Detección de errores desactivada.</value>
+    <value>La directiva de ejecución de PowerShell está bloqueando los scripts. Detección de errores desactivada.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Uso</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/et-EE/Resources.resw
@@ -223,39 +223,39 @@
     <value>Seadistamine...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windowsi paketihalduri poliitika blokeeris üksuse {0} installimise. Kui kasutate hallatavat seadet, võtke ühendust oma IT-administraatoriga.</value>
+    <value>Windowsi paketihalduri poliitika blokeeris üksuse {0} installimise. Kui kasutate hallatavat seadet, võtke ühendust oma IT-administraatoriga.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Üksust {0} ei saanud installida (tõrkekood {1}). Vaadake üksikasju logist või installige {0} käsitsi.</value>
+    <value>Üksust {0} ei saanud installida (tõrkekood {1}). Vaadake üksikasju logist või installige {0} käsitsi.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Üksust {0} ei saanud installida. Vaadake üksikasju logist või installige {0} käsitsi.</value>
+    <value>Üksust {0} ei saanud installida. Vaadake üksikasju logist või installige {0} käsitsi.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} installiprogramm teatas tõrkest (kood {1}). Vaadake üksikasju logist või installige {0} käsitsi.</value>
+    <value>{0} installiprogramm teatas tõrkest (kood {1}). Vaadake üksikasju logist või installige {0} käsitsi.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Windowsi paketihalduriga ei saanud {0} installimise ajal ühendust võtta. Kontrollige internetiühendust (VPN, puhverserver või tulemüür võib seda blokeerida) ja proovige uuesti.</value>
+    <value>Windowsi paketihalduriga ei saanud {0} installimise ajal ühendust võtta. Kontrollige internetiühendust (VPN, puhverserver või tulemüür võib seda blokeerida) ja proovige uuesti.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Selles süsteemis pole üksuse {0} jaoks ühilduvat installiprogrammi saadaval (OS-i versioon või arhitektuur ei pruugi olla toetatud). Installige {0} käsitsi.</value>
+    <value>Selles süsteemis pole üksuse {0} jaoks ühilduvat installiprogrammi saadaval (OS-i versioon või arhitektuur ei pruugi olla toetatud). Installige {0} käsitsi.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} ei leitud Windowsi paketihalduri kataloogist. Proovige winget-allikaid värskendada või installige {0} käsitsi.</value>
+    <value>{0} ei leitud Windowsi paketihalduri kataloogist. Proovige winget-allikaid värskendada või installige {0} käsitsi.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} installimine võttis kauem kui 20 minutit. Intelligent Terminal lõpetas ootamise, kuid installiprogramm võib endiselt taustal töötada. Kontrollige Task Manageri või proovige hiljem uuesti.</value>
+    <value>{0} installimine võttis kauem kui 20 minutit. Intelligent Terminal lõpetas ootamise, kuid installiprogramm võib endiselt taustal töötada. Kontrollige Task Manageri või proovige hiljem uuesti.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windowsi paketihaldur (winget) pole installitud või pole saadaval. Installige see esmalt ja proovige siis uuesti.</value>
+    <value>Windowsi paketihaldur (winget) pole installitud või pole saadaval. Installige see esmalt ja proovige siis uuesti.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>Lubage rakendusel Intelligent Terminal pääseda juurde teie kestale ja tuvastada vead automaatselt.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Kestaintegratsiooni installimine nurjus. Vigade tuvastamine on välja lülitatud. Saate selle uuesti lubada ja uuesti proovida või salvestada, et jätkata ilma selleta.</value>
+    <value>Kestaintegratsiooni installimine nurjus. Vigade tuvastamine on välja lülitatud. Saate selle uuesti lubada ja uuesti proovida või salvestada, et jätkata ilma selleta.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Session hooks installimine nurjus. Seansihaldus on välja lülitatud. Saate selle uuesti lubada ja uuesti proovida või salvestada, et jätkata ilma selleta.</value>
+    <value>Session hooks installimine nurjus. Seansihaldus on välja lülitatud. Saate selle uuesti lubada ja uuesti proovida või salvestada, et jätkata ilma selleta.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Lugege, kuidas seda käsitsi parandada</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShelli käivituspoliitika blokeerib skripte. Vigade tuvastamine välja lülitatud.</value>
+    <value>PowerShelli käivituspoliitika blokeerib skripte. Vigade tuvastamine välja lülitatud.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Kasutus</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/eu-ES/Resources.resw
@@ -110,39 +110,39 @@
     <value>Konfiguratzen...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ {0} instalatzea Windows pakete-kudeatzailearen gidalerro batek blokeatu du. Gailu kudeatu batean bazaude, jarri harremanetan zure IT administratzailearekin.</value>
+    <value>{0} instalatzea Windows pakete-kudeatzailearen gidalerro batek blokeatu du. Gailu kudeatu batean bazaude, jarri harremanetan zure IT administratzailearekin.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Ezin izan da {0} instalatu (errore-kodea: {1}). Begiratu erregistroa xehetasunetarako, edo instalatu {0} eskuz.</value>
+    <value>Ezin izan da {0} instalatu (errore-kodea: {1}). Begiratu erregistroa xehetasunetarako, edo instalatu {0} eskuz.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Ezin izan da {0} instalatu. Begiratu erregistroa xehetasunetarako, edo instalatu {0} eskuz.</value>
+    <value>Ezin izan da {0} instalatu. Begiratu erregistroa xehetasunetarako, edo instalatu {0} eskuz.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} instalatzaileak errore bat jakinarazi du (kodea: {1}). Begiratu erregistroa xehetasunetarako, edo instalatu {0} eskuz.</value>
+    <value>{0} instalatzaileak errore bat jakinarazi du (kodea: {1}). Begiratu erregistroa xehetasunetarako, edo instalatu {0} eskuz.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Ezin izan da Windows pakete-kudeatzailearekin konektatu {0} instalatzen zen bitartean. Egiaztatu Interneteko konexioa (VPN, proxy edo suebaki batek blokea dezake) eta saiatu berriro.</value>
+    <value>Ezin izan da Windows pakete-kudeatzailearekin konektatu {0} instalatzen zen bitartean. Egiaztatu Interneteko konexioa (VPN, proxy edo suebaki batek blokea dezake) eta saiatu berriro.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ {0} instalatzeko ez dago instalatzaile bateragarririk sistema honetan (baliteke SEaren bertsioa edo arkitektura ez onartzea). Instalatu {0} eskuz.</value>
+    <value>{0} instalatzeko ez dago instalatzaile bateragarririk sistema honetan (baliteke SEaren bertsioa edo arkitektura ez onartzea). Instalatu {0} eskuz.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} ez da aurkitu Windows pakete-kudeatzailearen katalogoan. Saiatu winget iturburuak freskatzen, edo instalatu {0} eskuz.</value>
+    <value>{0} ez da aurkitu Windows pakete-kudeatzailearen katalogoan. Saiatu winget iturburuak freskatzen, edo instalatu {0} eskuz.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} instalatzeak 20 minutu baino gehiago iraun du. Intelligent Terminal itxaroteari utzi dio, baina baliteke instalatzaileak atzeko planoan exekutatzen jarraitzea. Begiratu Task Manager, edo saiatu berriro geroago.</value>
+    <value>{0} instalatzeak 20 minutu baino gehiago iraun du. Intelligent Terminal itxaroteari utzi dio, baina baliteke instalatzaileak atzeko planoan exekutatzen jarraitzea. Begiratu Task Manager, edo saiatu berriro geroago.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows pakete-kudeatzailea (winget) ez dago instalatuta edo ez dago erabilgarri. Instalatu lehenik, eta saiatu berriro.</value>
+    <value>Windows pakete-kudeatzailea (winget) ez dago instalatuta edo ez dago erabilgarri. Instalatu lehenik, eta saiatu berriro.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -166,9 +166,9 @@
     <value>Eman baimena Intelligent Terminal-i zure shell-era sartzeko eta erroreak automatikoki detektatzeko.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Shell integrazioa instalatzeak huts egin du. Erroreen detekzioa desaktibatu da. Berriro aktibatu eta berriro saiatu dezakezu, edo gorde hori gabe jarraitzeko.</value>
+    <value>Shell integrazioa instalatzeak huts egin du. Erroreen detekzioa desaktibatu da. Berriro aktibatu eta berriro saiatu dezakezu, edo gorde hori gabe jarraitzeko.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Session hooks instalatzeak huts egin du. Saio-kudeaketa desaktibatu da. Berriro aktibatu eta berriro saiatu dezakezu, edo gorde hori gabe jarraitzeko.</value>
+    <value>Session hooks instalatzeak huts egin du. Saio-kudeaketa desaktibatu da. Berriro aktibatu eta berriro saiatu dezakezu, edo gorde hori gabe jarraitzeko.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Ikasi nola konpondu hau eskuz</value>
@@ -184,7 +184,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell exekuzio-politikak script-ak blokeatzen ditu. Erroreen detekzioa desaktibatuta.</value>
+    <value>PowerShell exekuzio-politikak script-ak blokeatzen ditu. Erroreen detekzioa desaktibatuta.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Erabilera</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fa-IR/Resources.resw
@@ -224,39 +224,39 @@
     <value>در حال تنظیم...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ نصب {0} توسط خط‌مشی مدیر بسته Windows مسدود شد. اگر از دستگاه مدیریت‌شده استفاده می‌کنید، با سرپرست IT خود تماس بگیرید.</value>
+    <value>نصب {0} توسط خط‌مشی مدیر بسته Windows مسدود شد. اگر از دستگاه مدیریت‌شده استفاده می‌کنید، با سرپرست IT خود تماس بگیرید.</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ نصب {0} ممکن نشد (کد خطا {1}). برای جزئیات، گزارش را ببینید، یا {0} را دستی نصب کنید.</value>
+    <value>نصب {0} ممکن نشد (کد خطا {1}). برای جزئیات، گزارش را ببینید، یا {0} را دستی نصب کنید.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ نصب {0} ممکن نشد. برای جزئیات، گزارش را ببینید، یا {0} را دستی نصب کنید.</value>
+    <value>نصب {0} ممکن نشد. برای جزئیات، گزارش را ببینید، یا {0} را دستی نصب کنید.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ نصب‌کننده {0} خطایی گزارش کرد (کد {1}). برای جزئیات، گزارش را بررسی کنید، یا {0} را دستی نصب کنید.</value>
+    <value>نصب‌کننده {0} خطایی گزارش کرد (کد {1}). برای جزئیات، گزارش را بررسی کنید، یا {0} را دستی نصب کنید.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ هنگام نصب {0}، دسترسی به مدیر بسته Windows ممکن نشد. اتصال اینترنت خود را بررسی کنید (ممکن است VPN، پراکسی یا فایروال آن را مسدود کرده باشد) و دوباره تلاش کنید.</value>
+    <value>هنگام نصب {0}، دسترسی به مدیر بسته Windows ممکن نشد. اتصال اینترنت خود را بررسی کنید (ممکن است VPN، پراکسی یا فایروال آن را مسدود کرده باشد) و دوباره تلاش کنید.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ نصب‌کننده سازگاری برای {0} در این سیستم در دسترس نیست (ممکن است نسخه سیستم‌عامل یا معماری پشتیبانی نشود). {0} را دستی نصب کنید.</value>
+    <value>نصب‌کننده سازگاری برای {0} در این سیستم در دسترس نیست (ممکن است نسخه سیستم‌عامل یا معماری پشتیبانی نشود). {0} را دستی نصب کنید.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} در کاتالوگ مدیر بسته Windows یافت نشد. سعی کنید منابع winget را تازه‌سازی کنید، یا {0} را دستی نصب کنید.</value>
+    <value>{0} در کاتالوگ مدیر بسته Windows یافت نشد. سعی کنید منابع winget را تازه‌سازی کنید، یا {0} را دستی نصب کنید.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ نصب {0} بیش از 20 دقیقه طول کشید. Intelligent Terminal دیگر منتظر نماند، اما نصب‌کننده ممکن است همچنان در پس‌زمینه در حال اجرا باشد. Task Manager را بررسی کنید، یا بعداً دوباره تلاش کنید.</value>
+    <value>نصب {0} بیش از 20 دقیقه طول کشید. Intelligent Terminal دیگر منتظر نماند، اما نصب‌کننده ممکن است همچنان در پس‌زمینه در حال اجرا باشد. Task Manager را بررسی کنید، یا بعداً دوباره تلاش کنید.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ مدیر بسته Windows (winget) نصب نشده یا در دسترس نیست. ابتدا آن را نصب کنید، سپس دوباره تلاش کنید.</value>
+    <value>مدیر بسته Windows (winget) نصب نشده یا در دسترس نیست. ابتدا آن را نصب کنید، سپس دوباره تلاش کنید.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>به Intelligent Terminal اجازه دهید به پوسته شما دسترسی پیدا کند و خطاها را به طور خودکار تشخیص دهد.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ نصب یکپارچه‌سازی پوسته ناموفق بود. تشخیص خطا غیرفعال شده است. می‌توانید آن را دوباره فعال کنید و دوباره تلاش کنید، یا ذخیره کنید تا بدون آن ادامه دهید.</value>
+    <value>نصب یکپارچه‌سازی پوسته ناموفق بود. تشخیص خطا غیرفعال شده است. می‌توانید آن را دوباره فعال کنید و دوباره تلاش کنید، یا ذخیره کنید تا بدون آن ادامه دهید.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ نصب session hooks ناموفق بود. مدیریت نشست غیرفعال شده است. می‌توانید آن را دوباره فعال کنید و دوباره تلاش کنید، یا ذخیره کنید تا بدون آن ادامه دهید.</value>
+    <value>نصب session hooks ناموفق بود. مدیریت نشست غیرفعال شده است. می‌توانید آن را دوباره فعال کنید و دوباره تلاش کنید، یا ذخیره کنید تا بدون آن ادامه دهید.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>با نحوه رفع این مشکل به‌صورت دستی آشنا شوید</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ خط‌مشی اجرای PowerShell اسکریپت‌ها را مسدود می‌کند. تشخیص خطا غیرفعال شد.</value>
+    <value>خط‌مشی اجرای PowerShell اسکریپت‌ها را مسدود می‌کند. تشخیص خطا غیرفعال شد.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>استفاده</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fi-FI/Resources.resw
@@ -223,39 +223,39 @@
     <value>Määritetään...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Kohteen {0} asennus estettiin Windowsin paketinhallinnan käytännön vuoksi. Jos käytät hallittua laitetta, ota yhteyttä IT-järjestelmänvalvojaan.</value>
+    <value>Kohteen {0} asennus estettiin Windowsin paketinhallinnan käytännön vuoksi. Jos käytät hallittua laitetta, ota yhteyttä IT-järjestelmänvalvojaan.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Kohdetta {0} ei voitu asentaa (virhekoodi {1}). Katso lokista lisätiedot tai asenna {0} manuaalisesti.</value>
+    <value>Kohdetta {0} ei voitu asentaa (virhekoodi {1}). Katso lokista lisätiedot tai asenna {0} manuaalisesti.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Kohdetta {0} ei voitu asentaa. Katso lokista lisätiedot tai asenna {0} manuaalisesti.</value>
+    <value>Kohdetta {0} ei voitu asentaa. Katso lokista lisätiedot tai asenna {0} manuaalisesti.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Kohteen {0} asennusohjelma ilmoitti virheestä (koodi {1}). Tarkista lokista lisätiedot tai asenna {0} manuaalisesti.</value>
+    <value>Kohteen {0} asennusohjelma ilmoitti virheestä (koodi {1}). Tarkista lokista lisätiedot tai asenna {0} manuaalisesti.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Windowsin paketinhallintaan ei saatu yhteyttä asennettaessa kohdetta {0}. Tarkista internetyhteys (VPN, välityspalvelin tai palomuuri voi estää sen) ja yritä uudelleen.</value>
+    <value>Windowsin paketinhallintaan ei saatu yhteyttä asennettaessa kohdetta {0}. Tarkista internetyhteys (VPN, välityspalvelin tai palomuuri voi estää sen) ja yritä uudelleen.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Tälle järjestelmälle ei ole saatavilla yhteensopivaa asennusohjelmaa kohteelle {0} (käyttöjärjestelmän versiota tai arkkitehtuuria ei ehkä tueta). Asenna {0} manuaalisesti.</value>
+    <value>Tälle järjestelmälle ei ole saatavilla yhteensopivaa asennusohjelmaa kohteelle {0} (käyttöjärjestelmän versiota tai arkkitehtuuria ei ehkä tueta). Asenna {0} manuaalisesti.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Kohdetta {0} ei löytynyt Windowsin paketinhallinnan luettelosta. Yritä päivittää winget-lähteet tai asenna {0} manuaalisesti.</value>
+    <value>Kohdetta {0} ei löytynyt Windowsin paketinhallinnan luettelosta. Yritä päivittää winget-lähteet tai asenna {0} manuaalisesti.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Kohteen {0} asennus kesti yli 20 minuuttia. Intelligent Terminal lopetti odottamisen, mutta asennusohjelma saattaa edelleen olla käynnissä taustalla. Tarkista Task Manager tai yritä myöhemmin uudelleen.</value>
+    <value>Kohteen {0} asennus kesti yli 20 minuuttia. Intelligent Terminal lopetti odottamisen, mutta asennusohjelma saattaa edelleen olla käynnissä taustalla. Tarkista Task Manager tai yritä myöhemmin uudelleen.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windowsin paketinhallintaa (winget) ei ole asennettu tai se ei ole käytettävissä. Asenna se ensin ja yritä sitten uudelleen.</value>
+    <value>Windowsin paketinhallintaa (winget) ei ole asennettu tai se ei ole käytettävissä. Asenna se ensin ja yritä sitten uudelleen.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -347,9 +347,9 @@
     <value>Salli Intelligent Terminalin käyttää komentotulkkia ja tunnistaa virheet automaattisesti.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Komentotulkin integroinnin asennus epäonnistui. Virheiden tunnistus on poistettu käytöstä. Voit ottaa sen uudelleen käyttöön ja yrittää uudelleen tai tallentaa jatkaaksesi ilman sitä.</value>
+    <value>Komentotulkin integroinnin asennus epäonnistui. Virheiden tunnistus on poistettu käytöstä. Voit ottaa sen uudelleen käyttöön ja yrittää uudelleen tai tallentaa jatkaaksesi ilman sitä.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Session hooks eivät asentuneet. Istunnonhallinta on poistettu käytöstä. Voit ottaa sen uudelleen käyttöön ja yrittää uudelleen tai tallentaa jatkaaksesi ilman sitä.</value>
+    <value>Session hooks eivät asentuneet. Istunnonhallinta on poistettu käytöstä. Voit ottaa sen uudelleen käyttöön ja yrittää uudelleen tai tallentaa jatkaaksesi ilman sitä.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Opi korjaamaan tämä manuaalisesti</value>
@@ -365,7 +365,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShellin suorituskäytäntö estää komentosarjat. Virheiden tunnistus poistettu käytöstä.</value>
+    <value>PowerShellin suorituskäytäntö estää komentosarjat. Virheiden tunnistus poistettu käytöstä.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Käyttö</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fil-PH/Resources.resw
@@ -223,39 +223,39 @@
     <value>Sine-set up...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Na-block ng patakaran ng Windows Package Manager ang pag-install ng {0}. Kung nasa pinamamahalaang device ka, makipag-ugnayan sa iyong IT admin.</value>
+    <value>Na-block ng patakaran ng Windows Package Manager ang pag-install ng {0}. Kung nasa pinamamahalaang device ka, makipag-ugnayan sa iyong IT admin.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Hindi ma-install ang {0} (error code {1}). Tingnan ang log para sa mga detalye, o manu-manong i-install ang {0}.</value>
+    <value>Hindi ma-install ang {0} (error code {1}). Tingnan ang log para sa mga detalye, o manu-manong i-install ang {0}.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Hindi ma-install ang {0}. Tingnan ang log para sa mga detalye, o manu-manong i-install ang {0}.</value>
+    <value>Hindi ma-install ang {0}. Tingnan ang log para sa mga detalye, o manu-manong i-install ang {0}.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Nag-ulat ng error ang installer ng {0} (code {1}). Tingnan ang log para sa mga detalye, o manu-manong i-install ang {0}.</value>
+    <value>Nag-ulat ng error ang installer ng {0} (code {1}). Tingnan ang log para sa mga detalye, o manu-manong i-install ang {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Hindi maabot ang Windows Package Manager habang ini-install ang {0}. Suriin ang iyong koneksyon sa internet (maaaring bina-block ito ng VPN, proxy, o firewall) at subukang muli.</value>
+    <value>Hindi maabot ang Windows Package Manager habang ini-install ang {0}. Suriin ang iyong koneksyon sa internet (maaaring bina-block ito ng VPN, proxy, o firewall) at subukang muli.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Walang compatible na installer para sa {0} na available sa system na ito (maaaring hindi suportado ang bersyon ng OS o architecture). Manu-manong i-install ang {0}.</value>
+    <value>Walang compatible na installer para sa {0} na available sa system na ito (maaaring hindi suportado ang bersyon ng OS o architecture). Manu-manong i-install ang {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Hindi natagpuan ang {0} sa catalog ng Windows Package Manager. Subukang i-refresh ang mga source ng winget, o manu-manong i-install ang {0}.</value>
+    <value>Hindi natagpuan ang {0} sa catalog ng Windows Package Manager. Subukang i-refresh ang mga source ng winget, o manu-manong i-install ang {0}.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Tumagal nang higit sa 20 minuto ang pag-install ng {0}. Huminto sa paghihintay ang Intelligent Terminal, pero maaaring tumatakbo pa rin sa background ang installer. Suriin ang Task Manager, o subukang muli mamaya.</value>
+    <value>Tumagal nang higit sa 20 minuto ang pag-install ng {0}. Huminto sa paghihintay ang Intelligent Terminal, pero maaaring tumatakbo pa rin sa background ang installer. Suriin ang Task Manager, o subukang muli mamaya.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Hindi naka-install o hindi available ang Windows Package Manager (winget). I-install muna ito, pagkatapos ay subukang muli.</value>
+    <value>Hindi naka-install o hindi available ang Windows Package Manager (winget). I-install muna ito, pagkatapos ay subukang muli.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -279,9 +279,9 @@
     <value>Bigyan ang Intelligent Terminal ng pahintulot na i-access ang iyong shell at awtomatikong tukuyin ang mga error.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Nabigong i-install ang shell integration. Na-off ang error detection. Maaari mo itong i-enable ulit at subukang muli, o i-save para magpatuloy nang wala ito.</value>
+    <value>Nabigong i-install ang shell integration. Na-off ang error detection. Maaari mo itong i-enable ulit at subukang muli, o i-save para magpatuloy nang wala ito.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Nabigong i-install ang session hooks. Na-off ang pamamahala ng session. Maaari mo itong i-enable ulit at subukang muli, o i-save para magpatuloy nang wala ito.</value>
+    <value>Nabigong i-install ang session hooks. Na-off ang pamamahala ng session. Maaari mo itong i-enable ulit at subukang muli, o i-save para magpatuloy nang wala ito.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Alamin kung paano ito ayusin nang manu-mano</value>
@@ -297,7 +297,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Hinaharangan ng execution policy ng PowerShell ang mga script. Na-off ang error detection.</value>
+    <value>Hinaharangan ng execution policy ng PowerShell ang mga script. Na-off ang error detection.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Paggamit</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-CA/Resources.resw
@@ -218,39 +218,39 @@
     <value>Configuration en cours...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ L'installation de {0} a été bloquée par une stratégie du Gestionnaire de package Windows. Si vous utilisez un appareil géré, contactez votre administrateur informatique.</value>
+    <value>L'installation de {0} a été bloquée par une stratégie du Gestionnaire de package Windows. Si vous utilisez un appareil géré, contactez votre administrateur informatique.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Impossible d'installer {0} (code d'erreur {1}). Consultez le journal pour plus de détails, ou installez {0} manuellement.</value>
+    <value>Impossible d'installer {0} (code d'erreur {1}). Consultez le journal pour plus de détails, ou installez {0} manuellement.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Impossible d'installer {0}. Consultez le journal pour plus de détails, ou installez {0} manuellement.</value>
+    <value>Impossible d'installer {0}. Consultez le journal pour plus de détails, ou installez {0} manuellement.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Le programme d'installation de {0} a signalé une erreur (code {1}). Consultez le journal pour plus de détails, ou installez {0} manuellement.</value>
+    <value>Le programme d'installation de {0} a signalé une erreur (code {1}). Consultez le journal pour plus de détails, ou installez {0} manuellement.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Impossible de joindre le Gestionnaire de package Windows pendant l'installation de {0}. Vérifiez votre connexion Internet (un VPN, un proxy ou un pare-feu peut la bloquer), puis réessayez.</value>
+    <value>Impossible de joindre le Gestionnaire de package Windows pendant l'installation de {0}. Vérifiez votre connexion Internet (un VPN, un proxy ou un pare-feu peut la bloquer), puis réessayez.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Aucun programme d'installation compatible pour {0} n'est disponible sur ce système (la version du système d'exploitation ou l'architecture n'est peut-être pas prise en charge). Installez {0} manuellement.</value>
+    <value>Aucun programme d'installation compatible pour {0} n'est disponible sur ce système (la version du système d'exploitation ou l'architecture n'est peut-être pas prise en charge). Installez {0} manuellement.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} est introuvable dans le catalogue du Gestionnaire de package Windows. Essayez d'actualiser les sources winget, ou installez {0} manuellement.</value>
+    <value>{0} est introuvable dans le catalogue du Gestionnaire de package Windows. Essayez d'actualiser les sources winget, ou installez {0} manuellement.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ L'installation de {0} a pris plus de 20 minutes. Intelligent Terminal a cessé d'attendre, mais le programme d'installation est peut-être toujours en cours d'exécution en arrière-plan. Consultez Task Manager, ou réessayez plus tard.</value>
+    <value>L'installation de {0} a pris plus de 20 minutes. Intelligent Terminal a cessé d'attendre, mais le programme d'installation est peut-être toujours en cours d'exécution en arrière-plan. Consultez Task Manager, ou réessayez plus tard.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Le Gestionnaire de package Windows (winget) n'est pas installé ou n'est pas disponible. Installez-le d'abord, puis réessayez.</value>
+    <value>Le Gestionnaire de package Windows (winget) n'est pas installé ou n'est pas disponible. Installez-le d'abord, puis réessayez.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -342,9 +342,9 @@
     <value>Autorisez Intelligent Terminal à accéder à votre shell et à détecter automatiquement les erreurs.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Échec de l'installation de l'intégration du shell. La détection des erreurs a été désactivée. Vous pouvez la réactiver et réessayer, ou enregistrer pour continuer sans elle.</value>
+    <value>Échec de l'installation de l'intégration du shell. La détection des erreurs a été désactivée. Vous pouvez la réactiver et réessayer, ou enregistrer pour continuer sans elle.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Échec de l'installation des hooks de session. La gestion des sessions a été désactivée. Vous pouvez la réactiver et réessayer, ou enregistrer pour continuer sans elle.</value>
+    <value>Échec de l'installation des hooks de session. La gestion des sessions a été désactivée. Vous pouvez la réactiver et réessayer, ou enregistrer pour continuer sans elle.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Découvrez comment résoudre ce problème manuellement</value>
@@ -360,7 +360,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ La stratégie d'exécution de PowerShell bloque les scripts. Détection des erreurs désactivée.</value>
+    <value>La stratégie d'exécution de PowerShell bloque les scripts. Détection des erreurs désactivée.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Utilisation</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/fr-FR/Resources.resw
@@ -1118,39 +1118,39 @@
     <value>Configuration en cours...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ L'installation de {0} a été bloquée par une stratégie du Gestionnaire de package Windows. Si vous utilisez un appareil géré, contactez votre administrateur informatique.</value>
+    <value>L'installation de {0} a été bloquée par une stratégie du Gestionnaire de package Windows. Si vous utilisez un appareil géré, contactez votre administrateur informatique.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Impossible d'installer {0} (code d'erreur {1}). Consultez le journal pour plus de détails, ou installez {0} manuellement.</value>
+    <value>Impossible d'installer {0} (code d'erreur {1}). Consultez le journal pour plus de détails, ou installez {0} manuellement.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Impossible d'installer {0}. Consultez le journal pour plus de détails, ou installez {0} manuellement.</value>
+    <value>Impossible d'installer {0}. Consultez le journal pour plus de détails, ou installez {0} manuellement.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Le programme d'installation de {0} a signalé une erreur (code {1}). Consultez le journal pour plus de détails, ou installez {0} manuellement.</value>
+    <value>Le programme d'installation de {0} a signalé une erreur (code {1}). Consultez le journal pour plus de détails, ou installez {0} manuellement.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Impossible de joindre le Gestionnaire de package Windows pendant l'installation de {0}. Vérifiez votre connexion Internet (un VPN, un proxy ou un pare-feu peut la bloquer), puis réessayez.</value>
+    <value>Impossible de joindre le Gestionnaire de package Windows pendant l'installation de {0}. Vérifiez votre connexion Internet (un VPN, un proxy ou un pare-feu peut la bloquer), puis réessayez.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Aucun programme d'installation compatible pour {0} n'est disponible sur ce système (la version du système d'exploitation ou l'architecture n'est peut-être pas prise en charge). Installez {0} manuellement.</value>
+    <value>Aucun programme d'installation compatible pour {0} n'est disponible sur ce système (la version du système d'exploitation ou l'architecture n'est peut-être pas prise en charge). Installez {0} manuellement.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} est introuvable dans le catalogue du Gestionnaire de package Windows. Essayez d'actualiser les sources winget, ou installez {0} manuellement.</value>
+    <value>{0} est introuvable dans le catalogue du Gestionnaire de package Windows. Essayez d'actualiser les sources winget, ou installez {0} manuellement.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ L'installation de {0} a pris plus de 20 minutes. Intelligent Terminal a cessé d'attendre, mais le programme d'installation est peut-être toujours en cours d'exécution en arrière-plan. Consultez Task Manager, ou réessayez plus tard.</value>
+    <value>L'installation de {0} a pris plus de 20 minutes. Intelligent Terminal a cessé d'attendre, mais le programme d'installation est peut-être toujours en cours d'exécution en arrière-plan. Consultez Task Manager, ou réessayez plus tard.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Le Gestionnaire de package Windows (winget) n'est pas installé ou n'est pas disponible. Installez-le d'abord, puis réessayez.</value>
+    <value>Le Gestionnaire de package Windows (winget) n'est pas installé ou n'est pas disponible. Installez-le d'abord, puis réessayez.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1162,11 +1162,11 @@
     <comment>{Locked="Node.js","LTS"} Product display name substituted into the FreOverlay_InstallError_* templates when reporting a winget install failure for the Node.js prerequisite.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Échec de l'installation des hooks de session. La gestion des sessions a été désactivée. Vous pouvez la réactiver et réessayer, ou enregistrer pour continuer sans elle.</value>
+    <value>Échec de l'installation des hooks de session. La gestion des sessions a été désactivée. Vous pouvez la réactiver et réessayer, ou enregistrer pour continuer sans elle.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Échec de l'installation de l'intégration du shell. La détection des erreurs a été désactivée. Vous pouvez la réactiver et réessayer, ou enregistrer pour continuer sans elle.</value>
+    <value>Échec de l'installation de l'intégration du shell. La détection des erreurs a été désactivée. Vous pouvez la réactiver et réessayer, ou enregistrer pour continuer sans elle.</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Découvrez comment résoudre ce problème manuellement</value>
@@ -1271,7 +1271,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ La stratégie d'exécution de PowerShell bloque les scripts. Détection des erreurs désactivée.</value>
+    <value>La stratégie d'exécution de PowerShell bloque les scripts. Détection des erreurs désactivée.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Utilisation</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ga-IE/Resources.resw
@@ -110,39 +110,39 @@
     <value>Ag socrú...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Chuir polasaí de chuid Bhainisteoir Pacáistí Windows bac ar shuiteáil {0}. Má tá gléas bainistithe in úsáid agat, déan teagmháil le do riarthóir TF.</value>
+    <value>Chuir polasaí de chuid Bhainisteoir Pacáistí Windows bac ar shuiteáil {0}. Má tá gléas bainistithe in úsáid agat, déan teagmháil le do riarthóir TF.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Níorbh fhéidir {0} a shuiteáil (cód earráide {1}). Seiceáil an loga le haghaidh sonraí, nó suiteáil {0} de láimh.</value>
+    <value>Níorbh fhéidir {0} a shuiteáil (cód earráide {1}). Seiceáil an loga le haghaidh sonraí, nó suiteáil {0} de láimh.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Níorbh fhéidir {0} a shuiteáil. Seiceáil an loga le haghaidh sonraí, nó suiteáil {0} de láimh.</value>
+    <value>Níorbh fhéidir {0} a shuiteáil. Seiceáil an loga le haghaidh sonraí, nó suiteáil {0} de láimh.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Thuairiscigh suiteálaí {0} earráid (cód {1}). Seiceáil an loga le haghaidh sonraí, nó suiteáil {0} de láimh.</value>
+    <value>Thuairiscigh suiteálaí {0} earráid (cód {1}). Seiceáil an loga le haghaidh sonraí, nó suiteáil {0} de láimh.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Níorbh fhéidir Bainisteoir Pacáistí Windows a bhaint amach agus {0} á shuiteáil. Seiceáil do cheangal idirlín (d'fhéadfadh VPN, seachfhreastalaí nó balla dóiteáin é a bhlocáil) agus bain triail eile as.</value>
+    <value>Níorbh fhéidir Bainisteoir Pacáistí Windows a bhaint amach agus {0} á shuiteáil. Seiceáil do cheangal idirlín (d'fhéadfadh VPN, seachfhreastalaí nó balla dóiteáin é a bhlocáil) agus bain triail eile as.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Níl aon suiteálaí comhoiriúnach do {0} ar fáil ar an gcóras seo (seans nach dtacaítear le leagan an chórais oibriúcháin nó leis an ailtireacht). Suiteáil {0} de láimh.</value>
+    <value>Níl aon suiteálaí comhoiriúnach do {0} ar fáil ar an gcóras seo (seans nach dtacaítear le leagan an chórais oibriúcháin nó leis an ailtireacht). Suiteáil {0} de láimh.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Níor aimsíodh {0} i gcatalóg Bhainisteoir Pacáistí Windows. Bain triail as foinsí winget a athnuachan, nó suiteáil {0} de láimh.</value>
+    <value>Níor aimsíodh {0} i gcatalóg Bhainisteoir Pacáistí Windows. Bain triail as foinsí winget a athnuachan, nó suiteáil {0} de láimh.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Thóg suiteáil {0} níos mó ná 20 nóiméad. Stop Intelligent Terminal de bheith ag fanacht, ach d'fhéadfadh an suiteálaí a bheith fós ag rith sa chúlra. Seiceáil Task Manager, nó bain triail eile as níos déanaí.</value>
+    <value>Thóg suiteáil {0} níos mó ná 20 nóiméad. Stop Intelligent Terminal de bheith ag fanacht, ach d'fhéadfadh an suiteálaí a bheith fós ag rith sa chúlra. Seiceáil Task Manager, nó bain triail eile as níos déanaí.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Níl Bainisteoir Pacáistí Windows (winget) suiteáilte nó ar fáil. Suiteáil é ar dtús, ansin bain triail eile as.</value>
+    <value>Níl Bainisteoir Pacáistí Windows (winget) suiteáilte nó ar fáil. Suiteáil é ar dtús, ansin bain triail eile as.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -234,9 +234,9 @@
     <value>Tabhair cead do Intelligent Terminal rochtain a fháil ar do bhlaosc agus earráidí a bhrath go huathoibríoch.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Theip ar chomhtháthú blaoisce a shuiteáil. Tá brath earráidí múchta. Is féidir leat é a athchumasú agus triail eile a bhaint as, nó sábháil chun leanúint ar aghaidh gan é.</value>
+    <value>Theip ar chomhtháthú blaoisce a shuiteáil. Tá brath earráidí múchta. Is féidir leat é a athchumasú agus triail eile a bhaint as, nó sábháil chun leanúint ar aghaidh gan é.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Theip ar na session hooks a shuiteáil. Tá bainistiú seisiún múchta. Is féidir leat é a athchumasú agus triail eile a bhaint as, nó sábháil chun leanúint ar aghaidh gan é.</value>
+    <value>Theip ar na session hooks a shuiteáil. Tá bainistiú seisiún múchta. Is féidir leat é a athchumasú agus triail eile a bhaint as, nó sábháil chun leanúint ar aghaidh gan é.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Foghlaim conas é seo a shocrú de láimh</value>
@@ -252,7 +252,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Tá beartas feidhmithe PowerShell ag cosc scripteanna. Brath earráidí múchta.</value>
+    <value>Tá beartas feidhmithe PowerShell ag cosc scripteanna. Brath earráidí múchta.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Úsáid</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gd-gb/Resources.resw
@@ -110,39 +110,39 @@
     <value>Ga shuidheachadh...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Chaidh stàladh {0} a bhacadh le poileasaidh Manaidsear Pacaidean Windows. Ma tha thu air uidheam air a stiùireadh, cuir fios chun rianaire IT agad.</value>
+    <value>Chaidh stàladh {0} a bhacadh le poileasaidh Manaidsear Pacaidean Windows. Ma tha thu air uidheam air a stiùireadh, cuir fios chun rianaire IT agad.</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Cha b' urrainn dhuinn {0} a stàladh (còd mearachd {1}). Faic an loga airson mion-fhiosrachadh, no stàlaich {0} le làimh.</value>
+    <value>Cha b' urrainn dhuinn {0} a stàladh (còd mearachd {1}). Faic an loga airson mion-fhiosrachadh, no stàlaich {0} le làimh.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Cha b' urrainn dhuinn {0} a stàladh. Faic an loga airson mion-fhiosrachadh, no stàlaich {0} le làimh.</value>
+    <value>Cha b' urrainn dhuinn {0} a stàladh. Faic an loga airson mion-fhiosrachadh, no stàlaich {0} le làimh.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Dh'aithris stàlaichear {0} mearachd (còd {1}). Thoir sùil air an loga airson mion-fhiosrachadh, no stàlaich {0} le làimh.</value>
+    <value>Dh'aithris stàlaichear {0} mearachd (còd {1}). Thoir sùil air an loga airson mion-fhiosrachadh, no stàlaich {0} le làimh.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Cha b' urrainn dhuinn Manaidsear Pacaidean Windows a ruigsinn fhad 's a bha {0} ga stàladh. Thoir sùil air do cheangal eadar-lìn (dh'fhaodadh VPN, progsaidh no balla-teine a bhith ga bhacadh) agus feuch a-rithist.</value>
+    <value>Cha b' urrainn dhuinn Manaidsear Pacaidean Windows a ruigsinn fhad 's a bha {0} ga stàladh. Thoir sùil air do cheangal eadar-lìn (dh'fhaodadh VPN, progsaidh no balla-teine a bhith ga bhacadh) agus feuch a-rithist.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Chan eil stàlaichear co-chòrdail airson {0} ri fhaighinn air an t-siostam seo (dh'fhaodadh nach eil taic ann do dhreach an OS no dhan ailtireachd). Stàlaich {0} le làimh.</value>
+    <value>Chan eil stàlaichear co-chòrdail airson {0} ri fhaighinn air an t-siostam seo (dh'fhaodadh nach eil taic ann do dhreach an OS no dhan ailtireachd). Stàlaich {0} le làimh.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Cha deach {0} a lorg ann an catalog Manaidsear Pacaidean Windows. Feuch ri tùsan winget ùrachadh, no stàlaich {0} le làimh.</value>
+    <value>Cha deach {0} a lorg ann an catalog Manaidsear Pacaidean Windows. Feuch ri tùsan winget ùrachadh, no stàlaich {0} le làimh.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Thug stàladh {0} nas fhaide na 20 mionaid. Sguir Intelligent Terminal a bhith a' feitheamh, ach dh'fhaodadh an stàlaichear a bhith fhathast a' ruith sa chùlaibh. Thoir sùil air Task Manager, no feuch a-rithist nas fhaide air adhart.</value>
+    <value>Thug stàladh {0} nas fhaide na 20 mionaid. Sguir Intelligent Terminal a bhith a' feitheamh, ach dh'fhaodadh an stàlaichear a bhith fhathast a' ruith sa chùlaibh. Thoir sùil air Task Manager, no feuch a-rithist nas fhaide air adhart.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Chan eil Manaidsear Pacaidean Windows (winget) air a stàladh no ri fhaighinn. Stàlaich e an toiseach, agus feuch a-rithist.</value>
+    <value>Chan eil Manaidsear Pacaidean Windows (winget) air a stàladh no ri fhaighinn. Stàlaich e an toiseach, agus feuch a-rithist.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -234,9 +234,9 @@
     <value>Thoir cead do Intelligent Terminal cothrom fhaighinn air an t-slige agad agus mearachdan a lorg gu fèin-obrachail.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Dh'fhàillig stàladh amalachadh na slige. Chaidh lorg mhearachdan a chur dheth. 'S urrainn dhut a chur air a-rithist agus feuchainn a-rithist, no sàbhail gus leantainn às aonais.</value>
+    <value>Dh'fhàillig stàladh amalachadh na slige. Chaidh lorg mhearachdan a chur dheth. 'S urrainn dhut a chur air a-rithist agus feuchainn a-rithist, no sàbhail gus leantainn às aonais.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Dh'fhàillig stàladh nan session hooks. Chaidh rianachd nan seisean a chur dheth. 'S urrainn dhut a chur air a-rithist agus feuchainn a-rithist, no sàbhail gus leantainn às aonais.</value>
+    <value>Dh'fhàillig stàladh nan session hooks. Chaidh rianachd nan seisean a chur dheth. 'S urrainn dhut a chur air a-rithist agus feuchainn a-rithist, no sàbhail gus leantainn às aonais.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Ionnsaich mar a chàraicheas tu seo a làimh</value>
@@ -252,7 +252,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Tha poileasaidh ruith PowerShell a' bacadh sgriobtaichean. Tha lorg mhearachdan dheth.</value>
+    <value>Tha poileasaidh ruith PowerShell a' bacadh sgriobtaichean. Tha lorg mhearachdan dheth.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Cleachdadh</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gl-ES/Resources.resw
@@ -110,39 +110,39 @@
     <value>Configurando...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ A instalación de {0} foi bloqueada por unha directiva do Xestor de paquetes de Windows. Se está nun dispositivo administrado, póñase en contacto co seu administrador de TI.</value>
+    <value>A instalación de {0} foi bloqueada por unha directiva do Xestor de paquetes de Windows. Se está nun dispositivo administrado, póñase en contacto co seu administrador de TI.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Non se puido instalar {0} (código de erro {1}). Consulte o rexistro para obter detalles, ou instale {0} manualmente.</value>
+    <value>Non se puido instalar {0} (código de erro {1}). Consulte o rexistro para obter detalles, ou instale {0} manualmente.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Non se puido instalar {0}. Consulte o rexistro para obter detalles, ou instale {0} manualmente.</value>
+    <value>Non se puido instalar {0}. Consulte o rexistro para obter detalles, ou instale {0} manualmente.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ O instalador de {0} notificou un erro (código {1}). Consulte o rexistro para obter detalles, ou instale {0} manualmente.</value>
+    <value>O instalador de {0} notificou un erro (código {1}). Consulte o rexistro para obter detalles, ou instale {0} manualmente.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Non se puido contactar co Xestor de paquetes de Windows ao instalar {0}. Comprobe a súa conexión a Internet (VPN, proxy ou firewall poden estar bloqueándoa) e ténteo de novo.</value>
+    <value>Non se puido contactar co Xestor de paquetes de Windows ao instalar {0}. Comprobe a súa conexión a Internet (VPN, proxy ou firewall poden estar bloqueándoa) e ténteo de novo.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Non hai dispoñible ningún instalador compatible para {0} neste sistema (é posible que a versión do sistema operativo ou a arquitectura non sexan compatibles). Instale {0} manualmente.</value>
+    <value>Non hai dispoñible ningún instalador compatible para {0} neste sistema (é posible que a versión do sistema operativo ou a arquitectura non sexan compatibles). Instale {0} manualmente.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} non se atopou no catálogo do Xestor de paquetes de Windows. Tente actualizar as orixes de winget, ou instale {0} manualmente.</value>
+    <value>{0} non se atopou no catálogo do Xestor de paquetes de Windows. Tente actualizar as orixes de winget, ou instale {0} manualmente.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ A instalación de {0} tardou máis de 20 minutos. Intelligent Terminal deixou de agardar, pero é posible que o instalador aínda se estea executando en segundo plano. Consulte Task Manager, ou ténteo de novo máis tarde.</value>
+    <value>A instalación de {0} tardou máis de 20 minutos. Intelligent Terminal deixou de agardar, pero é posible que o instalador aínda se estea executando en segundo plano. Consulte Task Manager, ou ténteo de novo máis tarde.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ O Xestor de paquetes de Windows (winget) non está instalado ou non está dispoñible. Instáleo primeiro e ténteo de novo.</value>
+    <value>O Xestor de paquetes de Windows (winget) non está instalado ou non está dispoñible. Instáleo primeiro e ténteo de novo.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -166,9 +166,9 @@
     <value>Permite que Intelligent Terminal acceda ao teu intérprete de ordes e detecte erros automaticamente.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Produciuse un erro ao instalar a integración do shell. A detección de erros desactivouse. Pode reactivala e tentalo de novo, ou gardar para continuar sen ela.</value>
+    <value>Produciuse un erro ao instalar a integración do shell. A detección de erros desactivouse. Pode reactivala e tentalo de novo, ou gardar para continuar sen ela.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Produciuse un erro ao instalar os hooks de sesión. A xestión de sesións desactivouse. Pode reactivala e tentalo de novo, ou gardar para continuar sen ela.</value>
+    <value>Produciuse un erro ao instalar os hooks de sesión. A xestión de sesións desactivouse. Pode reactivala e tentalo de novo, ou gardar para continuar sen ela.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Aprenda como solucionar isto manualmente</value>
@@ -184,7 +184,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ A directiva de execución de PowerShell está a bloquear os scripts. Detección de erros desactivada.</value>
+    <value>A directiva de execución de PowerShell está a bloquear os scripts. Detección de erros desactivada.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Uso</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/gu-IN/Resources.resw
@@ -223,50 +223,50 @@
     <value>સેટ અપ થઈ રહ્યું છે...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager નીતિ દ્વારા {0} નું ઇન્સ્ટોલેશન અવરોધિત કરવામાં આવ્યું હતું. જો તમે મેનેજ્ડ ડિવાઇસ પર હો, તો તમારા IT એડમિનનો સંપર્ક કરો.</value>
+    <value>Windows Package Manager નીતિ દ્વારા {0} નું ઇન્સ્ટોલેશન અવરોધિત કરવામાં આવ્યું હતું. જો તમે મેનેજ્ડ ડિવાઇસ પર હો, તો તમારા IT એડમિનનો સંપર્ક કરો.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} ઇન્સ્ટોલ કરી શકાયું નહીં (ભૂલ કોડ {1}). વિગતો માટે લૉગ જુઓ, અથવા {0} ને મેન્યુઅલી ઇન્સ્ટોલ કરો.</value>
+    <value>{0} ઇન્સ્ટોલ કરી શકાયું નહીં (ભૂલ કોડ {1}). વિગતો માટે લૉગ જુઓ, અથવા {0} ને મેન્યુઅલી ઇન્સ્ટોલ કરો.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} ઇન્સ્ટોલ કરી શકાયું નહીં. વિગતો માટે લૉગ જુઓ, અથવા {0} ને મેન્યુઅલી ઇન્સ્ટોલ કરો.</value>
+    <value>{0} ઇન્સ્ટોલ કરી શકાયું નહીં. વિગતો માટે લૉગ જુઓ, અથવા {0} ને મેન્યુઅલી ઇન્સ્ટોલ કરો.</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} ઇન્સ્ટોલરે ભૂલ રિપોર્ટ કરી (કોડ {1}). વિગતો માટે લૉગ તપાસો, અથવા {0} ને મેન્યુઅલી ઇન્સ્ટોલ કરો.</value>
+    <value>{0} ઇન્સ્ટોલરે ભૂલ રિપોર્ટ કરી (કોડ {1}). વિગતો માટે લૉગ તપાસો, અથવા {0} ને મેન્યુઅલી ઇન્સ્ટોલ કરો.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} ઇન્સ્ટોલ કરતી વખતે Windows Package Manager સુધી પહોંચી શકાયું નહીં. તમારું ઇન્ટરનેટ કનેક્શન તપાસો (VPN, proxy, અથવા firewall તેને બ્લૉક કરી રહ્યાં હોઈ શકે છે) અને ફરી પ્રયાસ કરો.</value>
+    <value>{0} ઇન્સ્ટોલ કરતી વખતે Windows Package Manager સુધી પહોંચી શકાયું નહીં. તમારું ઇન્ટરનેટ કનેક્શન તપાસો (VPN, proxy, અથવા firewall તેને બ્લૉક કરી રહ્યાં હોઈ શકે છે) અને ફરી પ્રયાસ કરો.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ આ સિસ્ટમ પર {0} માટે કોઈ સુસંગત ઇન્સ્ટોલર ઉપલબ્ધ નથી (OS વર્ઝન અથવા આર્કિટેક્ચર સપોર્ટેડ ન હોઈ શકે). {0} ને મેન્યુઅલી ઇન્સ્ટોલ કરો.</value>
+    <value>આ સિસ્ટમ પર {0} માટે કોઈ સુસંગત ઇન્સ્ટોલર ઉપલબ્ધ નથી (OS વર્ઝન અથવા આર્કિટેક્ચર સપોર્ટેડ ન હોઈ શકે). {0} ને મેન્યુઅલી ઇન્સ્ટોલ કરો.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager કૅટલોગમાં {0} મળ્યું નથી. winget સોર્સ રિફ્રેશ કરવાનો પ્રયાસ કરો, અથવા {0} ને મેન્યુઅલી ઇન્સ્ટોલ કરો.</value>
+    <value>Windows Package Manager કૅટલોગમાં {0} મળ્યું નથી. winget સોર્સ રિફ્રેશ કરવાનો પ્રયાસ કરો, અથવા {0} ને મેન્યુઅલી ઇન્સ્ટોલ કરો.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} ઇન્સ્ટોલ કરવામાં 20 મિનિટથી વધુ સમય લાગ્યો. Intelligent Terminal એ રાહ જોવાનું બંધ કર્યું, પરંતુ ઇન્સ્ટોલર હજી પણ બેકગ્રાઉન્ડમાં ચાલી રહ્યું હોઈ શકે છે. Task Manager તપાસો, અથવા પછીથી ફરી પ્રયાસ કરો.</value>
+    <value>{0} ઇન્સ્ટોલ કરવામાં 20 મિનિટથી વધુ સમય લાગ્યો. Intelligent Terminal એ રાહ જોવાનું બંધ કર્યું, પરંતુ ઇન્સ્ટોલર હજી પણ બેકગ્રાઉન્ડમાં ચાલી રહ્યું હોઈ શકે છે. Task Manager તપાસો, અથવા પછીથી ફરી પ્રયાસ કરો.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks ઇન્સ્ટોલ કરવામાં નિષ્ફળ. સેશન મેનેજમેન્ટ બંધ કરવામાં આવ્યું છે. તમે તેને ફરીથી સક્ષમ કરીને ફરી પ્રયાસ કરી શકો છો, અથવા તેના વિના ચાલુ રાખવા માટે સાચવો.</value>
+    <value>session hooks ઇન્સ્ટોલ કરવામાં નિષ્ફળ. સેશન મેનેજમેન્ટ બંધ કરવામાં આવ્યું છે. તમે તેને ફરીથી સક્ષમ કરીને ફરી પ્રયાસ કરી શકો છો, અથવા તેના વિના ચાલુ રાખવા માટે સાચવો.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ શેલ ઇન્ટિગ્રેશન ઇન્સ્ટોલ કરવામાં નિષ્ફળ. ભૂલ શોધ બંધ કરવામાં આવી છે. તમે તેને ફરીથી સક્ષમ કરીને ફરી પ્રયાસ કરી શકો છો, અથવા તેના વિના ચાલુ રાખવા માટે સાચવો.</value>
+    <value>શેલ ઇન્ટિગ્રેશન ઇન્સ્ટોલ કરવામાં નિષ્ફળ. ભૂલ શોધ બંધ કરવામાં આવી છે. તમે તેને ફરીથી સક્ષમ કરીને ફરી પ્રયાસ કરી શકો છો, અથવા તેના વિના ચાલુ રાખવા માટે સાચવો.</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell એક્ઝિક્યુશન પોલિસી સ્ક્રિપ્ટ્સને અવરોધી રહી છે. ભૂલ શોધ બંધ કરી દીધી.</value>
+    <value>PowerShell એક્ઝિક્યુશન પોલિસી સ્ક્રિપ્ટ્સને અવરોધી રહી છે. ભૂલ શોધ બંધ કરી દીધી.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) ઇન્સ્ટોલ થયેલ નથી અથવા ઉપલબ્ધ નથી. પહેલાં તેને ઇન્સ્ટોલ કરો, પછી ફરી પ્રયાસ કરો.</value>
+    <value>Windows Package Manager (winget) ઇન્સ્ટોલ થયેલ નથી અથવા ઉપલબ્ધ નથી. પહેલાં તેને ઇન્સ્ટોલ કરો, પછી ફરી પ્રયાસ કરો.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/he-IL/Resources.resw
@@ -224,39 +224,39 @@
     <value>מגדיר...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ התקנת {0} נחסמה על-ידי מדיניות של מנהל החבילות של Windows. אם אתה במכשיר מנוהל, פנה למנהל ה-IT שלך.</value>
+    <value>התקנת {0} נחסמה על-ידי מדיניות של מנהל החבילות של Windows. אם אתה במכשיר מנוהל, פנה למנהל ה-IT שלך.</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ לא ניתן היה להתקין את {0} (קוד שגיאה {1}). עיין ביומן לקבלת פרטים, או התקן את {0} באופן ידני.</value>
+    <value>לא ניתן היה להתקין את {0} (קוד שגיאה {1}). עיין ביומן לקבלת פרטים, או התקן את {0} באופן ידני.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ לא ניתן היה להתקין את {0}. עיין ביומן לקבלת פרטים, או התקן את {0} באופן ידני.</value>
+    <value>לא ניתן היה להתקין את {0}. עיין ביומן לקבלת פרטים, או התקן את {0} באופן ידני.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ מתקין {0} דיווח על שגיאה (קוד {1}). בדוק את היומן לקבלת פרטים, או התקן את {0} באופן ידני.</value>
+    <value>מתקין {0} דיווח על שגיאה (קוד {1}). בדוק את היומן לקבלת פרטים, או התקן את {0} באופן ידני.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ לא ניתן היה להגיע למנהל החבילות של Windows בזמן התקנת {0}. בדוק את החיבור שלך לאינטרנט (VPN, proxy או חומת אש עשויים לחסום אותו) ונסה שוב.</value>
+    <value>לא ניתן היה להגיע למנהל החבילות של Windows בזמן התקנת {0}. בדוק את החיבור שלך לאינטרנט (VPN, proxy או חומת אש עשויים לחסום אותו) ונסה שוב.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ אין מתקין תואם עבור {0} במערכת זו (ייתכן שגרסת מערכת ההפעלה או הארכיטקטורה אינן נתמכות). התקן את {0} באופן ידני.</value>
+    <value>אין מתקין תואם עבור {0} במערכת זו (ייתכן שגרסת מערכת ההפעלה או הארכיטקטורה אינן נתמכות). התקן את {0} באופן ידני.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} לא נמצא בקטלוג של מנהל החבילות של Windows. נסה לרענן את מקורות winget, או התקן את {0} באופן ידני.</value>
+    <value>{0} לא נמצא בקטלוג של מנהל החבילות של Windows. נסה לרענן את מקורות winget, או התקן את {0} באופן ידני.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ התקנת {0} ארכה יותר מ-20 דקות. Intelligent Terminal הפסיק להמתין, אך ייתכן שהמתקין עדיין פועל ברקע. בדוק את Task Manager, או נסה שוב מאוחר יותר.</value>
+    <value>התקנת {0} ארכה יותר מ-20 דקות. Intelligent Terminal הפסיק להמתין, אך ייתכן שהמתקין עדיין פועל ברקע. בדוק את Task Manager, או נסה שוב מאוחר יותר.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ מנהל החבילות של Windows (winget) אינו מותקן או אינו זמין. התקן אותו תחילה ולאחר מכן נסה שוב.</value>
+    <value>מנהל החבילות של Windows (winget) אינו מותקן או אינו זמין. התקן אותו תחילה ולאחר מכן נסה שוב.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>העניק ל-Intelligent Terminal הרשאה לגשת למעטפת שלך ולזהות שגיאות באופן אוטומטי.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ התקנת שילוב מעטפת נכשלה. זיהוי שגיאות כובה. באפשרותך להפעיל מחדש ולנסות שוב, או לשמור כדי להמשיך בלעדיו.</value>
+    <value>התקנת שילוב מעטפת נכשלה. זיהוי שגיאות כובה. באפשרותך להפעיל מחדש ולנסות שוב, או לשמור כדי להמשיך בלעדיו.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ התקנת hooks של הפעלה נכשלה. ניהול ההפעלות כובה. באפשרותך להפעיל מחדש ולנסות שוב, או לשמור כדי להמשיך בלעדיו.</value>
+    <value>התקנת hooks של הפעלה נכשלה. ניהול ההפעלות כובה. באפשרותך להפעיל מחדש ולנסות שוב, או לשמור כדי להמשיך בלעדיו.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>למד כיצד לתקן זאת באופן ידני</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ מדיניות הביצוע של PowerShell חוסמת סקריפטים. זיהוי שגיאות כובה.</value>
+    <value>מדיניות הביצוע של PowerShell חוסמת סקריפטים. זיהוי שגיאות כובה.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>שימוש</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hi-IN/Resources.resw
@@ -223,50 +223,50 @@
     <value>सेट अप हो रहा है...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager नीति द्वारा {0} की स्थापना अवरुद्ध कर दी गई थी। यदि आप किसी प्रबंधित डिवाइस पर हैं, तो अपने IT व्यवस्थापक से संपर्क करें।</value>
+    <value>Windows Package Manager नीति द्वारा {0} की स्थापना अवरुद्ध कर दी गई थी। यदि आप किसी प्रबंधित डिवाइस पर हैं, तो अपने IT व्यवस्थापक से संपर्क करें।</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} इंस्टॉल नहीं कर सके (त्रुटि कोड {1})। विवरण के लिए लॉग देखें, या {0} को मैन्युअल रूप से इंस्टॉल करें।</value>
+    <value>{0} इंस्टॉल नहीं कर सके (त्रुटि कोड {1})। विवरण के लिए लॉग देखें, या {0} को मैन्युअल रूप से इंस्टॉल करें।</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} इंस्टॉल नहीं कर सके। विवरण के लिए लॉग देखें, या {0} को मैन्युअल रूप से इंस्टॉल करें।</value>
+    <value>{0} इंस्टॉल नहीं कर सके। विवरण के लिए लॉग देखें, या {0} को मैन्युअल रूप से इंस्टॉल करें।</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} इंस्टॉलर ने त्रुटि रिपोर्ट की (कोड {1})। विवरण के लिए लॉग जाँचें, या {0} को मैन्युअल रूप से इंस्टॉल करें।</value>
+    <value>{0} इंस्टॉलर ने त्रुटि रिपोर्ट की (कोड {1})। विवरण के लिए लॉग जाँचें, या {0} को मैन्युअल रूप से इंस्टॉल करें।</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} इंस्टॉल करते समय Windows Package Manager तक नहीं पहुँच सके। अपना इंटरनेट कनेक्शन जाँचें (VPN, proxy या firewall इसे ब्लॉक कर सकता है) और पुनः प्रयास करें।</value>
+    <value>{0} इंस्टॉल करते समय Windows Package Manager तक नहीं पहुँच सके। अपना इंटरनेट कनेक्शन जाँचें (VPN, proxy या firewall इसे ब्लॉक कर सकता है) और पुनः प्रयास करें।</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ इस सिस्टम पर {0} के लिए कोई संगत इंस्टॉलर उपलब्ध नहीं है (OS संस्करण या आर्किटेक्चर समर्थित नहीं हो सकता)। {0} को मैन्युअल रूप से इंस्टॉल करें।</value>
+    <value>इस सिस्टम पर {0} के लिए कोई संगत इंस्टॉलर उपलब्ध नहीं है (OS संस्करण या आर्किटेक्चर समर्थित नहीं हो सकता)। {0} को मैन्युअल रूप से इंस्टॉल करें।</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager कैटलॉग में {0} नहीं मिला। winget स्रोतों को रीफ़्रेश करने का प्रयास करें, या {0} को मैन्युअल रूप से इंस्टॉल करें।</value>
+    <value>Windows Package Manager कैटलॉग में {0} नहीं मिला। winget स्रोतों को रीफ़्रेश करने का प्रयास करें, या {0} को मैन्युअल रूप से इंस्टॉल करें।</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} इंस्टॉल करने में 20 मिनट से अधिक समय लगा। Intelligent Terminal ने प्रतीक्षा करना बंद कर दिया, लेकिन इंस्टॉलर अभी भी पृष्ठभूमि में चल रहा हो सकता है। Task Manager जाँचें, या बाद में पुनः प्रयास करें।</value>
+    <value>{0} इंस्टॉल करने में 20 मिनट से अधिक समय लगा। Intelligent Terminal ने प्रतीक्षा करना बंद कर दिया, लेकिन इंस्टॉलर अभी भी पृष्ठभूमि में चल रहा हो सकता है। Task Manager जाँचें, या बाद में पुनः प्रयास करें।</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks इंस्टॉल करने में विफल। सेशन प्रबंधन बंद कर दिया गया है। आप इसे पुनः सक्षम करके दोबारा प्रयास कर सकते हैं, या इसके बिना जारी रखने के लिए सहेजें।</value>
+    <value>session hooks इंस्टॉल करने में विफल। सेशन प्रबंधन बंद कर दिया गया है। आप इसे पुनः सक्षम करके दोबारा प्रयास कर सकते हैं, या इसके बिना जारी रखने के लिए सहेजें।</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ शेल एकीकरण इंस्टॉल करने में विफल। त्रुटि पहचान बंद कर दी गई है। आप इसे पुनः सक्षम करके दोबारा प्रयास कर सकते हैं, या इसके बिना जारी रखने के लिए सहेजें।</value>
+    <value>शेल एकीकरण इंस्टॉल करने में विफल। त्रुटि पहचान बंद कर दी गई है। आप इसे पुनः सक्षम करके दोबारा प्रयास कर सकते हैं, या इसके बिना जारी रखने के लिए सहेजें।</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell निष्पादन नीति स्क्रिप्ट्स को अवरुद्ध कर रही है। त्रुटि पहचान बंद कर दी गई।</value>
+    <value>PowerShell निष्पादन नीति स्क्रिप्ट्स को अवरुद्ध कर रही है। त्रुटि पहचान बंद कर दी गई।</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) इंस्टॉल नहीं है या उपलब्ध नहीं है। पहले इसे इंस्टॉल करें, फिर पुनः प्रयास करें।</value>
+    <value>Windows Package Manager (winget) इंस्टॉल नहीं है या उपलब्ध नहीं है। पहले इसे इंस्टॉल करें, फिर पुनः प्रयास करें।</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hr-HR/Resources.resw
@@ -223,39 +223,39 @@
     <value>Postavljanje...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Instalacija {0} blokirana je pravilima Upravitelja paketa za Windows. Ako koristite upravljani uređaj, obratite se administratoru IT-a.</value>
+    <value>Instalacija {0} blokirana je pravilima Upravitelja paketa za Windows. Ako koristite upravljani uređaj, obratite se administratoru IT-a.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Instalacija {0} nije uspjela (kod pogreške {1}). Pojedinosti potražite u zapisniku ili ručno instalirajte {0}.</value>
+    <value>Instalacija {0} nije uspjela (kod pogreške {1}). Pojedinosti potražite u zapisniku ili ručno instalirajte {0}.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Instalacija {0} nije uspjela. Pojedinosti potražite u zapisniku ili ručno instalirajte {0}.</value>
+    <value>Instalacija {0} nije uspjela. Pojedinosti potražite u zapisniku ili ručno instalirajte {0}.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Instalacijski program za {0} prijavio je pogrešku (kod {1}). Pojedinosti potražite u zapisniku ili ručno instalirajte {0}.</value>
+    <value>Instalacijski program za {0} prijavio je pogrešku (kod {1}). Pojedinosti potražite u zapisniku ili ručno instalirajte {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Nije bilo moguće pristupiti Upravitelju paketa za Windows tijekom instalacije {0}. Provjerite internetsku vezu (VPN, proxy ili vatrozid možda je blokiraju) i pokušajte ponovno.</value>
+    <value>Nije bilo moguće pristupiti Upravitelju paketa za Windows tijekom instalacije {0}. Provjerite internetsku vezu (VPN, proxy ili vatrozid možda je blokiraju) i pokušajte ponovno.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Na ovom sustavu nije dostupan kompatibilan instalacijski program za {0} (verzija OS-a ili arhitektura možda nisu podržani). Ručno instalirajte {0}.</value>
+    <value>Na ovom sustavu nije dostupan kompatibilan instalacijski program za {0} (verzija OS-a ili arhitektura možda nisu podržani). Ručno instalirajte {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} nije pronađen u katalogu Upravitelja paketa za Windows. Pokušajte osvježiti izvore winget ili ručno instalirajte {0}.</value>
+    <value>{0} nije pronađen u katalogu Upravitelja paketa za Windows. Pokušajte osvježiti izvore winget ili ručno instalirajte {0}.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Instalacija {0} trajala je dulje od 20 minuta. Intelligent Terminal prestao je čekati, ali instalacijski program možda još radi u pozadini. Provjerite Task Manager ili pokušajte ponovno kasnije.</value>
+    <value>Instalacija {0} trajala je dulje od 20 minuta. Intelligent Terminal prestao je čekati, ali instalacijski program možda još radi u pozadini. Provjerite Task Manager ili pokušajte ponovno kasnije.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Upravitelj paketa za Windows (winget) nije instaliran ili nije dostupan. Najprije ga instalirajte, a zatim pokušajte ponovno.</value>
+    <value>Upravitelj paketa za Windows (winget) nije instaliran ili nije dostupan. Najprije ga instalirajte, a zatim pokušajte ponovno.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>Dopustite aplikaciji Intelligent Terminal pristup ljusci i automatsko otkrivanje pogrešaka.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Instalacija integracije ljuske nije uspjela. Otkrivanje pogrešaka je isključeno. Možete ga ponovno omogućiti i pokušati ponovno ili spremiti za nastavak bez njega.</value>
+    <value>Instalacija integracije ljuske nije uspjela. Otkrivanje pogrešaka je isključeno. Možete ga ponovno omogućiti i pokušati ponovno ili spremiti za nastavak bez njega.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Instalacija session hooks nije uspjela. Upravljanje sesijama je isključeno. Možete ga ponovno omogućiti i pokušati ponovno ili spremiti za nastavak bez njega.</value>
+    <value>Instalacija session hooks nije uspjela. Upravljanje sesijama je isključeno. Možete ga ponovno omogućiti i pokušati ponovno ili spremiti za nastavak bez njega.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Saznajte kako to ručno popraviti</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell pravila izvođenja blokiraju skripte. Otkrivanje pogrešaka isključeno.</value>
+    <value>PowerShell pravila izvođenja blokiraju skripte. Otkrivanje pogrešaka isključeno.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Korištenje</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hu-HU/Resources.resw
@@ -223,39 +223,39 @@
     <value>Beállítás...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ A(z) {0} telepítését a Windows csomagkezelő egyik házirendje blokkolta. Ha felügyelt eszközt használ, forduljon az IT-rendszergazdához.</value>
+    <value>A(z) {0} telepítését a Windows csomagkezelő egyik házirendje blokkolta. Ha felügyelt eszközt használ, forduljon az IT-rendszergazdához.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Nem sikerült telepíteni a következőt: {0} (hibakód: {1}). A részletekért tekintse meg a naplót, vagy telepítse manuálisan: {0}.</value>
+    <value>Nem sikerült telepíteni a következőt: {0} (hibakód: {1}). A részletekért tekintse meg a naplót, vagy telepítse manuálisan: {0}.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Nem sikerült telepíteni a következőt: {0}. A részletekért tekintse meg a naplót, vagy telepítse manuálisan: {0}.</value>
+    <value>Nem sikerült telepíteni a következőt: {0}. A részletekért tekintse meg a naplót, vagy telepítse manuálisan: {0}.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ A(z) {0} telepítője hibát jelzett (kód: {1}). A részletekért tekintse meg a naplót, vagy telepítse manuálisan: {0}.</value>
+    <value>A(z) {0} telepítője hibát jelzett (kód: {1}). A részletekért tekintse meg a naplót, vagy telepítse manuálisan: {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Nem sikerült elérni a Windows csomagkezelőt a(z) {0} telepítése közben. Ellenőrizze az internetkapcsolatot (VPN, proxy vagy tűzfal blokkolhatja), és próbálja újra.</value>
+    <value>Nem sikerült elérni a Windows csomagkezelőt a(z) {0} telepítése közben. Ellenőrizze az internetkapcsolatot (VPN, proxy vagy tűzfal blokkolhatja), és próbálja újra.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Ezen a rendszeren nem érhető el kompatibilis telepítő a(z) {0} számára (előfordulhat, hogy az operációs rendszer verziója vagy az architektúra nem támogatott). Telepítse manuálisan: {0}.</value>
+    <value>Ezen a rendszeren nem érhető el kompatibilis telepítő a(z) {0} számára (előfordulhat, hogy az operációs rendszer verziója vagy az architektúra nem támogatott). Telepítse manuálisan: {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ A(z) {0} nem található a Windows csomagkezelő katalógusában. Próbálja frissíteni a winget-forrásokat, vagy telepítse manuálisan: {0}.</value>
+    <value>A(z) {0} nem található a Windows csomagkezelő katalógusában. Próbálja frissíteni a winget-forrásokat, vagy telepítse manuálisan: {0}.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ A(z) {0} telepítése több mint 20 percig tartott. Az Intelligent Terminal leállította a várakozást, de a telepítő továbbra is futhat a háttérben. Ellenőrizze a Task Manager alkalmazást, vagy próbálkozzon újra később.</value>
+    <value>A(z) {0} telepítése több mint 20 percig tartott. Az Intelligent Terminal leállította a várakozást, de a telepítő továbbra is futhat a háttérben. Ellenőrizze a Task Manager alkalmazást, vagy próbálkozzon újra később.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ A Windows csomagkezelő (winget) nincs telepítve vagy nem érhető el. Először telepítse, majd próbálja újra.</value>
+    <value>A Windows csomagkezelő (winget) nincs telepítve vagy nem érhető el. Először telepítse, majd próbálja újra.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>Engedélyezze az Intelligent Terminal számára, hogy hozzáférjen a parancshéjhoz, és automatikusan felismerje a hibákat.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ A shell-integráció telepítése sikertelen. A hibaészlelés ki lett kapcsolva. Újra engedélyezheti, és megpróbálhatja újra, vagy menthet a folytatáshoz nélküle.</value>
+    <value>A shell-integráció telepítése sikertelen. A hibaészlelés ki lett kapcsolva. Újra engedélyezheti, és megpróbálhatja újra, vagy menthet a folytatáshoz nélküle.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ A session hooks telepítése sikertelen. A munkamenet-kezelés ki lett kapcsolva. Újra engedélyezheti, és megpróbálhatja újra, vagy menthet a folytatáshoz nélküle.</value>
+    <value>A session hooks telepítése sikertelen. A munkamenet-kezelés ki lett kapcsolva. Újra engedélyezheti, és megpróbálhatja újra, vagy menthet a folytatáshoz nélküle.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Útmutató a probléma manuális megoldásához</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ A PowerShell végrehajtási házirendje blokkolja a parancsfájlokat. A hibaészlelés kikapcsolva.</value>
+    <value>A PowerShell végrehajtási házirendje blokkolja a parancsfájlokat. A hibaészlelés kikapcsolva.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Használat</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/hy-AM/Resources.resw
@@ -110,39 +110,39 @@
     <value>Կարգավորում...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ {0}-ի տեղադրումն արգելափակվել է Windows Package Manager-ի քաղաքականության կողմից։ Եթե կառավարելի սարքի վրա եք, կապվեք ձեր IT ադմինիստրատորի հետ։</value>
+    <value>{0}-ի տեղադրումն արգելափակվել է Windows Package Manager-ի քաղաքականության կողմից։ Եթե կառավարելի սարքի վրա եք, կապվեք ձեր IT ադմինիստրատորի հետ։</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Չհաջողվեց տեղադրել {0}-ը (սխալի կոդը՝ {1})։ Մանրամասների համար դիտեք գրանցամատյանը, կամ տեղադրեք {0}-ը ձեռքով։</value>
+    <value>Չհաջողվեց տեղադրել {0}-ը (սխալի կոդը՝ {1})։ Մանրամասների համար դիտեք գրանցամատյանը, կամ տեղադրեք {0}-ը ձեռքով։</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Չհաջողվեց տեղադրել {0}-ը։ Մանրամասների համար դիտեք գրանցամատյանը, կամ տեղադրեք {0}-ը ձեռքով։</value>
+    <value>Չհաջողվեց տեղադրել {0}-ը։ Մանրամասների համար դիտեք գրանցամատյանը, կամ տեղադրեք {0}-ը ձեռքով։</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0}-ի տեղադրիչը հաղորդեց սխալ (կոդ՝ {1})։ Ստուգեք գրանցամատյանը մանրամասների համար, կամ տեղադրեք {0}-ը ձեռքով։</value>
+    <value>{0}-ի տեղադրիչը հաղորդեց սխալ (կոդ՝ {1})։ Ստուգեք գրանցամատյանը մանրամասների համար, կամ տեղադրեք {0}-ը ձեռքով։</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0}-ը տեղադրելիս չհաջողվեց կապ հաստատել Windows Package Manager-ի հետ։ Ստուգեք ինտերնետ կապը (VPN-ը, պրոքսին կամ հրապատը կարող են արգելափակել այն) և նորից փորձեք։</value>
+    <value>{0}-ը տեղադրելիս չհաջողվեց կապ հաստատել Windows Package Manager-ի հետ։ Ստուգեք ինտերնետ կապը (VPN-ը, պրոքսին կամ հրապատը կարող են արգելափակել այն) և նորից փորձեք։</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Այս համակարգում {0}-ի համար համատեղելի տեղադրիչ հասանելի չէ (OS-ի տարբերակը կամ ճարտարապետությունը կարող է չաջակցվել)։ Տեղադրեք {0}-ը ձեռքով։</value>
+    <value>Այս համակարգում {0}-ի համար համատեղելի տեղադրիչ հասանելի չէ (OS-ի տարբերակը կամ ճարտարապետությունը կարող է չաջակցվել)։ Տեղադրեք {0}-ը ձեռքով։</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0}-ը չի գտնվել Windows Package Manager-ի կատալոգում։ Փորձեք թարմացնել winget աղբյուրները, կամ տեղադրեք {0}-ը ձեռքով։</value>
+    <value>{0}-ը չի գտնվել Windows Package Manager-ի կատալոգում։ Փորձեք թարմացնել winget աղբյուրները, կամ տեղադրեք {0}-ը ձեռքով։</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0}-ի տեղադրումը տևեց ավելի քան 20 րոպե։ Intelligent Terminal-ը դադարեց սպասել, բայց տեղադրիչը կարող է դեռ աշխատել հետին պլանում։ Ստուգեք Task Manager-ը, կամ փորձեք ավելի ուշ։</value>
+    <value>{0}-ի տեղադրումը տևեց ավելի քան 20 րոպե։ Intelligent Terminal-ը դադարեց սպասել, բայց տեղադրիչը կարող է դեռ աշխատել հետին պլանում։ Ստուգեք Task Manager-ը, կամ փորձեք ավելի ուշ։</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager-ը (winget) տեղադրված չէ կամ հասանելի չէ։ Նախ տեղադրեք այն, ապա նորից փորձեք:</value>
+    <value>Windows Package Manager-ը (winget) տեղադրված չէ կամ հասանելի չէ։ Նախ տեղադրեք այն, ապա նորից փորձեք:</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -234,9 +234,9 @@
     <value>Թույլ տվեք Intelligent Terminal-ին մուտք գործել ձեր թաղանթ և ավտոմատ կերպով հայտնաբերել սխալները։</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Shell-ի ինտեգրացիայի տեղադրումը ձախողվեց։ Սխալների հայտնաբերումը անջատվել է։ Կարող եք նորից միացնել և նորից փորձել, կամ պահել առանց դրա շարունակելու համար։</value>
+    <value>Shell-ի ինտեգրացիայի տեղադրումը ձախողվեց։ Սխալների հայտնաբերումը անջատվել է։ Կարող եք նորից միացնել և նորից փորձել, կամ պահել առանց դրա շարունակելու համար։</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Session hooks տեղադրումը ձախողվեց։ Նիստերի կառավարումը անջատվել է։ Կարող եք նորից միացնել և նորից փորձել, կամ պահել առանց դրա շարունակելու համար։</value>
+    <value>Session hooks տեղադրումը ձախողվեց։ Նիստերի կառավարումը անջատվել է։ Կարող եք նորից միացնել և նորից փորձել, կամ պահել առանց դրա շարունակելու համար։</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Իմացեք, թե ինչպես սա շտկել ձեռքով</value>
@@ -252,7 +252,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell-ի կատարման քաղաքականությունն արգելափակում է սկրիպտները։ Սխալների հայտնաբերումն անջատված է։</value>
+    <value>PowerShell-ի կատարման քաղաքականությունն արգելափակում է սկրիպտները։ Սխալների հայտնաբերումն անջատված է։</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Օգտագործում</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/id-ID/Resources.resw
@@ -223,39 +223,39 @@
     <value>Menyiapkan...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Penginstalan {0} diblokir oleh kebijakan Windows Package Manager. Jika Anda menggunakan perangkat terkelola, hubungi admin IT Anda.</value>
+    <value>Penginstalan {0} diblokir oleh kebijakan Windows Package Manager. Jika Anda menggunakan perangkat terkelola, hubungi admin IT Anda.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Tidak dapat menginstal {0} (kode kesalahan {1}). Lihat log untuk detail, atau instal {0} secara manual.</value>
+    <value>Tidak dapat menginstal {0} (kode kesalahan {1}). Lihat log untuk detail, atau instal {0} secara manual.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Tidak dapat menginstal {0}. Lihat log untuk detail, atau instal {0} secara manual.</value>
+    <value>Tidak dapat menginstal {0}. Lihat log untuk detail, atau instal {0} secara manual.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Penginstal {0} melaporkan kesalahan (kode {1}). Lihat log untuk detail, atau instal {0} secara manual.</value>
+    <value>Penginstal {0} melaporkan kesalahan (kode {1}). Lihat log untuk detail, atau instal {0} secara manual.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Tidak dapat menjangkau Windows Package Manager saat menginstal {0}. Periksa koneksi internet Anda (VPN, proxy, atau firewall mungkin memblokirnya) dan coba lagi.</value>
+    <value>Tidak dapat menjangkau Windows Package Manager saat menginstal {0}. Periksa koneksi internet Anda (VPN, proxy, atau firewall mungkin memblokirnya) dan coba lagi.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Tidak ada penginstal yang kompatibel untuk {0} yang tersedia di sistem ini (versi OS atau arsitektur mungkin tidak didukung). Instal {0} secara manual.</value>
+    <value>Tidak ada penginstal yang kompatibel untuk {0} yang tersedia di sistem ini (versi OS atau arsitektur mungkin tidak didukung). Instal {0} secara manual.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} tidak ditemukan di katalog Windows Package Manager. Coba refresh sumber winget, atau instal {0} secara manual.</value>
+    <value>{0} tidak ditemukan di katalog Windows Package Manager. Coba refresh sumber winget, atau instal {0} secara manual.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Menginstal {0} memakan waktu lebih dari 20 menit. Intelligent Terminal berhenti menunggu, tetapi penginstal mungkin masih berjalan di latar belakang. Periksa Task Manager, atau coba lagi nanti.</value>
+    <value>Menginstal {0} memakan waktu lebih dari 20 menit. Intelligent Terminal berhenti menunggu, tetapi penginstal mungkin masih berjalan di latar belakang. Periksa Task Manager, atau coba lagi nanti.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) tidak terinstal atau tidak tersedia. Instal terlebih dahulu, lalu coba lagi.</value>
+    <value>Windows Package Manager (winget) tidak terinstal atau tidak tersedia. Instal terlebih dahulu, lalu coba lagi.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -279,9 +279,9 @@
     <value>Izinkan Intelligent Terminal mengakses shell Anda dan mendeteksi kesalahan secara otomatis.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Gagal menginstal integrasi shell. Deteksi kesalahan telah dinonaktifkan. Anda dapat mengaktifkannya kembali dan mencoba lagi, atau simpan untuk melanjutkan tanpanya.</value>
+    <value>Gagal menginstal integrasi shell. Deteksi kesalahan telah dinonaktifkan. Anda dapat mengaktifkannya kembali dan mencoba lagi, atau simpan untuk melanjutkan tanpanya.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Gagal menginstal session hooks. Manajemen sesi telah dinonaktifkan. Anda dapat mengaktifkannya kembali dan mencoba lagi, atau simpan untuk melanjutkan tanpanya.</value>
+    <value>Gagal menginstal session hooks. Manajemen sesi telah dinonaktifkan. Anda dapat mengaktifkannya kembali dan mencoba lagi, atau simpan untuk melanjutkan tanpanya.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Pelajari cara memperbaikinya secara manual</value>
@@ -297,7 +297,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Kebijakan eksekusi PowerShell memblokir skrip. Deteksi kesalahan dinonaktifkan.</value>
+    <value>Kebijakan eksekusi PowerShell memblokir skrip. Deteksi kesalahan dinonaktifkan.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Penggunaan</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/is-IS/Resources.resw
@@ -223,39 +223,39 @@
     <value>Set upp...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Uppsetning á {0} var lokuð af stefnu Windows-pakkastjórans. Ef þú ert á stýrðu tæki skaltu hafa samband við upplýsingatæknistjórann þinn.</value>
+    <value>Uppsetning á {0} var lokuð af stefnu Windows-pakkastjórans. Ef þú ert á stýrðu tæki skaltu hafa samband við upplýsingatæknistjórann þinn.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Ekki tókst að setja upp {0} (villukóði {1}). Skoðaðu annálinn fyrir nánari upplýsingar eða settu {0} upp handvirkt.</value>
+    <value>Ekki tókst að setja upp {0} (villukóði {1}). Skoðaðu annálinn fyrir nánari upplýsingar eða settu {0} upp handvirkt.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Ekki tókst að setja upp {0}. Skoðaðu annálinn fyrir nánari upplýsingar eða settu {0} upp handvirkt.</value>
+    <value>Ekki tókst að setja upp {0}. Skoðaðu annálinn fyrir nánari upplýsingar eða settu {0} upp handvirkt.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Uppsetningarforritið fyrir {0} tilkynnti villu (kóði {1}). Skoðaðu annálinn fyrir nánari upplýsingar eða settu {0} upp handvirkt.</value>
+    <value>Uppsetningarforritið fyrir {0} tilkynnti villu (kóði {1}). Skoðaðu annálinn fyrir nánari upplýsingar eða settu {0} upp handvirkt.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Ekki náðist í Windows-pakkastjórann meðan {0} var sett upp. Athugaðu internettenginguna (VPN, proxy eða eldveggur gæti verið að loka á hana) og reyndu aftur.</value>
+    <value>Ekki náðist í Windows-pakkastjórann meðan {0} var sett upp. Athugaðu internettenginguna (VPN, proxy eða eldveggur gæti verið að loka á hana) og reyndu aftur.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Ekkert samhæft uppsetningarforrit fyrir {0} er tiltækt á þessu kerfi (útgáfa stýrikerfis eða örgjörvaarkitektúr er hugsanlega ekki studd). Settu {0} upp handvirkt.</value>
+    <value>Ekkert samhæft uppsetningarforrit fyrir {0} er tiltækt á þessu kerfi (útgáfa stýrikerfis eða örgjörvaarkitektúr er hugsanlega ekki studd). Settu {0} upp handvirkt.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} fannst ekki í vörulista Windows-pakkastjórans. Reyndu að endurnýja winget-upprunana eða settu {0} upp handvirkt.</value>
+    <value>{0} fannst ekki í vörulista Windows-pakkastjórans. Reyndu að endurnýja winget-upprunana eða settu {0} upp handvirkt.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Uppsetning á {0} tók meira en 20 mínútur. Intelligent Terminal hætti að bíða, en uppsetningarforritið gæti enn verið í gangi í bakgrunni. Athugaðu Task Manager eða reyndu aftur síðar.</value>
+    <value>Uppsetning á {0} tók meira en 20 mínútur. Intelligent Terminal hætti að bíða, en uppsetningarforritið gæti enn verið í gangi í bakgrunni. Athugaðu Task Manager eða reyndu aftur síðar.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows-pakkastjórinn (winget) er ekki uppsettur eða ekki tiltækur. Settu hann fyrst upp og reyndu svo aftur.</value>
+    <value>Windows-pakkastjórinn (winget) er ekki uppsettur eða ekki tiltækur. Settu hann fyrst upp og reyndu svo aftur.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -347,9 +347,9 @@
     <value>Veittu Intelligent Terminal heimild til að fá aðgang að skelinni þinni og greina villur sjálfkrafa.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Ekki tókst að setja upp skeljasamþættingu. Slökkt hefur verið á villuleit. Þú getur virkjað hana aftur og reynt aftur, eða vistað til að halda áfram án hennar.</value>
+    <value>Ekki tókst að setja upp skeljasamþættingu. Slökkt hefur verið á villuleit. Þú getur virkjað hana aftur og reynt aftur, eða vistað til að halda áfram án hennar.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Ekki tókst að setja upp session hooks. Slökkt hefur verið á lotustjórnun. Þú getur virkjað hana aftur og reynt aftur, eða vistað til að halda áfram án hennar.</value>
+    <value>Ekki tókst að setja upp session hooks. Slökkt hefur verið á lotustjórnun. Þú getur virkjað hana aftur og reynt aftur, eða vistað til að halda áfram án hennar.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Lærðu hvernig á að laga þetta handvirkt</value>
@@ -365,7 +365,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Keyrslustefna PowerShell hindrar forskriftir. Villuleit slökkt.</value>
+    <value>Keyrslustefna PowerShell hindrar forskriftir. Villuleit slökkt.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Notkun</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/it-IT/Resources.resw
@@ -1117,39 +1117,39 @@
     <value>Configurazione in corso...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ L'installazione di {0} è stata bloccata da un criterio di Gestione pacchetti Windows. Se usi un dispositivo gestito, contatta l'amministratore IT.</value>
+    <value>L'installazione di {0} è stata bloccata da un criterio di Gestione pacchetti Windows. Se usi un dispositivo gestito, contatta l'amministratore IT.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Impossibile installare {0} (codice errore {1}). Controlla il log per i dettagli oppure installa {0} manualmente.</value>
+    <value>Impossibile installare {0} (codice errore {1}). Controlla il log per i dettagli oppure installa {0} manualmente.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Impossibile installare {0}. Controlla il log per i dettagli oppure installa {0} manualmente.</value>
+    <value>Impossibile installare {0}. Controlla il log per i dettagli oppure installa {0} manualmente.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Il programma di installazione di {0} ha segnalato un errore (codice {1}). Controlla il log per i dettagli oppure installa {0} manualmente.</value>
+    <value>Il programma di installazione di {0} ha segnalato un errore (codice {1}). Controlla il log per i dettagli oppure installa {0} manualmente.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Impossibile raggiungere Gestione pacchetti Windows durante l'installazione di {0}. Controlla la connessione Internet (VPN, proxy o firewall potrebbero bloccarla) e riprova.</value>
+    <value>Impossibile raggiungere Gestione pacchetti Windows durante l'installazione di {0}. Controlla la connessione Internet (VPN, proxy o firewall potrebbero bloccarla) e riprova.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Non è disponibile un programma di installazione compatibile per {0} in questo sistema (la versione del sistema operativo o l'architettura potrebbe non essere supportata). Installa {0} manualmente.</value>
+    <value>Non è disponibile un programma di installazione compatibile per {0} in questo sistema (la versione del sistema operativo o l'architettura potrebbe non essere supportata). Installa {0} manualmente.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} non è stato trovato nel catalogo di Gestione pacchetti Windows. Prova ad aggiornare le origini di winget oppure installa {0} manualmente.</value>
+    <value>{0} non è stato trovato nel catalogo di Gestione pacchetti Windows. Prova ad aggiornare le origini di winget oppure installa {0} manualmente.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ L'installazione di {0} ha richiesto più di 20 minuti. Intelligent Terminal ha smesso di attendere, ma il programma di installazione potrebbe essere ancora in esecuzione in background. Controlla Task Manager oppure riprova più tardi.</value>
+    <value>L'installazione di {0} ha richiesto più di 20 minuti. Intelligent Terminal ha smesso di attendere, ma il programma di installazione potrebbe essere ancora in esecuzione in background. Controlla Task Manager oppure riprova più tardi.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Gestione pacchetti Windows (winget) non è installato o non è disponibile. Installalo prima, quindi riprova.</value>
+    <value>Gestione pacchetti Windows (winget) non è installato o non è disponibile. Installalo prima, quindi riprova.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1161,11 +1161,11 @@
     <comment>{Locked="Node.js","LTS"} Product display name substituted into the FreOverlay_InstallError_* templates when reporting a winget install failure for the Node.js prerequisite.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Installazione degli hooks di sessione non riuscita. La gestione delle sessioni è stata disattivata. È possibile riabilitarla e riprovare oppure salvare per continuare senza.</value>
+    <value>Installazione degli hooks di sessione non riuscita. La gestione delle sessioni è stata disattivata. È possibile riabilitarla e riprovare oppure salvare per continuare senza.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Installazione dell'integrazione della shell non riuscita. Il rilevamento degli errori è stato disattivato. È possibile riabilitarlo e riprovare oppure salvare per continuare senza.</value>
+    <value>Installazione dell'integrazione della shell non riuscita. Il rilevamento degli errori è stato disattivato. È possibile riabilitarlo e riprovare oppure salvare per continuare senza.</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Informazioni su come risolvere il problema manualmente</value>
@@ -1270,7 +1270,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Il criterio di esecuzione di PowerShell sta bloccando gli script. Rilevamento errori disattivato.</value>
+    <value>Il criterio di esecuzione di PowerShell sta bloccando gli script. Rilevamento errori disattivato.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Utilizzo</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ja-JP/Resources.resw
@@ -1126,39 +1126,39 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>セットアップ中...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ {0} のインストールは Windows パッケージ マネージャーのポリシーによってブロックされました。管理対象デバイスを使用している場合は、IT 管理者にお問い合わせください。</value>
+    <value>{0} のインストールは Windows パッケージ マネージャーのポリシーによってブロックされました。管理対象デバイスを使用している場合は、IT 管理者にお問い合わせください。</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} をインストールできませんでした (エラー コード {1})。詳細についてはログを確認するか、{0} を手動でインストールしてください。</value>
+    <value>{0} をインストールできませんでした (エラー コード {1})。詳細についてはログを確認するか、{0} を手動でインストールしてください。</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} をインストールできませんでした。詳細についてはログを確認するか、{0} を手動でインストールしてください。</value>
+    <value>{0} をインストールできませんでした。詳細についてはログを確認するか、{0} を手動でインストールしてください。</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} インストーラーからエラーが報告されました (コード {1})。詳細についてはログを確認するか、{0} を手動でインストールしてください。</value>
+    <value>{0} インストーラーからエラーが報告されました (コード {1})。詳細についてはログを確認するか、{0} を手動でインストールしてください。</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} のインストール中に Windows パッケージ マネージャーに接続できませんでした。インターネット接続 (VPN、プロキシ、ファイアウォールによってブロックされている可能性があります) を確認して、もう一度お試しください。</value>
+    <value>{0} のインストール中に Windows パッケージ マネージャーに接続できませんでした。インターネット接続 (VPN、プロキシ、ファイアウォールによってブロックされている可能性があります) を確認して、もう一度お試しください。</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ このシステムで使用できる {0} 用の互換性のあるインストーラーはありません (OS バージョンまたはアーキテクチャがサポートされていない可能性があります)。{0} を手動でインストールしてください。</value>
+    <value>このシステムで使用できる {0} 用の互換性のあるインストーラーはありません (OS バージョンまたはアーキテクチャがサポートされていない可能性があります)。{0} を手動でインストールしてください。</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows パッケージ マネージャー カタログに {0} が見つかりませんでした。winget ソースを更新するか、{0} を手動でインストールしてください。</value>
+    <value>Windows パッケージ マネージャー カタログに {0} が見つかりませんでした。winget ソースを更新するか、{0} を手動でインストールしてください。</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} のインストールに 20 分以上かかりました。Intelligent Terminal は待機を停止しましたが、インストーラーはまだバックグラウンドで実行されている可能性があります。Task Manager を確認するか、後でもう一度お試しください。</value>
+    <value>{0} のインストールに 20 分以上かかりました。Intelligent Terminal は待機を停止しましたが、インストーラーはまだバックグラウンドで実行されている可能性があります。Task Manager を確認するか、後でもう一度お試しください。</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows パッケージ マネージャー (winget) がインストールされていないか、利用できません。先にインストールしてから、もう一度お試しください。</value>
+    <value>Windows パッケージ マネージャー (winget) がインストールされていないか、利用できません。先にインストールしてから、もう一度お試しください。</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1170,11 +1170,11 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>{Locked="Node.js","LTS"} Product display name substituted into the FRE install error templates when reporting a winget install failure for the Node.js prerequisite.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooksのインストールに失敗しました。セッション管理がオフになりました。再度有効にしてやり直すか、保存してセッション管理なしで続行できます。</value>
+    <value>session hooksのインストールに失敗しました。セッション管理がオフになりました。再度有効にしてやり直すか、保存してセッション管理なしで続行できます。</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ シェル統合のインストールに失敗しました。エラー検出がオフになりました。再度有効にしてやり直すか、保存してエラー検出なしで続行できます。</value>
+    <value>シェル統合のインストールに失敗しました。エラー検出がオフになりました。再度有効にしてやり直すか、保存してエラー検出なしで続行できます。</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>手動で修正する方法について</value>
@@ -1279,7 +1279,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell の実行ポリシーがスクリプトをブロックしています。エラー検出はオフになりました。</value>
+    <value>PowerShell の実行ポリシーがスクリプトをブロックしています。エラー検出はオフになりました。</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>使用量</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ka-GE/Resources.resw
@@ -110,39 +110,39 @@
     <value>კონფიგურაცია...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ {0}-ის ინსტალაცია Windows-ის პაკეტების მენეჯერის პოლიტიკამ დაბლოკა. თუ მართული მოწყობილობა გაქვთ, დაუკავშირდით IT ადმინისტრატორს.</value>
+    <value>{0}-ის ინსტალაცია Windows-ის პაკეტების მენეჯერის პოლიტიკამ დაბლოკა. თუ მართული მოწყობილობა გაქვთ, დაუკავშირდით IT ადმინისტრატორს.</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0}-ის ინსტალაცია ვერ მოხერხდა (შეცდომის კოდი {1}). დეტალებისთვის იხილეთ ჟურნალი, ან დააინსტალირეთ {0} ხელით.</value>
+    <value>{0}-ის ინსტალაცია ვერ მოხერხდა (შეცდომის კოდი {1}). დეტალებისთვის იხილეთ ჟურნალი, ან დააინსტალირეთ {0} ხელით.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0}-ის ინსტალაცია ვერ მოხერხდა. დეტალებისთვის იხილეთ ჟურნალი, ან დააინსტალირეთ {0} ხელით.</value>
+    <value>{0}-ის ინსტალაცია ვერ მოხერხდა. დეტალებისთვის იხილეთ ჟურნალი, ან დააინსტალირეთ {0} ხელით.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0}-ის ინსტალატორმა შეცდომა დააბრუნა (კოდი {1}). დეტალებისთვის შეამოწმეთ ჟურნალი, ან დააინსტალირეთ {0} ხელით.</value>
+    <value>{0}-ის ინსტალატორმა შეცდომა დააბრუნა (კოდი {1}). დეტალებისთვის შეამოწმეთ ჟურნალი, ან დააინსტალირეთ {0} ხელით.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0}-ის ინსტალაციისას Windows-ის პაკეტების მენეჯერთან დაკავშირება ვერ მოხერხდა. შეამოწმეთ ინტერნეტკავშირი (VPN-მა, პროქსიმ ან ბრანდმაუერმა შეიძლება დაბლოკოს) და სცადეთ თავიდან.</value>
+    <value>{0}-ის ინსტალაციისას Windows-ის პაკეტების მენეჯერთან დაკავშირება ვერ მოხერხდა. შეამოწმეთ ინტერნეტკავშირი (VPN-მა, პროქსიმ ან ბრანდმაუერმა შეიძლება დაბლოკოს) და სცადეთ თავიდან.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ ამ სისტემაზე {0}-ისთვის თავსებადი ინსტალატორი ხელმისაწვდომი არ არის (შეიძლება OS-ის ვერსია ან არქიტექტურა არ იყოს მხარდაჭერილი). დააინსტალირეთ {0} ხელით.</value>
+    <value>ამ სისტემაზე {0}-ისთვის თავსებადი ინსტალატორი ხელმისაწვდომი არ არის (შეიძლება OS-ის ვერსია ან არქიტექტურა არ იყოს მხარდაჭერილი). დააინსტალირეთ {0} ხელით.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} Windows-ის პაკეტების მენეჯერის კატალოგში ვერ მოიძებნა. სცადეთ winget წყაროების განახლება, ან დააინსტალირეთ {0} ხელით.</value>
+    <value>{0} Windows-ის პაკეტების მენეჯერის კატალოგში ვერ მოიძებნა. სცადეთ winget წყაროების განახლება, ან დააინსტალირეთ {0} ხელით.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0}-ის ინსტალაციას 20 წუთზე მეტი დასჭირდა. Intelligent Terminal-მა ლოდინი შეწყვიტა, მაგრამ ინსტალატორი შეიძლება კვლავ ფონში მუშაობდეს. შეამოწმეთ Task Manager, ან სცადეთ მოგვიანებით.</value>
+    <value>{0}-ის ინსტალაციას 20 წუთზე მეტი დასჭირდა. Intelligent Terminal-მა ლოდინი შეწყვიტა, მაგრამ ინსტალატორი შეიძლება კვლავ ფონში მუშაობდეს. შეამოწმეთ Task Manager, ან სცადეთ მოგვიანებით.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows-ის პაკეტების მენეჯერი (winget) არ არის დაინსტალირებული ან ხელმისაწვდომი. ჯერ დააინსტალირეთ, შემდეგ სცადეთ თავიდან.</value>
+    <value>Windows-ის პაკეტების მენეჯერი (winget) არ არის დაინსტალირებული ან ხელმისაწვდომი. ჯერ დააინსტალირეთ, შემდეგ სცადეთ თავიდან.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -234,9 +234,9 @@
     <value>მიეცით Intelligent Terminal-ს უფლება, წვდომა ჰქონდეს თქვენს გარსზე და ავტომატურად აღმოაჩინოს შეცდომები.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ გარსის ინტეგრაციის ინსტალაცია ვერ მოხერხდა. შეცდომების აღმოჩენა გამორთულია. შეგიძლიათ ხელახლა ჩართოთ და სცადოთ თავიდან, ან შეინახოთ მის გარეშე გასაგრძელებლად.</value>
+    <value>გარსის ინტეგრაციის ინსტალაცია ვერ მოხერხდა. შეცდომების აღმოჩენა გამორთულია. შეგიძლიათ ხელახლა ჩართოთ და სცადოთ თავიდან, ან შეინახოთ მის გარეშე გასაგრძელებლად.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks ინსტალაცია ვერ მოხერხდა. სესიების მართვა გამორთულია. შეგიძლიათ ხელახლა ჩართოთ და სცადოთ თავიდან, ან შეინახოთ მის გარეშე გასაგრძელებლად.</value>
+    <value>session hooks ინსტალაცია ვერ მოხერხდა. სესიების მართვა გამორთულია. შეგიძლიათ ხელახლა ჩართოთ და სცადოთ თავიდან, ან შეინახოთ მის გარეშე გასაგრძელებლად.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>შეიტყვეთ, როგორ გამოასწოროთ ეს ხელით</value>
@@ -252,7 +252,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell-ის შესრულების პოლიტიკა ბლოკავს სკრიპტებს. შეცდომების აღმოჩენა გამორთულია.</value>
+    <value>PowerShell-ის შესრულების პოლიტიკა ბლოკავს სკრიპტებს. შეცდომების აღმოჩენა გამორთულია.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>გამოყენება</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kk-KZ/Resources.resw
@@ -223,39 +223,39 @@
     <value>Орнатылуда...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ {0} орнатуын Windows Package Manager саясаты бұғаттады. Егер басқарылатын құрылғыда болсаңыз, IT әкімшісіне хабарласыңыз.</value>
+    <value>{0} орнатуын Windows Package Manager саясаты бұғаттады. Егер басқарылатын құрылғыда болсаңыз, IT әкімшісіне хабарласыңыз.</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} орнату мүмкін болмады (қате коды {1}). Мәліметтер үшін журналды қараңыз немесе {0} қолданбасын қолмен орнатыңыз.</value>
+    <value>{0} орнату мүмкін болмады (қате коды {1}). Мәліметтер үшін журналды қараңыз немесе {0} қолданбасын қолмен орнатыңыз.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} орнату мүмкін болмады. Мәліметтер үшін журналды қараңыз немесе {0} қолданбасын қолмен орнатыңыз.</value>
+    <value>{0} орнату мүмкін болмады. Мәліметтер үшін журналды қараңыз немесе {0} қолданбасын қолмен орнатыңыз.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} орнатқышы қате туралы хабарлады (код {1}). Мәліметтер үшін журналды тексеріңіз немесе {0} қолданбасын қолмен орнатыңыз.</value>
+    <value>{0} орнатқышы қате туралы хабарлады (код {1}). Мәліметтер үшін журналды тексеріңіз немесе {0} қолданбасын қолмен орнатыңыз.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} орнату кезінде Windows Package Manager қызметіне қол жеткізу мүмкін болмады. Интернет қосылымыңызды тексеріңіз (VPN, прокси немесе брандмауэр оны бұғаттауы мүмкін) және қайталап көріңіз.</value>
+    <value>{0} орнату кезінде Windows Package Manager қызметіне қол жеткізу мүмкін болмады. Интернет қосылымыңызды тексеріңіз (VPN, прокси немесе брандмауэр оны бұғаттауы мүмкін) және қайталап көріңіз.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Бұл жүйеде {0} үшін үйлесімді орнатқыш жоқ (ОЖ нұсқасына немесе архитектураға қолдау көрсетілмеуі мүмкін). {0} қолданбасын қолмен орнатыңыз.</value>
+    <value>Бұл жүйеде {0} үшін үйлесімді орнатқыш жоқ (ОЖ нұсқасына немесе архитектураға қолдау көрсетілмеуі мүмкін). {0} қолданбасын қолмен орнатыңыз.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} Windows Package Manager каталогынан табылмады. winget көздерін жаңартып көріңіз немесе {0} қолданбасын қолмен орнатыңыз.</value>
+    <value>{0} Windows Package Manager каталогынан табылмады. winget көздерін жаңартып көріңіз немесе {0} қолданбасын қолмен орнатыңыз.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} орнату 20 минуттан ұзаққа созылды. Intelligent Terminal күтуді тоқтатты, бірақ орнатқыш әлі де фонда жұмыс істеп тұруы мүмкін. Task Manager құралын тексеріңіз немесе кейінірек қайталап көріңіз.</value>
+    <value>{0} орнату 20 минуттан ұзаққа созылды. Intelligent Terminal күтуді тоқтатты, бірақ орнатқыш әлі де фонда жұмыс істеп тұруы мүмкін. Task Manager құралын тексеріңіз немесе кейінірек қайталап көріңіз.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) орнатылмаған немесе қолжетімді емес. Алдымен оны орнатып, содан кейін қайталап көріңіз.</value>
+    <value>Windows Package Manager (winget) орнатылмаған немесе қолжетімді емес. Алдымен оны орнатып, содан кейін қайталап көріңіз.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -347,9 +347,9 @@
     <value>Intelligent Terminal қолданбасына қабықшаңызға кіруге және қателерді автоматты түрде анықтауға рұқсат беріңіз.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Shell біріктіруін орнату сәтсіз аяқталды. Қателерді анықтау өшірілді. Оны қайта қосып, қайталап көруіңізге немесе онсыз жалғастыру үшін сақтауыңызға болады.</value>
+    <value>Shell біріктіруін орнату сәтсіз аяқталды. Қателерді анықтау өшірілді. Оны қайта қосып, қайталап көруіңізге немесе онсыз жалғастыру үшін сақтауыңызға болады.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Session hooks орнату сәтсіз аяқталды. Сеанстарды басқару өшірілді. Оны қайта қосып, қайталап көруіңізге немесе онсыз жалғастыру үшін сақтауыңызға болады.</value>
+    <value>Session hooks орнату сәтсіз аяқталды. Сеанстарды басқару өшірілді. Оны қайта қосып, қайталап көруіңізге немесе онсыз жалғастыру үшін сақтауыңызға болады.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Мұны қолмен қалай түзетуге болатынын біліңіз</value>
@@ -365,7 +365,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell орындау саясаты сценарийлерді бұғаттайды. Қателерді анықтау өшірілді.</value>
+    <value>PowerShell орындау саясаты сценарийлерді бұғаттайды. Қателерді анықтау өшірілді.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Пайдалану</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/km-KH/Resources.resw
@@ -110,39 +110,39 @@
     <value>កំពុងដំឡើង...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ ការដំឡើង {0} ត្រូវបានរារាំងដោយគោលការណ៍ Windows Package Manager។ ប្រសិនបើអ្នកកំពុងប្រើឧបករណ៍ដែលគ្រប់គ្រង សូមទាក់ទងអ្នកគ្រប់គ្រង IT របស់អ្នក។</value>
+    <value>ការដំឡើង {0} ត្រូវបានរារាំងដោយគោលការណ៍ Windows Package Manager។ ប្រសិនបើអ្នកកំពុងប្រើឧបករណ៍ដែលគ្រប់គ្រង សូមទាក់ទងអ្នកគ្រប់គ្រង IT របស់អ្នក។</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ មិនអាចដំឡើង {0} បានទេ (កូដកំហុស {1})។ មើលកំណត់ហេតុសម្រាប់ព័ត៌មានលម្អិត ឬដំឡើង {0} ដោយដៃ។</value>
+    <value>មិនអាចដំឡើង {0} បានទេ (កូដកំហុស {1})។ មើលកំណត់ហេតុសម្រាប់ព័ត៌មានលម្អិត ឬដំឡើង {0} ដោយដៃ។</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ មិនអាចដំឡើង {0} បានទេ។ មើលកំណត់ហេតុសម្រាប់ព័ត៌មានលម្អិត ឬដំឡើង {0} ដោយដៃ។</value>
+    <value>មិនអាចដំឡើង {0} បានទេ។ មើលកំណត់ហេតុសម្រាប់ព័ត៌មានលម្អិត ឬដំឡើង {0} ដោយដៃ។</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ កម្មវិធីដំឡើង {0} បានរាយការណ៍កំហុស (កូដ {1})។ មើលកំណត់ហេតុសម្រាប់ព័ត៌មានលម្អិត ឬដំឡើង {0} ដោយដៃ។</value>
+    <value>កម្មវិធីដំឡើង {0} បានរាយការណ៍កំហុស (កូដ {1})។ មើលកំណត់ហេតុសម្រាប់ព័ត៌មានលម្អិត ឬដំឡើង {0} ដោយដៃ។</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ មិនអាចភ្ជាប់ទៅ Windows Package Manager ខណៈពេលដំឡើង {0} បានទេ។ ពិនិត្យការតភ្ជាប់អ៊ីនធឺណិតរបស់អ្នក (VPN, proxy ឬជញ្ជាំងភ្លើងអាចកំពុងរារាំងវា) ហើយសាកល្បងម្តងទៀត។</value>
+    <value>មិនអាចភ្ជាប់ទៅ Windows Package Manager ខណៈពេលដំឡើង {0} បានទេ។ ពិនិត្យការតភ្ជាប់អ៊ីនធឺណិតរបស់អ្នក (VPN, proxy ឬជញ្ជាំងភ្លើងអាចកំពុងរារាំងវា) ហើយសាកល្បងម្តងទៀត។</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ មិនមានកម្មវិធីដំឡើងដែលឆបគ្នាសម្រាប់ {0} នៅលើប្រព័ន្ធនេះទេ (អាចមិនគាំទ្រកំណែ OS ឬស្ថាបត្យកម្ម)។ ដំឡើង {0} ដោយដៃ។</value>
+    <value>មិនមានកម្មវិធីដំឡើងដែលឆបគ្នាសម្រាប់ {0} នៅលើប្រព័ន្ធនេះទេ (អាចមិនគាំទ្រកំណែ OS ឬស្ថាបត្យកម្ម)។ ដំឡើង {0} ដោយដៃ។</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ រកមិនឃើញ {0} នៅក្នុងកាតាឡុក Windows Package Manager ទេ។ សាកល្បងធ្វើឱ្យប្រភព winget ស្រស់ឡើងវិញ ឬដំឡើង {0} ដោយដៃ។</value>
+    <value>រកមិនឃើញ {0} នៅក្នុងកាតាឡុក Windows Package Manager ទេ។ សាកល្បងធ្វើឱ្យប្រភព winget ស្រស់ឡើងវិញ ឬដំឡើង {0} ដោយដៃ។</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ ការដំឡើង {0} ចំណាយពេលលើសពី 20 នាទី។ Intelligent Terminal បានឈប់រង់ចាំ ប៉ុន្តែកម្មវិធីដំឡើងអាចនៅតែដំណើរការនៅផ្ទៃខាងក្រោយ។ ពិនិត្យ Task Manager ឬសាកល្បងម្តងទៀតនៅពេលក្រោយ។</value>
+    <value>ការដំឡើង {0} ចំណាយពេលលើសពី 20 នាទី។ Intelligent Terminal បានឈប់រង់ចាំ ប៉ុន្តែកម្មវិធីដំឡើងអាចនៅតែដំណើរការនៅផ្ទៃខាងក្រោយ។ ពិនិត្យ Task Manager ឬសាកល្បងម្តងទៀតនៅពេលក្រោយ។</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) មិនទាន់បានដំឡើង ឬមិនអាចប្រើបានទេ។ ដំឡើងវាជាមុនសិន បន្ទាប់មកសាកល្បងម្ដងទៀត។</value>
+    <value>Windows Package Manager (winget) មិនទាន់បានដំឡើង ឬមិនអាចប្រើបានទេ។ ដំឡើងវាជាមុនសិន បន្ទាប់មកសាកល្បងម្ដងទៀត។</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -166,9 +166,9 @@
     <value>ផ្តល់សិទ្ធិឱ្យ Intelligent Terminal ចូលប្រើសែលរបស់អ្នក និងរកឃើញកំហុសដោយស្វ័យប្រវត្តិ។</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ បានបរាជ័យក្នុងការតំឡើងការរួមបញ្ចូល shell។ ការរកឃើញកំហុសត្រូវបានបិទ។ អ្នកអាចបើកវាឡើងវិញ ហើយសាកល្បងម្ដងទៀត ឬរក្សាទុកដើម្បីបន្តដោយគ្មានវា។</value>
+    <value>បានបរាជ័យក្នុងការតំឡើងការរួមបញ្ចូល shell។ ការរកឃើញកំហុសត្រូវបានបិទ។ អ្នកអាចបើកវាឡើងវិញ ហើយសាកល្បងម្ដងទៀត ឬរក្សាទុកដើម្បីបន្តដោយគ្មានវា។</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ បានបរាជ័យក្នុងការតំឡើង session hooks។ ការគ្រប់គ្រងវគ្គត្រូវបានបិទ។ អ្នកអាចបើកវាឡើងវិញ ហើយសាកល្បងម្ដងទៀត ឬរក្សាទុកដើម្បីបន្តដោយគ្មានវា។</value>
+    <value>បានបរាជ័យក្នុងការតំឡើង session hooks។ ការគ្រប់គ្រងវគ្គត្រូវបានបិទ។ អ្នកអាចបើកវាឡើងវិញ ហើយសាកល្បងម្ដងទៀត ឬរក្សាទុកដើម្បីបន្តដោយគ្មានវា។</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>ស្វែងយល់ពីរបៀបជួសជុលវាដោយដៃ</value>
@@ -184,7 +184,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ គោលនយោបាយប្រតិបត្តិរបស់ PowerShell កំពុងទប់ស្កាត់ស្គ្រីប។ ការរកឃើញកំហុសត្រូវបានបិទ។</value>
+    <value>គោលនយោបាយប្រតិបត្តិរបស់ PowerShell កំពុងទប់ស្កាត់ស្គ្រីប។ ការរកឃើញកំហុសត្រូវបានបិទ។</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>ការប្រើប្រាស់</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kn-IN/Resources.resw
@@ -223,50 +223,50 @@
     <value>ಹೊಂದಿಸಲಾಗುತ್ತಿದೆ...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager ನೀತಿಯಿಂದ {0} ಇನ್‌ಸ್ಟಾಲೇಶನ್ ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ. ನೀವು ನಿರ್ವಹಿತ ಸಾಧನದಲ್ಲಿದ್ದರೆ, ನಿಮ್ಮ IT ನಿರ್ವಾಹಕರನ್ನು ಸಂಪರ್ಕಿಸಿ.</value>
+    <value>Windows Package Manager ನೀತಿಯಿಂದ {0} ಇನ್‌ಸ್ಟಾಲೇಶನ್ ನಿರ್ಬಂಧಿಸಲಾಗಿದೆ. ನೀವು ನಿರ್ವಹಿತ ಸಾಧನದಲ್ಲಿದ್ದರೆ, ನಿಮ್ಮ IT ನಿರ್ವಾಹಕರನ್ನು ಸಂಪರ್ಕಿಸಿ.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲಾಗಲಿಲ್ಲ (ದೋಷ ಕೋಡ್ {1}). ವಿವರಗಳಿಗಾಗಿ ಲಾಗ್ ನೋಡಿ, ಅಥವಾ {0} ಅನ್ನು ಕೈಯಾರೆ ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ.</value>
+    <value>{0} ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲಾಗಲಿಲ್ಲ (ದೋಷ ಕೋಡ್ {1}). ವಿವರಗಳಿಗಾಗಿ ಲಾಗ್ ನೋಡಿ, ಅಥವಾ {0} ಅನ್ನು ಕೈಯಾರೆ ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲಾಗಲಿಲ್ಲ. ವಿವರಗಳಿಗಾಗಿ ಲಾಗ್ ನೋಡಿ, ಅಥವಾ {0} ಅನ್ನು ಕೈಯಾರೆ ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ.</value>
+    <value>{0} ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲಾಗಲಿಲ್ಲ. ವಿವರಗಳಿಗಾಗಿ ಲಾಗ್ ನೋಡಿ, ಅಥವಾ {0} ಅನ್ನು ಕೈಯಾರೆ ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ.</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} ಇನ್‌ಸ್ಟಾಲರ್ ದೋಷವನ್ನು ವರದಿ ಮಾಡಿದೆ (ಕೋಡ್ {1}). ವಿವರಗಳಿಗಾಗಿ ಲಾಗ್ ಪರಿಶೀಲಿಸಿ, ಅಥವಾ {0} ಅನ್ನು ಕೈಯಾರೆ ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ.</value>
+    <value>{0} ಇನ್‌ಸ್ಟಾಲರ್ ದೋಷವನ್ನು ವರದಿ ಮಾಡಿದೆ (ಕೋಡ್ {1}). ವಿವರಗಳಿಗಾಗಿ ಲಾಗ್ ಪರಿಶೀಲಿಸಿ, ಅಥವಾ {0} ಅನ್ನು ಕೈಯಾರೆ ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡುವಾಗ Windows Package Manager ಅನ್ನು ತಲುಪಲಾಗಲಿಲ್ಲ. ನಿಮ್ಮ ಇಂಟರ್ನೆಟ್ ಸಂಪರ್ಕವನ್ನು ಪರಿಶೀಲಿಸಿ (VPN, proxy, ಅಥವಾ firewall ಅದನ್ನು ನಿರ್ಬಂಧಿಸುತ್ತಿರಬಹುದು) ಮತ್ತು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</value>
+    <value>{0} ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡುವಾಗ Windows Package Manager ಅನ್ನು ತಲುಪಲಾಗಲಿಲ್ಲ. ನಿಮ್ಮ ಇಂಟರ್ನೆಟ್ ಸಂಪರ್ಕವನ್ನು ಪರಿಶೀಲಿಸಿ (VPN, proxy, ಅಥವಾ firewall ಅದನ್ನು ನಿರ್ಬಂಧಿಸುತ್ತಿರಬಹುದು) ಮತ್ತು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ ಈ ಸಿಸ್ಟಮ್‌ನಲ್ಲಿ {0} ಗಾಗಿ ಹೊಂದಾಣಿಕೆಯ ಇನ್‌ಸ್ಟಾಲರ್ ಲಭ್ಯವಿಲ್ಲ (OS ಆವೃತ್ತಿ ಅಥವಾ ಆರ್ಕಿಟೆಕ್ಚರ್ ಬೆಂಬಲಿತವಾಗಿರದಿರಬಹುದು). {0} ಅನ್ನು ಕೈಯಾರೆ ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ.</value>
+    <value>ಈ ಸಿಸ್ಟಮ್‌ನಲ್ಲಿ {0} ಗಾಗಿ ಹೊಂದಾಣಿಕೆಯ ಇನ್‌ಸ್ಟಾಲರ್ ಲಭ್ಯವಿಲ್ಲ (OS ಆವೃತ್ತಿ ಅಥವಾ ಆರ್ಕಿಟೆಕ್ಚರ್ ಬೆಂಬಲಿತವಾಗಿರದಿರಬಹುದು). {0} ಅನ್ನು ಕೈಯಾರೆ ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager ಕ್ಯಾಟಲಾಗ್‌ನಲ್ಲಿ {0} ಕಂಡುಬಂದಿಲ್ಲ. winget ಮೂಲಗಳನ್ನು ರಿಫ್ರೆಶ್ ಮಾಡಲು ಪ್ರಯತ್ನಿಸಿ, ಅಥವಾ {0} ಅನ್ನು ಕೈಯಾರೆ ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ.</value>
+    <value>Windows Package Manager ಕ್ಯಾಟಲಾಗ್‌ನಲ್ಲಿ {0} ಕಂಡುಬಂದಿಲ್ಲ. winget ಮೂಲಗಳನ್ನು ರಿಫ್ರೆಶ್ ಮಾಡಲು ಪ್ರಯತ್ನಿಸಿ, ಅಥವಾ {0} ಅನ್ನು ಕೈಯಾರೆ ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲು 20 ನಿಮಿಷಗಳಿಗಿಂತ ಹೆಚ್ಚು ಸಮಯ ತೆಗೆದುಕೊಂಡಿತು. Intelligent Terminal ಕಾಯುವುದನ್ನು ನಿಲ್ಲಿಸಿದೆ, ಆದರೆ ಇನ್‌ಸ್ಟಾಲರ್ ಇನ್ನೂ ಹಿನ್ನೆಲೆಯಲ್ಲಿರಬಹುದು. Task Manager ಪರಿಶೀಲಿಸಿ, ಅಥವಾ ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</value>
+    <value>{0} ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲು 20 ನಿಮಿಷಗಳಿಗಿಂತ ಹೆಚ್ಚು ಸಮಯ ತೆಗೆದುಕೊಂಡಿತು. Intelligent Terminal ಕಾಯುವುದನ್ನು ನಿಲ್ಲಿಸಿದೆ, ಆದರೆ ಇನ್‌ಸ್ಟಾಲರ್ ಇನ್ನೂ ಹಿನ್ನೆಲೆಯಲ್ಲಿರಬಹುದು. Task Manager ಪರಿಶೀಲಿಸಿ, ಅಥವಾ ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ. ಸೆಶನ್ ನಿರ್ವಹಣೆಯನ್ನು ಆಫ್ ಮಾಡಲಾಗಿದೆ. ನೀವು ಅದನ್ನು ಮರು-ಸಕ್ರಿಯಗೊಳಿಸಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಬಹುದು, ಅಥವಾ ಅದಿಲ್ಲದೆ ಮುಂದುವರಿಸಲು ಉಳಿಸಿ.</value>
+    <value>session hooks ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ. ಸೆಶನ್ ನಿರ್ವಹಣೆಯನ್ನು ಆಫ್ ಮಾಡಲಾಗಿದೆ. ನೀವು ಅದನ್ನು ಮರು-ಸಕ್ರಿಯಗೊಳಿಸಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಬಹುದು, ಅಥವಾ ಅದಿಲ್ಲದೆ ಮುಂದುವರಿಸಲು ಉಳಿಸಿ.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ ಶೆಲ್ ಏಕೀಕರಣವನ್ನು ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ. ದೋಷ ಪತ್ತೆಯನ್ನು ಆಫ್ ಮಾಡಲಾಗಿದೆ. ನೀವು ಅದನ್ನು ಮರು-ಸಕ್ರಿಯಗೊಳಿಸಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಬಹುದು, ಅಥವಾ ಅದಿಲ್ಲದೆ ಮುಂದುವರಿಸಲು ಉಳಿಸಿ.</value>
+    <value>ಶೆಲ್ ಏಕೀಕರಣವನ್ನು ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಲು ವಿಫಲವಾಗಿದೆ. ದೋಷ ಪತ್ತೆಯನ್ನು ಆಫ್ ಮಾಡಲಾಗಿದೆ. ನೀವು ಅದನ್ನು ಮರು-ಸಕ್ರಿಯಗೊಳಿಸಿ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಬಹುದು, ಅಥವಾ ಅದಿಲ್ಲದೆ ಮುಂದುವರಿಸಲು ಉಳಿಸಿ.</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell ಎಕ್ಸಿಕ್ಯೂಷನ್ ನೀತಿಯು ಸ್ಕ್ರಿಪ್ಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸುತ್ತಿದೆ. ದೋಷ ಪತ್ತೆ ಆಫ್ ಮಾಡಲಾಗಿದೆ.</value>
+    <value>PowerShell ಎಕ್ಸಿಕ್ಯೂಷನ್ ನೀತಿಯು ಸ್ಕ್ರಿಪ್ಟ್‌ಗಳನ್ನು ನಿರ್ಬಂಧಿಸುತ್ತಿದೆ. ದೋಷ ಪತ್ತೆ ಆಫ್ ಮಾಡಲಾಗಿದೆ.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) ಇನ್‌ಸ್ಟಾಲ್ ಆಗಿಲ್ಲ ಅಥವಾ ಲಭ್ಯವಿಲ್ಲ. ಮೊದಲು ಅದನ್ನು ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ, ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</value>
+    <value>Windows Package Manager (winget) ಇನ್‌ಸ್ಟಾಲ್ ಆಗಿಲ್ಲ ಅಥವಾ ಲಭ್ಯವಿಲ್ಲ. ಮೊದಲು ಅದನ್ನು ಇನ್‌ಸ್ಟಾಲ್ ಮಾಡಿ, ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ko-KR/Resources.resw
@@ -1153,39 +1153,39 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>설정 중...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows 패키지 관리자 정책에 의해 {0} 설치가 차단되었습니다. 관리되는 디바이스를 사용 중인 경우 IT 관리자에게 문의하세요.</value>
+    <value>Windows 패키지 관리자 정책에 의해 {0} 설치가 차단되었습니다. 관리되는 디바이스를 사용 중인 경우 IT 관리자에게 문의하세요.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0}을(를) 설치할 수 없습니다(오류 코드 {1}). 자세한 내용은 로그를 확인하거나 {0}을(를) 수동으로 설치하세요.</value>
+    <value>{0}을(를) 설치할 수 없습니다(오류 코드 {1}). 자세한 내용은 로그를 확인하거나 {0}을(를) 수동으로 설치하세요.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0}을(를) 설치할 수 없습니다. 자세한 내용은 로그를 확인하거나 {0}을(를) 수동으로 설치하세요.</value>
+    <value>{0}을(를) 설치할 수 없습니다. 자세한 내용은 로그를 확인하거나 {0}을(를) 수동으로 설치하세요.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} 설치 관리자가 오류를 보고했습니다(코드 {1}). 자세한 내용은 로그를 확인하거나 {0}을(를) 수동으로 설치하세요.</value>
+    <value>{0} 설치 관리자가 오류를 보고했습니다(코드 {1}). 자세한 내용은 로그를 확인하거나 {0}을(를) 수동으로 설치하세요.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0}을(를) 설치하는 동안 Windows 패키지 관리자에 연결할 수 없습니다. 인터넷 연결(VPN, 프록시 또는 방화벽이 차단하고 있을 수 있음)을 확인하고 다시 시도하세요.</value>
+    <value>{0}을(를) 설치하는 동안 Windows 패키지 관리자에 연결할 수 없습니다. 인터넷 연결(VPN, 프록시 또는 방화벽이 차단하고 있을 수 있음)을 확인하고 다시 시도하세요.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ 이 시스템에서 {0}에 사용할 수 있는 호환 설치 관리자가 없습니다(OS 버전 또는 아키텍처가 지원되지 않을 수 있음). {0}을(를) 수동으로 설치하세요.</value>
+    <value>이 시스템에서 {0}에 사용할 수 있는 호환 설치 관리자가 없습니다(OS 버전 또는 아키텍처가 지원되지 않을 수 있음). {0}을(를) 수동으로 설치하세요.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows 패키지 관리자 카탈로그에서 {0}을(를) 찾을 수 없습니다. winget 원본을 새로 고치거나 {0}을(를) 수동으로 설치하세요.</value>
+    <value>Windows 패키지 관리자 카탈로그에서 {0}을(를) 찾을 수 없습니다. winget 원본을 새로 고치거나 {0}을(를) 수동으로 설치하세요.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} 설치에 20분 넘게 걸렸습니다. Intelligent Terminal은 대기를 중지했지만 설치 관리자가 여전히 백그라운드에서 실행 중일 수 있습니다. Task Manager를 확인하거나 나중에 다시 시도하세요.</value>
+    <value>{0} 설치에 20분 넘게 걸렸습니다. Intelligent Terminal은 대기를 중지했지만 설치 관리자가 여전히 백그라운드에서 실행 중일 수 있습니다. Task Manager를 확인하거나 나중에 다시 시도하세요.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows 패키지 관리자(winget)가 설치되어 있지 않거나 사용할 수 없습니다. 먼저 설치한 다음 다시 시도하세요.</value>
+    <value>Windows 패키지 관리자(winget)가 설치되어 있지 않거나 사용할 수 없습니다. 먼저 설치한 다음 다시 시도하세요.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1197,11 +1197,11 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>{Locked="Node.js","LTS"} Product display name substituted into the FRE install error templates when reporting a winget install failure for the Node.js prerequisite.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks를 설치하지 못했습니다. 세션 관리가 꺼졌습니다. 다시 사용하도록 설정하고 다시 시도하거나, 저장하여 이 기능 없이 계속할 수 있습니다.</value>
+    <value>session hooks를 설치하지 못했습니다. 세션 관리가 꺼졌습니다. 다시 사용하도록 설정하고 다시 시도하거나, 저장하여 이 기능 없이 계속할 수 있습니다.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ 셸 통합을 설치하지 못했습니다. 오류 감지가 꺼졌습니다. 다시 사용하도록 설정하고 다시 시도하거나, 저장하여 이 기능 없이 계속할 수 있습니다.</value>
+    <value>셸 통합을 설치하지 못했습니다. 오류 감지가 꺼졌습니다. 다시 사용하도록 설정하고 다시 시도하거나, 저장하여 이 기능 없이 계속할 수 있습니다.</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>수동으로 해결하는 방법 알아보기</value>
@@ -1310,7 +1310,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell 실행 정책이 스크립트를 차단하고 있습니다. 오류 감지가 꺼졌습니다.</value>
+    <value>PowerShell 실행 정책이 스크립트를 차단하고 있습니다. 오류 감지가 꺼졌습니다.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>사용량</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/kok-IN/Resources.resw
@@ -224,50 +224,50 @@
     <value>सेट अप जाता...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager धोरणान {0} ची स्थापना आडायल्या. तुमी वेवस्थापित डिव्हाइसाचेर आसल्यार, तुमच्या IT प्रशासकाक संपर्क करात.</value>
+    <value>Windows Package Manager धोरणान {0} ची स्थापना आडायल्या. तुमी वेवस्थापित डिव्हाइसाचेर आसल्यार, तुमच्या IT प्रशासकाक संपर्क करात.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} इन्स्टॉल करपाक जमलें ना (चूक कोड {1}). तपशीलां खातीर लॉग पळयात, वा {0} मॅन्युअली इन्स्टॉल करात.</value>
+    <value>{0} इन्स्टॉल करपाक जमलें ना (चूक कोड {1}). तपशीलां खातीर लॉग पळयात, वा {0} मॅन्युअली इन्स्टॉल करात.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} इन्स्टॉल करपाक जमलें ना. तपशीलां खातीर लॉग पळयात, वा {0} मॅन्युअली इन्स्टॉल करात.</value>
+    <value>{0} इन्स्टॉल करपाक जमलें ना. तपशीलां खातीर लॉग पळयात, वा {0} मॅन्युअली इन्स्टॉल करात.</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} इन्स्टॉलरान चूक कळयल्या (कोड {1}). तपशीलां खातीर लॉग तपासात, वा {0} मॅन्युअली इन्स्टॉल करात.</value>
+    <value>{0} इन्स्टॉलरान चूक कळयल्या (कोड {1}). तपशीलां खातीर लॉग तपासात, वा {0} मॅन्युअली इन्स्टॉल करात.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} इन्स्टॉल करतना Windows Package Manager मेरेन पावपाक जमलें ना. तुमचें इंटरनेट कनेक्शन तपासात (VPN, proxy, वा firewall तें आडावपी आसूं येता) आनी परतून यत्न करात.</value>
+    <value>{0} इन्स्टॉल करतना Windows Package Manager मेरेन पावपाक जमलें ना. तुमचें इंटरनेट कनेक्शन तपासात (VPN, proxy, वा firewall तें आडावपी आसूं येता) आनी परतून यत्न करात.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ ह्या सिस्टिमाचेर {0} खातीर कसोय सुसंगत इन्स्टॉलर उपलब्ध ना (OS आवृत्ती वा आर्किटेक्चर समर्थित आसूं न शकता). {0} मॅन्युअली इन्स्टॉल करात.</value>
+    <value>ह्या सिस्टिमाचेर {0} खातीर कसोय सुसंगत इन्स्टॉलर उपलब्ध ना (OS आवृत्ती वा आर्किटेक्चर समर्थित आसूं न शकता). {0} मॅन्युअली इन्स्टॉल करात.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager कॅटलॉगांत {0} मेळूंक ना. winget स्रोत रिफ्रेश करपाचो यत्न करात, वा {0} मॅन्युअली इन्स्टॉल करात.</value>
+    <value>Windows Package Manager कॅटलॉगांत {0} मेळूंक ना. winget स्रोत रिफ्रेश करपाचो यत्न करात, वा {0} मॅन्युअली इन्स्टॉल करात.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} इन्स्टॉल करपाक 20 मिनिटांपरस चड वेळ लागलो. Intelligent Terminal-ान वाट पळोवप बंद केलें, पूण इन्स्टॉलर अजूनय पाटभूंयेर चलू आसूं येता. Task Manager तपासात, वा उपरांत परतून यत्न करात.</value>
+    <value>{0} इन्स्टॉल करपाक 20 मिनिटांपरस चड वेळ लागलो. Intelligent Terminal-ान वाट पळोवप बंद केलें, पूण इन्स्टॉलर अजूनय पाटभूंयेर चलू आसूं येता. Task Manager तपासात, वा उपरांत परतून यत्न करात.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks इन्स्टॉल करपाक अपेशी. सत्र वेवस्थापन बंद केलां. तुमी तें परतून सक्षम करून परतून यत्न करूं येता, वा ताचे बगर फुडें वचपाक सांबाळात.</value>
+    <value>session hooks इन्स्टॉल करपाक अपेशी. सत्र वेवस्थापन बंद केलां. तुमी तें परतून सक्षम करून परतून यत्न करूं येता, वा ताचे बगर फुडें वचपाक सांबाळात.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ शेल एकीकरण इन्स्टॉल करपाक अपेशी. चूक सोद बंद केल्या. तुमी तें परतून सक्षम करून परतून यत्न करूं येता, वा ताचे बगर फुडें वचपाक सांबाळात.</value>
+    <value>शेल एकीकरण इन्स्टॉल करपाक अपेशी. चूक सोद बंद केल्या. तुमी तें परतून सक्षम करून परतून यत्न करूं येता, वा ताचे बगर फुडें वचपाक सांबाळात.</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell एक्झिक्यूशन धोरणान स्क्रिप्ट्स आडावपी आसा. चूक सोद बंद केल्या.</value>
+    <value>PowerShell एक्झिक्यूशन धोरणान स्क्रिप्ट्स आडावपी आसा. चूक सोद बंद केल्या.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) इन्स्टॉल केल्लो ना वा उपलब्ध ना. पयलीं तो इन्स्टॉल करात, मागीर परतून यत्न करात.</value>
+    <value>Windows Package Manager (winget) इन्स्टॉल केल्लो ना वा उपलब्ध ना. पयलीं तो इन्स्टॉल करात, मागीर परतून यत्न करात.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lb-LU/Resources.resw
@@ -110,39 +110,39 @@
     <value>Gëtt agestallt...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ D'Installatioun vu {0} gouf duerch eng Windows Package Manager-Politik blockéiert. Wann Dir op engem geréierte Gerät sidd, kontaktéiert Ären IT-Administrateur.</value>
+    <value>D'Installatioun vu {0} gouf duerch eng Windows Package Manager-Politik blockéiert. Wann Dir op engem geréierte Gerät sidd, kontaktéiert Ären IT-Administrateur.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} konnt net installéiert ginn (Feelercode {1}). Kuckt am Log fir Detailer, oder installéiert {0} manuell.</value>
+    <value>{0} konnt net installéiert ginn (Feelercode {1}). Kuckt am Log fir Detailer, oder installéiert {0} manuell.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} konnt net installéiert ginn. Kuckt am Log fir Detailer, oder installéiert {0} manuell.</value>
+    <value>{0} konnt net installéiert ginn. Kuckt am Log fir Detailer, oder installéiert {0} manuell.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Den Installateur vu {0} huet e Feeler gemellt (Code {1}). Kuckt am Log fir Detailer, oder installéiert {0} manuell.</value>
+    <value>Den Installateur vu {0} huet e Feeler gemellt (Code {1}). Kuckt am Log fir Detailer, oder installéiert {0} manuell.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ De Windows Package Manager konnt wärend der Installatioun vu {0} net erreecht ginn. Iwwerpréift Är Internetverbindung (VPN, Proxy oder Firewall kéint se blockéieren) a probéiert et nach eng Kéier.</value>
+    <value>De Windows Package Manager konnt wärend der Installatioun vu {0} net erreecht ginn. Iwwerpréift Är Internetverbindung (VPN, Proxy oder Firewall kéint se blockéieren) a probéiert et nach eng Kéier.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Kee kompatibelen Installateur fir {0} ass op dësem System verfügbar (d'Versioun vum Betribssystem oder d'Architektur gëtt eventuell net ënnerstëtzt). Installéiert {0} manuell.</value>
+    <value>Kee kompatibelen Installateur fir {0} ass op dësem System verfügbar (d'Versioun vum Betribssystem oder d'Architektur gëtt eventuell net ënnerstëtzt). Installéiert {0} manuell.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} gouf net am Katalog vum Windows Package Manager fonnt. Probéiert d'winget-Quellen ze aktualiséieren, oder installéiert {0} manuell.</value>
+    <value>{0} gouf net am Katalog vum Windows Package Manager fonnt. Probéiert d'winget-Quellen ze aktualiséieren, oder installéiert {0} manuell.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ D'Installatioun vu {0} huet méi laang wéi 20 Minutte gedauert. Intelligent Terminal huet opgehalen ze waarden, mee den Installateur leeft eventuell nach am Hannergrond. Kuckt am Task Manager, oder probéiert et méi spéit nach eng Kéier.</value>
+    <value>D'Installatioun vu {0} huet méi laang wéi 20 Minutte gedauert. Intelligent Terminal huet opgehalen ze waarden, mee den Installateur leeft eventuell nach am Hannergrond. Kuckt am Task Manager, oder probéiert et méi spéit nach eng Kéier.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ De Windows Package Manager (winget) ass net installéiert oder net verfügbar. Installéiert en als éischt a probéiert et dann nach eng Kéier.</value>
+    <value>De Windows Package Manager (winget) ass net installéiert oder net verfügbar. Installéiert en als éischt a probéiert et dann nach eng Kéier.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -234,9 +234,9 @@
     <value>Erlaabt Intelligent Terminal Zougrëff op Är Shell an d'Feeler automatesch z'erkennen.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ D'Shell-Integratioun konnt net installéiert ginn. D'Feelerkennung gouf ausgeschalt. Dir kënnt se nees aktivéieren a nach eng Kéier probéieren, oder späicheren fir ouni se weiderzefueren.</value>
+    <value>D'Shell-Integratioun konnt net installéiert ginn. D'Feelerkennung gouf ausgeschalt. Dir kënnt se nees aktivéieren a nach eng Kéier probéieren, oder späicheren fir ouni se weiderzefueren.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ D'Sessiouns-hooks konnten net installéiert ginn. D'Sessiounsgestioun gouf ausgeschalt. Dir kënnt se nees aktivéieren a nach eng Kéier probéieren, oder späicheren fir ouni se weiderzefueren.</value>
+    <value>D'Sessiouns-hooks konnten net installéiert ginn. D'Sessiounsgestioun gouf ausgeschalt. Dir kënnt se nees aktivéieren a nach eng Kéier probéieren, oder späicheren fir ouni se weiderzefueren.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Léiert wéi Dir dëst manuell behieft</value>
@@ -252,7 +252,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ D'PowerShell-Ausféierungspolitik blockéiert Scripten. D'Feelerkennung ass ausgeschalt.</value>
+    <value>D'PowerShell-Ausféierungspolitik blockéiert Scripten. D'Feelerkennung ass ausgeschalt.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Benotzung</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lo-LA/Resources.resw
@@ -110,39 +110,39 @@
     <value>ກຳລັງຕັ້ງຄ່າ...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ ການຕິດຕັ້ງ {0} ຖືກບລັອກໂດຍນະໂຍບາຍ Windows Package Manager. ຖ້າທ່ານໃຊ້ອຸປະກອນທີ່ຖືກຈັດການ, ຕິດຕໍ່ຜູ້ດູແລ IT ຂອງທ່ານ.</value>
+    <value>ການຕິດຕັ້ງ {0} ຖືກບລັອກໂດຍນະໂຍບາຍ Windows Package Manager. ຖ້າທ່ານໃຊ້ອຸປະກອນທີ່ຖືກຈັດການ, ຕິດຕໍ່ຜູ້ດູແລ IT ຂອງທ່ານ.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ ບໍ່ສາມາດຕິດຕັ້ງ {0} ໄດ້ (ລະຫັດຂໍ້ຜິດພາດ {1}). ເບິ່ງບັນທຶກສຳລັບລາຍລະອຽດ ຫຼືຕິດຕັ້ງ {0} ດ້ວຍຕົນເອງ.</value>
+    <value>ບໍ່ສາມາດຕິດຕັ້ງ {0} ໄດ້ (ລະຫັດຂໍ້ຜິດພາດ {1}). ເບິ່ງບັນທຶກສຳລັບລາຍລະອຽດ ຫຼືຕິດຕັ້ງ {0} ດ້ວຍຕົນເອງ.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ ບໍ່ສາມາດຕິດຕັ້ງ {0} ໄດ້. ເບິ່ງບັນທຶກສຳລັບລາຍລະອຽດ ຫຼືຕິດຕັ້ງ {0} ດ້ວຍຕົນເອງ.</value>
+    <value>ບໍ່ສາມາດຕິດຕັ້ງ {0} ໄດ້. ເບິ່ງບັນທຶກສຳລັບລາຍລະອຽດ ຫຼືຕິດຕັ້ງ {0} ດ້ວຍຕົນເອງ.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ ໂຕຕິດຕັ້ງ {0} ໄດ້ລາຍງານຂໍ້ຜິດພາດ (ລະຫັດ {1}). ເບິ່ງບັນທຶກສຳລັບລາຍລະອຽດ ຫຼືຕິດຕັ້ງ {0} ດ້ວຍຕົນເອງ.</value>
+    <value>ໂຕຕິດຕັ້ງ {0} ໄດ້ລາຍງານຂໍ້ຜິດພາດ (ລະຫັດ {1}). ເບິ່ງບັນທຶກສຳລັບລາຍລະອຽດ ຫຼືຕິດຕັ້ງ {0} ດ້ວຍຕົນເອງ.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ ບໍ່ສາມາດເຊື່ອມຕໍ່ Windows Package Manager ຂະນະຕິດຕັ້ງ {0}. ກວດເບິ່ງການເຊື່ອມຕໍ່ອິນເຕີເນັດຂອງທ່ານ (VPN, proxy ຫຼືໄຟວໍອາດຈະບລັອກຢູ່) ແລ້ວລອງໃໝ່.</value>
+    <value>ບໍ່ສາມາດເຊື່ອມຕໍ່ Windows Package Manager ຂະນະຕິດຕັ້ງ {0}. ກວດເບິ່ງການເຊື່ອມຕໍ່ອິນເຕີເນັດຂອງທ່ານ (VPN, proxy ຫຼືໄຟວໍອາດຈະບລັອກຢູ່) ແລ້ວລອງໃໝ່.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ ບໍ່ມີໂຕຕິດຕັ້ງທີ່ເຂົ້າກັນໄດ້ສຳລັບ {0} ໃນລະບົບນີ້ (ອາດບໍ່ຮອງຮັບລຸ້ນ OS ຫຼືສະຖາປັດຕະຍະກຳ). ຕິດຕັ້ງ {0} ດ້ວຍຕົນເອງ.</value>
+    <value>ບໍ່ມີໂຕຕິດຕັ້ງທີ່ເຂົ້າກັນໄດ້ສຳລັບ {0} ໃນລະບົບນີ້ (ອາດບໍ່ຮອງຮັບລຸ້ນ OS ຫຼືສະຖາປັດຕະຍະກຳ). ຕິດຕັ້ງ {0} ດ້ວຍຕົນເອງ.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ ບໍ່ພົບ {0} ໃນແຄັດຕາລັອກ Windows Package Manager. ລອງຣີເຟຣດແຫຼ່ງ winget ຫຼືຕິດຕັ້ງ {0} ດ້ວຍຕົນເອງ.</value>
+    <value>ບໍ່ພົບ {0} ໃນແຄັດຕາລັອກ Windows Package Manager. ລອງຣີເຟຣດແຫຼ່ງ winget ຫຼືຕິດຕັ້ງ {0} ດ້ວຍຕົນເອງ.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ ການຕິດຕັ້ງ {0} ໃຊ້ເວລາເກີນ 20 ນາທີ. Intelligent Terminal ຢຸດລໍຖ້າແລ້ວ, ແຕ່ໂຕຕິດຕັ້ງອາດຍັງເຮັດວຽກໃນພື້ນຫຼັງ. ກວດເບິ່ງ Task Manager ຫຼືລອງໃໝ່ພາຍຫຼັງ.</value>
+    <value>ການຕິດຕັ້ງ {0} ໃຊ້ເວລາເກີນ 20 ນາທີ. Intelligent Terminal ຢຸດລໍຖ້າແລ້ວ, ແຕ່ໂຕຕິດຕັ້ງອາດຍັງເຮັດວຽກໃນພື້ນຫຼັງ. ກວດເບິ່ງ Task Manager ຫຼືລອງໃໝ່ພາຍຫຼັງ.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) ຍັງບໍ່ໄດ້ຕິດຕັ້ງ ຫຼື ບໍ່ພ້ອມໃຊ້ງານ. ຕິດຕັ້ງມັນກ່ອນ ແລ້ວລອງໃໝ່.</value>
+    <value>Windows Package Manager (winget) ຍັງບໍ່ໄດ້ຕິດຕັ້ງ ຫຼື ບໍ່ພ້ອມໃຊ້ງານ. ຕິດຕັ້ງມັນກ່ອນ ແລ້ວລອງໃໝ່.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -166,9 +166,9 @@
     <value>ອະນຸຍາດໃຫ້ Intelligent Terminal ເຂົ້າເຖິງເຊລຂອງທ່ານ ແລະກວດຫາຂໍ້ຜິດພາດໂດຍອັດຕະໂນມັດ.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ ການຕິດຕັ້ງ shell integration ລົ້ມເຫລວ. ການກວດຫາຂໍ້ຜິດພາດໄດ້ຖືກປິດແລ້ວ. ທ່ານສາມາດເປີດໃຊ້ງານມັນອີກຄັ້ງແລະລອງໃຫມ່, ຫຼືບັນທຶກເພື່ອສືບຕໍ່ໂດຍບໍ່ມີມັນ.</value>
+    <value>ການຕິດຕັ້ງ shell integration ລົ້ມເຫລວ. ການກວດຫາຂໍ້ຜິດພາດໄດ້ຖືກປິດແລ້ວ. ທ່ານສາມາດເປີດໃຊ້ງານມັນອີກຄັ້ງແລະລອງໃຫມ່, ຫຼືບັນທຶກເພື່ອສືບຕໍ່ໂດຍບໍ່ມີມັນ.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ ການຕິດຕັ້ງ session hooks ລົ້ມເຫລວ. ການຈັດການ session ໄດ້ຖືກປິດແລ້ວ. ທ່ານສາມາດເປີດໃຊ້ງານມັນອີກຄັ້ງແລະລອງໃຫມ່, ຫຼືບັນທຶກເພື່ອສືບຕໍ່ໂດຍບໍ່ມີມັນ.</value>
+    <value>ການຕິດຕັ້ງ session hooks ລົ້ມເຫລວ. ການຈັດການ session ໄດ້ຖືກປິດແລ້ວ. ທ່ານສາມາດເປີດໃຊ້ງານມັນອີກຄັ້ງແລະລອງໃຫມ່, ຫຼືບັນທຶກເພື່ອສືບຕໍ່ໂດຍບໍ່ມີມັນ.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>ຮຽນຮູ້ວິທີແກ້ໄຂສິ່ງນີ້ດ້ວຍຕົນເອງ</value>
@@ -184,7 +184,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ ນະໂຍບາຍການດຳເນີນການຂອງ PowerShell ກໍາລັງບລັອກສະຄຣິບ. ການກວດຫາຂໍ້ຜິດພາດຖືກປິດແລ້ວ.</value>
+    <value>ນະໂຍບາຍການດຳເນີນການຂອງ PowerShell ກໍາລັງບລັອກສະຄຣິບ. ການກວດຫາຂໍ້ຜິດພາດຖືກປິດແລ້ວ.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>ການນຳໃຊ້</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lt-LT/Resources.resw
@@ -223,39 +223,39 @@
     <value>Nustatoma...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ „Windows“ paketų tvarkytuvo strategija užblokavo {0} diegimą. Jei naudojate valdomą įrenginį, kreipkitės į savo IT administratorių.</value>
+    <value>„Windows“ paketų tvarkytuvo strategija užblokavo {0} diegimą. Jei naudojate valdomą įrenginį, kreipkitės į savo IT administratorių.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Nepavyko įdiegti {0} (klaidos kodas {1}). Daugiau informacijos žr. žurnale arba įdiekite {0} rankiniu būdu.</value>
+    <value>Nepavyko įdiegti {0} (klaidos kodas {1}). Daugiau informacijos žr. žurnale arba įdiekite {0} rankiniu būdu.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Nepavyko įdiegti {0}. Daugiau informacijos žr. žurnale arba įdiekite {0} rankiniu būdu.</value>
+    <value>Nepavyko įdiegti {0}. Daugiau informacijos žr. žurnale arba įdiekite {0} rankiniu būdu.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} diegyklė pranešė apie klaidą (kodas {1}). Daugiau informacijos žr. žurnale arba įdiekite {0} rankiniu būdu.</value>
+    <value>{0} diegyklė pranešė apie klaidą (kodas {1}). Daugiau informacijos žr. žurnale arba įdiekite {0} rankiniu būdu.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Nepavyko pasiekti „Windows“ paketų tvarkytuvo diegiant {0}. Patikrinkite interneto ryšį (VPN, tarpinis serveris arba užkarda gali jį blokuoti) ir bandykite dar kartą.</value>
+    <value>Nepavyko pasiekti „Windows“ paketų tvarkytuvo diegiant {0}. Patikrinkite interneto ryšį (VPN, tarpinis serveris arba užkarda gali jį blokuoti) ir bandykite dar kartą.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Šioje sistemoje nėra suderinamos {0} diegyklės (OS versija arba architektūra gali būti nepalaikoma). Įdiekite {0} rankiniu būdu.</value>
+    <value>Šioje sistemoje nėra suderinamos {0} diegyklės (OS versija arba architektūra gali būti nepalaikoma). Įdiekite {0} rankiniu būdu.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} nerasta „Windows“ paketų tvarkytuvo kataloge. Pabandykite atnaujinti winget šaltinius arba įdiekite {0} rankiniu būdu.</value>
+    <value>{0} nerasta „Windows“ paketų tvarkytuvo kataloge. Pabandykite atnaujinti winget šaltinius arba įdiekite {0} rankiniu būdu.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Diegiant {0} užtrukta ilgiau nei 20 minučių. Intelligent Terminal nustojo laukti, bet diegyklė vis dar gali veikti fone. Patikrinkite Task Manager arba bandykite dar kartą vėliau.</value>
+    <value>Diegiant {0} užtrukta ilgiau nei 20 minučių. Intelligent Terminal nustojo laukti, bet diegyklė vis dar gali veikti fone. Patikrinkite Task Manager arba bandykite dar kartą vėliau.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ „Windows“ paketų tvarkytuvas (winget) neįdiegtas arba nepasiekiamas. Pirmiausia jį įdiekite, tada bandykite dar kartą.</value>
+    <value>„Windows“ paketų tvarkytuvas (winget) neįdiegtas arba nepasiekiamas. Pirmiausia jį įdiekite, tada bandykite dar kartą.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>Leiskite „Intelligent Terminal“ pasiekti jūsų apvalkalą ir automatiškai aptikti klaidas.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Nepavyko įdiegti apvalkalo integracijos. Klaidų aptikimas buvo išjungtas. Galite jį vėl įjungti ir bandyti dar kartą arba išsaugoti ir tęsti be jo.</value>
+    <value>Nepavyko įdiegti apvalkalo integracijos. Klaidų aptikimas buvo išjungtas. Galite jį vėl įjungti ir bandyti dar kartą arba išsaugoti ir tęsti be jo.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Nepavyko įdiegti session hooks. Sesijų valdymas buvo išjungtas. Galite jį vėl įjungti ir bandyti dar kartą arba išsaugoti ir tęsti be jo.</value>
+    <value>Nepavyko įdiegti session hooks. Sesijų valdymas buvo išjungtas. Galite jį vėl įjungti ir bandyti dar kartą arba išsaugoti ir tęsti be jo.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Sužinokite, kaip tai išspręsti rankiniu būdu</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ „PowerShell“ vykdymo strategija blokuoja scenarijus. Klaidų aptikimas išjungtas.</value>
+    <value>„PowerShell“ vykdymo strategija blokuoja scenarijus. Klaidų aptikimas išjungtas.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Naudojimas</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/lv-LV/Resources.resw
@@ -223,39 +223,39 @@
     <value>Iestata...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ {0} instalēšanu bloķēja Windows pakotņu pārvaldnieka politika. Ja izmantojat pārvaldītu ierīci, sazinieties ar savu IT administratoru.</value>
+    <value>{0} instalēšanu bloķēja Windows pakotņu pārvaldnieka politika. Ja izmantojat pārvaldītu ierīci, sazinieties ar savu IT administratoru.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Neizdevās instalēt {0} (kļūdas kods {1}). Skatiet žurnālu, lai iegūtu detalizētu informāciju, vai instalējiet {0} manuāli.</value>
+    <value>Neizdevās instalēt {0} (kļūdas kods {1}). Skatiet žurnālu, lai iegūtu detalizētu informāciju, vai instalējiet {0} manuāli.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Neizdevās instalēt {0}. Skatiet žurnālu, lai iegūtu detalizētu informāciju, vai instalējiet {0} manuāli.</value>
+    <value>Neizdevās instalēt {0}. Skatiet žurnālu, lai iegūtu detalizētu informāciju, vai instalējiet {0} manuāli.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} instalētājs ziņoja par kļūdu (kods {1}). Skatiet žurnālu, lai iegūtu detalizētu informāciju, vai instalējiet {0} manuāli.</value>
+    <value>{0} instalētājs ziņoja par kļūdu (kods {1}). Skatiet žurnālu, lai iegūtu detalizētu informāciju, vai instalējiet {0} manuāli.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Neizdevās sasniegt Windows pakotņu pārvaldnieku, instalējot {0}. Pārbaudiet interneta savienojumu (VPN, starpniekserveris vai ugunsmūris to var bloķēt) un mēģiniet vēlreiz.</value>
+    <value>Neizdevās sasniegt Windows pakotņu pārvaldnieku, instalējot {0}. Pārbaudiet interneta savienojumu (VPN, starpniekserveris vai ugunsmūris to var bloķēt) un mēģiniet vēlreiz.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Šajā sistēmā nav pieejams saderīgs instalētājs pakotnei {0} (OS versija vai arhitektūra var netikt atbalstīta). Instalējiet {0} manuāli.</value>
+    <value>Šajā sistēmā nav pieejams saderīgs instalētājs pakotnei {0} (OS versija vai arhitektūra var netikt atbalstīta). Instalējiet {0} manuāli.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} netika atrasts Windows pakotņu pārvaldnieka katalogā. Mēģiniet atsvaidzināt winget avotus vai instalējiet {0} manuāli.</value>
+    <value>{0} netika atrasts Windows pakotņu pārvaldnieka katalogā. Mēģiniet atsvaidzināt winget avotus vai instalējiet {0} manuāli.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} instalēšana ilga vairāk nekā 20 minūtes. Intelligent Terminal pārtrauca gaidīt, bet instalētājs, iespējams, joprojām darbojas fonā. Pārbaudiet Task Manager vai mēģiniet vēlreiz vēlāk.</value>
+    <value>{0} instalēšana ilga vairāk nekā 20 minūtes. Intelligent Terminal pārtrauca gaidīt, bet instalētājs, iespējams, joprojām darbojas fonā. Pārbaudiet Task Manager vai mēģiniet vēlreiz vēlāk.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows pakotņu pārvaldnieks (winget) nav instalēts vai nav pieejams. Vispirms instalējiet to un pēc tam mēģiniet vēlreiz.</value>
+    <value>Windows pakotņu pārvaldnieks (winget) nav instalēts vai nav pieejams. Vispirms instalējiet to un pēc tam mēģiniet vēlreiz.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>Atļaujiet Intelligent Terminal piekļūt jūsu čaulai un automātiski noteikt kļūdas.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Neizdevās instalēt čaulas integrāciju. Kļūdu noteikšana ir izslēgta. Varat to atkārtoti iespējot un mēģināt vēlreiz vai saglabāt, lai turpinātu bez tās.</value>
+    <value>Neizdevās instalēt čaulas integrāciju. Kļūdu noteikšana ir izslēgta. Varat to atkārtoti iespējot un mēģināt vēlreiz vai saglabāt, lai turpinātu bez tās.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Neizdevās instalēt session hooks. Sesiju pārvaldība ir izslēgta. Varat to atkārtoti iespējot un mēģināt vēlreiz vai saglabāt, lai turpinātu bez tās.</value>
+    <value>Neizdevās instalēt session hooks. Sesiju pārvaldība ir izslēgta. Varat to atkārtoti iespējot un mēģināt vēlreiz vai saglabāt, lai turpinātu bez tās.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Uzziniet, kā to manuāli novērst</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell izpildes politika bloķē skriptus. Kļūdu noteikšana ir izslēgta.</value>
+    <value>PowerShell izpildes politika bloķē skriptus. Kļūdu noteikšana ir izslēgta.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Lietošana</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mi-NZ/Resources.resw
@@ -110,39 +110,39 @@
     <value>Kei te whakarite...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ I āraia te tāutanga o {0} e tētahi kaupapahere Kaiwhakahaere Mōkī Windows. Mēnā kei runga koe i tētahi pūrere whakahaere, whakapā atu ki tō kaiwhakahaere IT.</value>
+    <value>I āraia te tāutanga o {0} e tētahi kaupapahere Kaiwhakahaere Mōkī Windows. Mēnā kei runga koe i tētahi pūrere whakahaere, whakapā atu ki tō kaiwhakahaere IT.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Kāore i taea te tāuta i a {0} (waehere hapa {1}). Tirohia te rangitaki mō ngā taipitopito, tāutahia rānei a {0} ā-ringa.</value>
+    <value>Kāore i taea te tāuta i a {0} (waehere hapa {1}). Tirohia te rangitaki mō ngā taipitopito, tāutahia rānei a {0} ā-ringa.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Kāore i taea te tāuta i a {0}. Tirohia te rangitaki mō ngā taipitopito, tāutahia rānei a {0} ā-ringa.</value>
+    <value>Kāore i taea te tāuta i a {0}. Tirohia te rangitaki mō ngā taipitopito, tāutahia rānei a {0} ā-ringa.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ I pūrongo te kaitāuta o {0} i tētahi hapa (waehere {1}). Tirohia te rangitaki mō ngā taipitopito, tāutahia rānei a {0} ā-ringa.</value>
+    <value>I pūrongo te kaitāuta o {0} i tētahi hapa (waehere {1}). Tirohia te rangitaki mō ngā taipitopito, tāutahia rānei a {0} ā-ringa.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Kāore i taea te toro atu ki te Kaiwhakahaere Mōkī Windows i te wā e tāuta ana i a {0}. Tirohia tō hononga ipurangi (tērā pea kei te āraia e VPN, takawaenga, pātūahi rānei), kātahi ka ngana anō.</value>
+    <value>Kāore i taea te toro atu ki te Kaiwhakahaere Mōkī Windows i te wā e tāuta ana i a {0}. Tirohia tō hononga ipurangi (tērā pea kei te āraia e VPN, takawaenga, pātūahi rānei), kātahi ka ngana anō.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Kāore he kaitāuta hototahi mō {0} e wātea ana i tēnei pūnaha (kāore pea te putanga OS, te hoahoanga rānei e tautokona). Tāutahia a {0} ā-ringa.</value>
+    <value>Kāore he kaitāuta hototahi mō {0} e wātea ana i tēnei pūnaha (kāore pea te putanga OS, te hoahoanga rānei e tautokona). Tāutahia a {0} ā-ringa.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Kāore a {0} i kitea i te putumōhio Kaiwhakahaere Mōkī Windows. Whakamātauria te whakahou i ngā pūtake winget, tāutahia rānei a {0} ā-ringa.</value>
+    <value>Kāore a {0} i kitea i te putumōhio Kaiwhakahaere Mōkī Windows. Whakamātauria te whakahou i ngā pūtake winget, tāutahia rānei a {0} ā-ringa.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Neke atu i te 20 meneti te tāuta i a {0}. Kua mutu te tatari a Intelligent Terminal, engari tērā pea kei te rere tonu te kaitāuta i muri. Tirohia te Task Manager, ngana anō rānei ā muri ake.</value>
+    <value>Neke atu i te 20 meneti te tāuta i a {0}. Kua mutu te tatari a Intelligent Terminal, engari tērā pea kei te rere tonu te kaitāuta i muri. Tirohia te Task Manager, ngana anō rānei ā muri ake.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Kāore anō te Kaiwhakahaere Mōkī Windows (winget) kia tāutatia, kāore rānei i te wātea. Tāutahia i te tuatahi, kātahi ka ngana anō.</value>
+    <value>Kāore anō te Kaiwhakahaere Mōkī Windows (winget) kia tāutatia, kāore rānei i te wātea. Tāutahia i te tuatahi, kātahi ka ngana anō.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -234,9 +234,9 @@
     <value>Tukua a Intelligent Terminal kia uru ki tō anga me te kimi hapa aunoa.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ I rahua te tāuta i te whakaurunga anga. Kua whakawetohia te kitenga hapa. Ka taea e koe te whakahoki anō me te ngana anō, te tiaki rānei kia haere tonu i te kore.</value>
+    <value>I rahua te tāuta i te whakaurunga anga. Kua whakawetohia te kitenga hapa. Ka taea e koe te whakahoki anō me te ngana anō, te tiaki rānei kia haere tonu i te kore.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ I rahua te tāuta i ngā session hooks. Kua whakawetohia te whakahaere whakatūnga. Ka taea e koe te whakahoki anō me te ngana anō, te tiaki rānei kia haere tonu i te kore.</value>
+    <value>I rahua te tāuta i ngā session hooks. Kua whakawetohia te whakahaere whakatūnga. Ka taea e koe te whakahoki anō me te ngana anō, te tiaki rānei kia haere tonu i te kore.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Akona me pēhea te whakatika i tēnei mā te ringa</value>
@@ -252,7 +252,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Kei te ārai te kaupapahere whakatinana o PowerShell i ngā tuhinga. Kua whakawetohia te kitenga hapa.</value>
+    <value>Kei te ārai te kaupapahere whakatinana o PowerShell i ngā tuhinga. Kua whakawetohia te kitenga hapa.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Whakamahinga</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mk-MK/Resources.resw
@@ -223,39 +223,39 @@
     <value>Се поставува...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Инсталирањето на {0} беше блокирано од политика на Windows Package Manager. Ако користите управуван уред, контактирајте со IT администраторот.</value>
+    <value>Инсталирањето на {0} беше блокирано од политика на Windows Package Manager. Ако користите управуван уред, контактирајте со IT администраторот.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Инсталирањето на {0} не успеа (код на грешка {1}). Проверете го дневникот за детали или инсталирајте {0} рачно.</value>
+    <value>Инсталирањето на {0} не успеа (код на грешка {1}). Проверете го дневникот за детали или инсталирајте {0} рачно.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Инсталирањето на {0} не успеа. Проверете го дневникот за детали или инсталирајте {0} рачно.</value>
+    <value>Инсталирањето на {0} не успеа. Проверете го дневникот за детали или инсталирајте {0} рачно.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Инсталаторот за {0} пријави грешка (код {1}). Проверете го дневникот за детали или инсталирајте {0} рачно.</value>
+    <value>Инсталаторот за {0} пријави грешка (код {1}). Проверете го дневникот за детали или инсталирајте {0} рачно.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Не можеше да се пристапи до Windows Package Manager при инсталирањето на {0}. Проверете ја интернет-врската (VPN, прокси или заштитен ѕид може да ја блокира) и обидете се повторно.</value>
+    <value>Не можеше да се пристапи до Windows Package Manager при инсталирањето на {0}. Проверете ја интернет-врската (VPN, прокси или заштитен ѕид може да ја блокира) и обидете се повторно.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ На овој систем нема достапен компатибилен инсталатор за {0} (верзијата на ОС или архитектурата можеби не се поддржани). Инсталирајте {0} рачно.</value>
+    <value>На овој систем нема достапен компатибилен инсталатор за {0} (верзијата на ОС или архитектурата можеби не се поддржани). Инсталирајте {0} рачно.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} не беше пронајден во каталогот на Windows Package Manager. Обидете се да ги освежите изворите на winget или инсталирајте {0} рачно.</value>
+    <value>{0} не беше пронајден во каталогот на Windows Package Manager. Обидете се да ги освежите изворите на winget или инсталирајте {0} рачно.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Инсталирањето на {0} траеше подолго од 20 минути. Intelligent Terminal престана да чека, но инсталаторот можеби сè уште работи во заднина. Проверете Task Manager или обидете се повторно подоцна.</value>
+    <value>Инсталирањето на {0} траеше подолго од 20 минути. Intelligent Terminal престана да чека, но инсталаторот можеби сè уште работи во заднина. Проверете Task Manager или обидете се повторно подоцна.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) не е инсталиран или не е достапен. Прво инсталирајте го, а потоа обидете се повторно.</value>
+    <value>Windows Package Manager (winget) не е инсталиран или не е достапен. Прво инсталирајте го, а потоа обидете се повторно.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>Дозволете му на Intelligent Terminal да пристапи до вашата обвивка и автоматски да открива грешки.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Не успеа инсталирањето на интеграција на школка. Детекцијата на грешки е исклучена. Можете повторно да ја вклучите и да се обидете повторно, или да зачувате за да продолжите без неа.</value>
+    <value>Не успеа инсталирањето на интеграција на школка. Детекцијата на грешки е исклучена. Можете повторно да ја вклучите и да се обидете повторно, или да зачувате за да продолжите без неа.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Не успеа инсталирањето на session hooks. Управувањето со сесии е исклучено. Можете повторно да го вклучите и да се обидете повторно, или да зачувате за да продолжите без него.</value>
+    <value>Не успеа инсталирањето на session hooks. Управувањето со сесии е исклучено. Можете повторно да го вклучите и да се обидете повторно, или да зачувате за да продолжите без него.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Дознајте како да го поправите ова рачно</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Политиката за извршување на PowerShell ги блокира скриптите. Детекцијата на грешки е исклучена.</value>
+    <value>Политиката за извршување на PowerShell ги блокира скриптите. Детекцијата на грешки е исклучена.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Употреба</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ml-IN/Resources.resw
@@ -223,50 +223,50 @@
     <value>സജ്ജമാക്കുന്നു...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager പോളിസി {0} ഇൻസ്റ്റാളേഷൻ തടഞ്ഞു. നിങ്ങൾ മാനേജുചെയ്യുന്ന ഉപകരണത്തിലാണ് എങ്കിൽ, നിങ്ങളുടെ IT അഡ്മിനുമായി ബന്ധപ്പെടുക.</value>
+    <value>Windows Package Manager പോളിസി {0} ഇൻസ്റ്റാളേഷൻ തടഞ്ഞു. നിങ്ങൾ മാനേജുചെയ്യുന്ന ഉപകരണത്തിലാണ് എങ്കിൽ, നിങ്ങളുടെ IT അഡ്മിനുമായി ബന്ധപ്പെടുക.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} ഇൻസ്റ്റാൾ ചെയ്യാനായില്ല (പിശക് കോഡ് {1}). വിശദാംശങ്ങൾക്ക് ലോഗ് കാണുക, അല്ലെങ്കിൽ {0} മാനുവലായി ഇൻസ്റ്റാൾ ചെയ്യുക.</value>
+    <value>{0} ഇൻസ്റ്റാൾ ചെയ്യാനായില്ല (പിശക് കോഡ് {1}). വിശദാംശങ്ങൾക്ക് ലോഗ് കാണുക, അല്ലെങ്കിൽ {0} മാനുവലായി ഇൻസ്റ്റാൾ ചെയ്യുക.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} ഇൻസ്റ്റാൾ ചെയ്യാനായില്ല. വിശദാംശങ്ങൾക്ക് ലോഗ് കാണുക, അല്ലെങ്കിൽ {0} മാനുവലായി ഇൻസ്റ്റാൾ ചെയ്യുക.</value>
+    <value>{0} ഇൻസ്റ്റാൾ ചെയ്യാനായില്ല. വിശദാംശങ്ങൾക്ക് ലോഗ് കാണുക, അല്ലെങ്കിൽ {0} മാനുവലായി ഇൻസ്റ്റാൾ ചെയ്യുക.</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} ഇൻസ്റ്റാളർ ഒരു പിശക് റിപ്പോർട്ട് ചെയ്തു (കോഡ് {1}). വിശദാംശങ്ങൾക്ക് ലോഗ് പരിശോധിക്കുക, അല്ലെങ്കിൽ {0} മാനുവലായി ഇൻസ്റ്റാൾ ചെയ്യുക.</value>
+    <value>{0} ഇൻസ്റ്റാളർ ഒരു പിശക് റിപ്പോർട്ട് ചെയ്തു (കോഡ് {1}). വിശദാംശങ്ങൾക്ക് ലോഗ് പരിശോധിക്കുക, അല്ലെങ്കിൽ {0} മാനുവലായി ഇൻസ്റ്റാൾ ചെയ്യുക.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} ഇൻസ്റ്റാൾ ചെയ്യുമ്പോൾ Windows Package Manager-ലേക്ക് എത്താനായില്ല. നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ പരിശോധിക്കുക (VPN, proxy, അല്ലെങ്കിൽ firewall ഇത് തടയുന്നുണ്ടാകാം) വീണ്ടും ശ്രമിക്കുക.</value>
+    <value>{0} ഇൻസ്റ്റാൾ ചെയ്യുമ്പോൾ Windows Package Manager-ലേക്ക് എത്താനായില്ല. നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ പരിശോധിക്കുക (VPN, proxy, അല്ലെങ്കിൽ firewall ഇത് തടയുന്നുണ്ടാകാം) വീണ്ടും ശ്രമിക്കുക.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ ഈ സിസ്റ്റത്തിൽ {0}-നായി അനുയോജ്യമായ ഇൻസ്റ്റാളർ ലഭ്യമല്ല (OS പതിപ്പ് അല്ലെങ്കിൽ ആർക്കിടെക്ചർ പിന്തുണയ്ക്കുന്നില്ലായിരിക്കാം). {0} മാനുവലായി ഇൻസ്റ്റാൾ ചെയ്യുക.</value>
+    <value>ഈ സിസ്റ്റത്തിൽ {0}-നായി അനുയോജ്യമായ ഇൻസ്റ്റാളർ ലഭ്യമല്ല (OS പതിപ്പ് അല്ലെങ്കിൽ ആർക്കിടെക്ചർ പിന്തുണയ്ക്കുന്നില്ലായിരിക്കാം). {0} മാനുവലായി ഇൻസ്റ്റാൾ ചെയ്യുക.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager കാറ്റലോഗിൽ {0} കണ്ടെത്താനായില്ല. winget സോഴ്സുകൾ റിഫ്രെഷ് ചെയ്യാൻ ശ്രമിക്കുക, അല്ലെങ്കിൽ {0} മാനുവലായി ഇൻസ്റ്റാൾ ചെയ്യുക.</value>
+    <value>Windows Package Manager കാറ്റലോഗിൽ {0} കണ്ടെത്താനായില്ല. winget സോഴ്സുകൾ റിഫ്രെഷ് ചെയ്യാൻ ശ്രമിക്കുക, അല്ലെങ്കിൽ {0} മാനുവലായി ഇൻസ്റ്റാൾ ചെയ്യുക.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} ഇൻസ്റ്റാൾ ചെയ്യാൻ 20 മിനിറ്റിൽ കൂടുതൽ എടുത്തു. Intelligent Terminal കാത്തിരിപ്പ് നിർത്തി, പക്ഷേ ഇൻസ്റ്റാളർ ഇപ്പോഴും പശ്ചാത്തലത്തിൽ പ്രവർത്തിക്കുകയായിരിക്കാം. Task Manager പരിശോധിക്കുക, അല്ലെങ്കിൽ പിന്നീട് വീണ്ടും ശ്രമിക്കുക.</value>
+    <value>{0} ഇൻസ്റ്റാൾ ചെയ്യാൻ 20 മിനിറ്റിൽ കൂടുതൽ എടുത്തു. Intelligent Terminal കാത്തിരിപ്പ് നിർത്തി, പക്ഷേ ഇൻസ്റ്റാളർ ഇപ്പോഴും പശ്ചാത്തലത്തിൽ പ്രവർത്തിക്കുകയായിരിക്കാം. Task Manager പരിശോധിക്കുക, അല്ലെങ്കിൽ പിന്നീട് വീണ്ടും ശ്രമിക്കുക.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks ഇൻസ്റ്റാൾ ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു. സെഷൻ മാനേജ്മെന്റ് ഓഫ് ചെയ്തിരിക്കുന്നു. നിങ്ങൾക്ക് ഇത് വീണ്ടും പ്രവർത്തനക്ഷമമാക്കി വീണ്ടും ശ്രമിക്കാം, അല്ലെങ്കിൽ ഇത് ഇല്ലാതെ തുടരാൻ സേവ് ചെയ്യാം.</value>
+    <value>session hooks ഇൻസ്റ്റാൾ ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു. സെഷൻ മാനേജ്മെന്റ് ഓഫ് ചെയ്തിരിക്കുന്നു. നിങ്ങൾക്ക് ഇത് വീണ്ടും പ്രവർത്തനക്ഷമമാക്കി വീണ്ടും ശ്രമിക്കാം, അല്ലെങ്കിൽ ഇത് ഇല്ലാതെ തുടരാൻ സേവ് ചെയ്യാം.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ ഷെൽ ഇന്റഗ്രേഷൻ ഇൻസ്റ്റാൾ ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു. പിശക് കണ്ടെത്തൽ ഓഫ് ചെയ്തിരിക്കുന്നു. നിങ്ങൾക്ക് ഇത് വീണ്ടും പ്രവർത്തനക്ഷമമാക്കി വീണ്ടും ശ്രമിക്കാം, അല്ലെങ്കിൽ ഇത് ഇല്ലാതെ തുടരാൻ സേവ് ചെയ്യാം.</value>
+    <value>ഷെൽ ഇന്റഗ്രേഷൻ ഇൻസ്റ്റാൾ ചെയ്യുന്നതിൽ പരാജയപ്പെട്ടു. പിശക് കണ്ടെത്തൽ ഓഫ് ചെയ്തിരിക്കുന്നു. നിങ്ങൾക്ക് ഇത് വീണ്ടും പ്രവർത്തനക്ഷമമാക്കി വീണ്ടും ശ്രമിക്കാം, അല്ലെങ്കിൽ ഇത് ഇല്ലാതെ തുടരാൻ സേവ് ചെയ്യാം.</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell എക്സിക്യൂഷൻ പോളിസി സ്ക്രിപ്റ്റുകളെ തടയുന്നു. പിശക് കണ്ടെത്തൽ ഓഫ് ചെയ്തു.</value>
+    <value>PowerShell എക്സിക്യൂഷൻ പോളിസി സ്ക്രിപ്റ്റുകളെ തടയുന്നു. പിശക് കണ്ടെത്തൽ ഓഫ് ചെയ്തു.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) ഇൻസ്റ്റാൾ ചെയ്തിട്ടില്ല അല്ലെങ്കിൽ ലഭ്യമല്ല. ആദ്യം അത് ഇൻസ്റ്റാൾ ചെയ്യുക, തുടർന്ന് വീണ്ടും ശ്രമിക്കുക.</value>
+    <value>Windows Package Manager (winget) ഇൻസ്റ്റാൾ ചെയ്തിട്ടില്ല അല്ലെങ്കിൽ ലഭ്യമല്ല. ആദ്യം അത് ഇൻസ്റ്റാൾ ചെയ്യുക, തുടർന്ന് വീണ്ടും ശ്രമിക്കുക.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mr-IN/Resources.resw
@@ -223,50 +223,50 @@
     <value>सेट अप होत आहे...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager धोरणामुळे {0} ची स्थापना अवरोधित झाली. तुम्ही व्यवस्थापित डिव्हाइसवर असल्यास, तुमच्या IT प्रशासकाशी संपर्क साधा.</value>
+    <value>Windows Package Manager धोरणामुळे {0} ची स्थापना अवरोधित झाली. तुम्ही व्यवस्थापित डिव्हाइसवर असल्यास, तुमच्या IT प्रशासकाशी संपर्क साधा.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} इंस्टॉल करता आले नाही (त्रुटी कोड {1}). तपशीलांसाठी लॉग पहा, किंवा {0} मॅन्युअली इंस्टॉल करा.</value>
+    <value>{0} इंस्टॉल करता आले नाही (त्रुटी कोड {1}). तपशीलांसाठी लॉग पहा, किंवा {0} मॅन्युअली इंस्टॉल करा.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} इंस्टॉल करता आले नाही. तपशीलांसाठी लॉग पहा, किंवा {0} मॅन्युअली इंस्टॉल करा.</value>
+    <value>{0} इंस्टॉल करता आले नाही. तपशीलांसाठी लॉग पहा, किंवा {0} मॅन्युअली इंस्टॉल करा.</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} इंस्टॉलरने त्रुटी नोंदवली (कोड {1}). तपशीलांसाठी लॉग तपासा, किंवा {0} मॅन्युअली इंस्टॉल करा.</value>
+    <value>{0} इंस्टॉलरने त्रुटी नोंदवली (कोड {1}). तपशीलांसाठी लॉग तपासा, किंवा {0} मॅन्युअली इंस्टॉल करा.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} इंस्टॉल करताना Windows Package Manager पर्यंत पोहोचता आले नाही. तुमचे इंटरनेट कनेक्शन तपासा (VPN, proxy किंवा firewall ते अवरोधित करत असू शकते) आणि पुन्हा प्रयत्न करा.</value>
+    <value>{0} इंस्टॉल करताना Windows Package Manager पर्यंत पोहोचता आले नाही. तुमचे इंटरनेट कनेक्शन तपासा (VPN, proxy किंवा firewall ते अवरोधित करत असू शकते) आणि पुन्हा प्रयत्न करा.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ या सिस्टमवर {0} साठी कोणताही सुसंगत इंस्टॉलर उपलब्ध नाही (OS आवृत्ती किंवा आर्किटेक्चर समर्थित नसू शकते). {0} मॅन्युअली इंस्टॉल करा.</value>
+    <value>या सिस्टमवर {0} साठी कोणताही सुसंगत इंस्टॉलर उपलब्ध नाही (OS आवृत्ती किंवा आर्किटेक्चर समर्थित नसू शकते). {0} मॅन्युअली इंस्टॉल करा.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager कॅटलॉगमध्ये {0} सापडले नाही. winget स्रोत रिफ्रेश करण्याचा प्रयत्न करा, किंवा {0} मॅन्युअली इंस्टॉल करा.</value>
+    <value>Windows Package Manager कॅटलॉगमध्ये {0} सापडले नाही. winget स्रोत रिफ्रेश करण्याचा प्रयत्न करा, किंवा {0} मॅन्युअली इंस्टॉल करा.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} इंस्टॉल करण्यास 20 मिनिटांपेक्षा जास्त वेळ लागला. Intelligent Terminal ने प्रतीक्षा करणे थांबवले, पण इंस्टॉलर अजूनही पार्श्वभूमीत चालू असू शकतो. Task Manager तपासा, किंवा नंतर पुन्हा प्रयत्न करा.</value>
+    <value>{0} इंस्टॉल करण्यास 20 मिनिटांपेक्षा जास्त वेळ लागला. Intelligent Terminal ने प्रतीक्षा करणे थांबवले, पण इंस्टॉलर अजूनही पार्श्वभूमीत चालू असू शकतो. Task Manager तपासा, किंवा नंतर पुन्हा प्रयत्न करा.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks इंस्टॉल करणे अयशस्वी. सत्र व्यवस्थापन बंद केले गेले आहे. तुम्ही ते पुन्हा सक्षम करू शकता आणि पुन्हा प्रयत्न करू शकता, किंवा त्याशिवाय सुरू ठेवण्यासाठी सेव्ह करू शकता.</value>
+    <value>session hooks इंस्टॉल करणे अयशस्वी. सत्र व्यवस्थापन बंद केले गेले आहे. तुम्ही ते पुन्हा सक्षम करू शकता आणि पुन्हा प्रयत्न करू शकता, किंवा त्याशिवाय सुरू ठेवण्यासाठी सेव्ह करू शकता.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ शेल इंटिग्रेशन इंस्टॉल करणे अयशस्वी. त्रुटी शोध बंद केले गेले आहे. तुम्ही ते पुन्हा सक्षम करू शकता आणि पुन्हा प्रयत्न करू शकता, किंवा त्याशिवाय सुरू ठेवण्यासाठी सेव्ह करू शकता.</value>
+    <value>शेल इंटिग्रेशन इंस्टॉल करणे अयशस्वी. त्रुटी शोध बंद केले गेले आहे. तुम्ही ते पुन्हा सक्षम करू शकता आणि पुन्हा प्रयत्न करू शकता, किंवा त्याशिवाय सुरू ठेवण्यासाठी सेव्ह करू शकता.</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell कार्यान्वयन धोरण स्क्रिप्ट्स अवरोधित करत आहे. त्रुटी शोध बंद केले.</value>
+    <value>PowerShell कार्यान्वयन धोरण स्क्रिप्ट्स अवरोधित करत आहे. त्रुटी शोध बंद केले.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) इंस्टॉल केलेले नाही किंवा उपलब्ध नाही. प्रथम ते इंस्टॉल करा, नंतर पुन्हा प्रयत्न करा.</value>
+    <value>Windows Package Manager (winget) इंस्टॉल केलेले नाही किंवा उपलब्ध नाही. प्रथम ते इंस्टॉल करा, नंतर पुन्हा प्रयत्न करा.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ms-MY/Resources.resw
@@ -223,39 +223,39 @@
     <value>Menyediakan...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Pemasangan {0} disekat oleh dasar Windows Package Manager. Jika anda menggunakan peranti terurus, hubungi pentadbir IT anda.</value>
+    <value>Pemasangan {0} disekat oleh dasar Windows Package Manager. Jika anda menggunakan peranti terurus, hubungi pentadbir IT anda.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Tidak dapat memasang {0} (kod ralat {1}). Lihat log untuk butiran, atau pasang {0} secara manual.</value>
+    <value>Tidak dapat memasang {0} (kod ralat {1}). Lihat log untuk butiran, atau pasang {0} secara manual.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Tidak dapat memasang {0}. Lihat log untuk butiran, atau pasang {0} secara manual.</value>
+    <value>Tidak dapat memasang {0}. Lihat log untuk butiran, atau pasang {0} secara manual.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Pemasang {0} melaporkan ralat (kod {1}). Lihat log untuk butiran, atau pasang {0} secara manual.</value>
+    <value>Pemasang {0} melaporkan ralat (kod {1}). Lihat log untuk butiran, atau pasang {0} secara manual.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Tidak dapat mencapai Windows Package Manager semasa memasang {0}. Semak sambungan internet anda (VPN, proksi atau tembok api mungkin menyekatnya) dan cuba lagi.</value>
+    <value>Tidak dapat mencapai Windows Package Manager semasa memasang {0}. Semak sambungan internet anda (VPN, proksi atau tembok api mungkin menyekatnya) dan cuba lagi.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Tiada pemasang yang serasi untuk {0} tersedia pada sistem ini (versi OS atau seni bina mungkin tidak disokong). Pasang {0} secara manual.</value>
+    <value>Tiada pemasang yang serasi untuk {0} tersedia pada sistem ini (versi OS atau seni bina mungkin tidak disokong). Pasang {0} secara manual.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} tidak ditemui dalam katalog Windows Package Manager. Cuba segarkan semula sumber winget, atau pasang {0} secara manual.</value>
+    <value>{0} tidak ditemui dalam katalog Windows Package Manager. Cuba segarkan semula sumber winget, atau pasang {0} secara manual.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Memasang {0} mengambil masa lebih daripada 20 minit. Intelligent Terminal berhenti menunggu, tetapi pemasang mungkin masih berjalan di latar belakang. Semak Task Manager, atau cuba lagi kemudian.</value>
+    <value>Memasang {0} mengambil masa lebih daripada 20 minit. Intelligent Terminal berhenti menunggu, tetapi pemasang mungkin masih berjalan di latar belakang. Semak Task Manager, atau cuba lagi kemudian.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) tidak dipasang atau tidak tersedia. Pasang dahulu, kemudian cuba lagi.</value>
+    <value>Windows Package Manager (winget) tidak dipasang atau tidak tersedia. Pasang dahulu, kemudian cuba lagi.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -279,9 +279,9 @@
     <value>Benarkan Intelligent Terminal mengakses shell anda dan mengesan ralat secara automatik.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Gagal memasang integrasi shell. Pengesanan ralat telah dimatikan. Anda boleh mengaktifkannya semula dan cuba lagi, atau simpan untuk meneruskan tanpanya.</value>
+    <value>Gagal memasang integrasi shell. Pengesanan ralat telah dimatikan. Anda boleh mengaktifkannya semula dan cuba lagi, atau simpan untuk meneruskan tanpanya.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Gagal memasang session hooks. Pengurusan sesi telah dimatikan. Anda boleh mengaktifkannya semula dan cuba lagi, atau simpan untuk meneruskan tanpanya.</value>
+    <value>Gagal memasang session hooks. Pengurusan sesi telah dimatikan. Anda boleh mengaktifkannya semula dan cuba lagi, atau simpan untuk meneruskan tanpanya.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Ketahui cara membaiki ini secara manual</value>
@@ -297,7 +297,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Dasar pelaksanaan PowerShell menyekat skrip. Pengesanan ralat dimatikan.</value>
+    <value>Dasar pelaksanaan PowerShell menyekat skrip. Pengesanan ralat dimatikan.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Penggunaan</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/mt-MT/Resources.resw
@@ -110,39 +110,39 @@
     <value>Qed jiġi ssettjat...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ L-installazzjoni ta' {0} ġiet imblukkata minn politika tal-Maniġer tal-Pakketti ta' Windows. Jekk qiegħed fuq apparat immaniġġjat, ikkuntattja lill-amministratur tal-IT tiegħek.</value>
+    <value>L-installazzjoni ta' {0} ġiet imblukkata minn politika tal-Maniġer tal-Pakketti ta' Windows. Jekk qiegħed fuq apparat immaniġġjat, ikkuntattja lill-amministratur tal-IT tiegħek.</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Ma setax jiġi installat {0} (kodiċi tal-iżball {1}). Ara l-log għad-dettalji, jew installa {0} manwalment.</value>
+    <value>Ma setax jiġi installat {0} (kodiċi tal-iżball {1}). Ara l-log għad-dettalji, jew installa {0} manwalment.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Ma setax jiġi installat {0}. Ara l-log għad-dettalji, jew installa {0} manwalment.</value>
+    <value>Ma setax jiġi installat {0}. Ara l-log għad-dettalji, jew installa {0} manwalment.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ L-installatur ta' {0} irrapporta żball (kodiċi {1}). Iċċekkja l-log għad-dettalji, jew installa {0} manwalment.</value>
+    <value>L-installatur ta' {0} irrapporta żball (kodiċi {1}). Iċċekkja l-log għad-dettalji, jew installa {0} manwalment.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Ma setax jintlaħaq il-Maniġer tal-Pakketti ta' Windows waqt l-installazzjoni ta' {0}. Iċċekkja l-konnessjoni tal-internet tiegħek (VPN, proxy jew firewall jistgħu jkunu qed jimblukkawha) u erġa' pprova.</value>
+    <value>Ma setax jintlaħaq il-Maniġer tal-Pakketti ta' Windows waqt l-installazzjoni ta' {0}. Iċċekkja l-konnessjoni tal-internet tiegħek (VPN, proxy jew firewall jistgħu jkunu qed jimblukkawha) u erġa' pprova.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ L-ebda installatur kompatibbli għal {0} mhu disponibbli fuq din is-sistema (il-verżjoni tal-OS jew l-arkitettura jistgħu ma jkunux appoġġjati). Installa {0} manwalment.</value>
+    <value>L-ebda installatur kompatibbli għal {0} mhu disponibbli fuq din is-sistema (il-verżjoni tal-OS jew l-arkitettura jistgħu ma jkunux appoġġjati). Installa {0} manwalment.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} ma nstabx fil-katalgu tal-Maniġer tal-Pakketti ta' Windows. Ipprova aġġorna s-sorsi ta' winget, jew installa {0} manwalment.</value>
+    <value>{0} ma nstabx fil-katalgu tal-Maniġer tal-Pakketti ta' Windows. Ipprova aġġorna s-sorsi ta' winget, jew installa {0} manwalment.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ L-installazzjoni ta' {0} ħadet aktar minn 20 minuta. Intelligent Terminal waqaf jistenna, iżda l-installatur jista' jkun għadu għaddej fl-isfond. Iċċekkja Task Manager, jew erġa' pprova aktar tard.</value>
+    <value>L-installazzjoni ta' {0} ħadet aktar minn 20 minuta. Intelligent Terminal waqaf jistenna, iżda l-installatur jista' jkun għadu għaddej fl-isfond. Iċċekkja Task Manager, jew erġa' pprova aktar tard.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Il-Maniġer tal-Pakketti ta' Windows (winget) mhuwiex installat jew mhux disponibbli. Installah l-ewwel, imbagħad erġa' pprova.</value>
+    <value>Il-Maniġer tal-Pakketti ta' Windows (winget) mhuwiex installat jew mhux disponibbli. Installah l-ewwel, imbagħad erġa' pprova.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -234,9 +234,9 @@
     <value>Agħti permess lil Intelligent Terminal biex jaċċessa l-qoxra tiegħek u jidentifika l-iżbalji awtomatikament.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ L-installazzjoni tal-integrazzjoni tal-qoxra falliet. Id-detezzjoni tal-iżbalji ġiet mitfija. Tista' terġa' tixgħelha u terġa' tipprova, jew issejvja biex tkompli mingħajrha.</value>
+    <value>L-installazzjoni tal-integrazzjoni tal-qoxra falliet. Id-detezzjoni tal-iżbalji ġiet mitfija. Tista' terġa' tixgħelha u terġa' tipprova, jew issejvja biex tkompli mingħajrha.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ L-installazzjoni tal-hooks tas-sessjoni falliet. Il-ġestjoni tas-sessjonijiet ġiet mitfija. Tista' terġa' tixgħelha u terġa' tipprova, jew issejvja biex tkompli mingħajrha.</value>
+    <value>L-installazzjoni tal-hooks tas-sessjoni falliet. Il-ġestjoni tas-sessjonijiet ġiet mitfija. Tista' terġa' tixgħelha u terġa' tipprova, jew issejvja biex tkompli mingħajrha.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Tgħallem kif issewwi dan manwalment</value>
@@ -252,7 +252,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Il-politika tal-eżekuzzjoni ta' PowerShell qed timblokka l-iskripts. Id-detezzjoni tal-iżbalji mitfija.</value>
+    <value>Il-politika tal-eżekuzzjoni ta' PowerShell qed timblokka l-iskripts. Id-detezzjoni tal-iżbalji mitfija.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Użu</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nb-NO/Resources.resw
@@ -224,39 +224,39 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Konfigurerer...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Installasjon av {0} ble blokkert av en Windows Pakkebehandling-policy. Hvis du bruker en administrert enhet, kontakter du IT-administratoren.</value>
+    <value>Installasjon av {0} ble blokkert av en Windows Pakkebehandling-policy. Hvis du bruker en administrert enhet, kontakter du IT-administratoren.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Kunne ikke installere {0} (feilkode {1}). Sjekk loggen for detaljer, eller installer {0} manuelt.</value>
+    <value>Kunne ikke installere {0} (feilkode {1}). Sjekk loggen for detaljer, eller installer {0} manuelt.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Kunne ikke installere {0}. Sjekk loggen for detaljer, eller installer {0} manuelt.</value>
+    <value>Kunne ikke installere {0}. Sjekk loggen for detaljer, eller installer {0} manuelt.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Installasjonsprogrammet for {0} rapporterte en feil (kode {1}). Sjekk loggen for detaljer, eller installer {0} manuelt.</value>
+    <value>Installasjonsprogrammet for {0} rapporterte en feil (kode {1}). Sjekk loggen for detaljer, eller installer {0} manuelt.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Fikk ikke kontakt med Windows Pakkebehandling under installasjon av {0}. Sjekk internettkoblingen (VPN, proxy eller brannmur kan blokkere den) og prøv igjen.</value>
+    <value>Fikk ikke kontakt med Windows Pakkebehandling under installasjon av {0}. Sjekk internettkoblingen (VPN, proxy eller brannmur kan blokkere den) og prøv igjen.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Det finnes ikke noe kompatibelt installasjonsprogram for {0} på dette systemet (OS-versjonen eller arkitekturen støttes kanskje ikke). Installer {0} manuelt.</value>
+    <value>Det finnes ikke noe kompatibelt installasjonsprogram for {0} på dette systemet (OS-versjonen eller arkitekturen støttes kanskje ikke). Installer {0} manuelt.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} ble ikke funnet i katalogen til Windows Pakkebehandling. Prøv å oppdatere winget-kildene, eller installer {0} manuelt.</value>
+    <value>{0} ble ikke funnet i katalogen til Windows Pakkebehandling. Prøv å oppdatere winget-kildene, eller installer {0} manuelt.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Installasjon av {0} tok mer enn 20 minutter. Intelligent Terminal sluttet å vente, men installasjonsprogrammet kan fortsatt kjøre i bakgrunnen. Sjekk Task Manager, eller prøv igjen senere.</value>
+    <value>Installasjon av {0} tok mer enn 20 minutter. Intelligent Terminal sluttet å vente, men installasjonsprogrammet kan fortsatt kjøre i bakgrunnen. Sjekk Task Manager, eller prøv igjen senere.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Pakkebehandling (winget) er ikke installert eller ikke tilgjengelig. Installer den først, og prøv deretter på nytt.</value>
+    <value>Windows Pakkebehandling (winget) er ikke installert eller ikke tilgjengelig. Installer den først, og prøv deretter på nytt.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Gi Intelligent Terminal tillatelse til å få tilgang til skallet og automatisk oppdage feil.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Kunne ikke installere skallintegrasjon. Feiloppdaging er slått av. Du kan aktivere den på nytt og prøve igjen, eller lagre for å fortsette uten den.</value>
+    <value>Kunne ikke installere skallintegrasjon. Feiloppdaging er slått av. Du kan aktivere den på nytt og prøve igjen, eller lagre for å fortsette uten den.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Kunne ikke installere session hooks. Sesjonshåndtering er slått av. Du kan aktivere den på nytt og prøve igjen, eller lagre for å fortsette uten den.</value>
+    <value>Kunne ikke installere session hooks. Sesjonshåndtering er slått av. Du kan aktivere den på nytt og prøve igjen, eller lagre for å fortsette uten den.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Finn ut hvordan du løser dette manuelt</value>
@@ -366,7 +366,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell-utførelsespolicyen blokkerer skript. Feiloppdaging slått av.</value>
+    <value>PowerShell-utførelsespolicyen blokkerer skript. Feiloppdaging slått av.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Bruk</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ne-NP/Resources.resw
@@ -224,50 +224,50 @@
     <value>सेटअप हुँदैछ...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager नीतिले {0} को स्थापना रोक्यो। तपाईं व्यवस्थापित उपकरणमा हुनुहुन्छ भने, आफ्नो IT प्रशासकलाई सम्पर्क गर्नुहोस्।</value>
+    <value>Windows Package Manager नीतिले {0} को स्थापना रोक्यो। तपाईं व्यवस्थापित उपकरणमा हुनुहुन्छ भने, आफ्नो IT प्रशासकलाई सम्पर्क गर्नुहोस्।</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} स्थापना गर्न सकिएन (त्रुटि कोड {1})। विवरणका लागि लग हेर्नुहोस्, वा {0} म्यानुअल रूपमा स्थापना गर्नुहोस्।</value>
+    <value>{0} स्थापना गर्न सकिएन (त्रुटि कोड {1})। विवरणका लागि लग हेर्नुहोस्, वा {0} म्यानुअल रूपमा स्थापना गर्नुहोस्।</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} स्थापना गर्न सकिएन। विवरणका लागि लग हेर्नुहोस्, वा {0} म्यानुअल रूपमा स्थापना गर्नुहोस्।</value>
+    <value>{0} स्थापना गर्न सकिएन। विवरणका लागि लग हेर्नुहोस्, वा {0} म्यानुअल रूपमा स्थापना गर्नुहोस्।</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} स्थापनाकर्ताले त्रुटि रिपोर्ट गर्‍यो (कोड {1})। विवरणका लागि लग जाँच गर्नुहोस्, वा {0} म्यानुअल रूपमा स्थापना गर्नुहोस्।</value>
+    <value>{0} स्थापनाकर्ताले त्रुटि रिपोर्ट गर्‍यो (कोड {1})। विवरणका लागि लग जाँच गर्नुहोस्, वा {0} म्यानुअल रूपमा स्थापना गर्नुहोस्।</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} स्थापना गर्दा Windows Package Manager मा पुग्न सकिएन। आफ्नो इन्टरनेट जडान जाँच गर्नुहोस् (VPN, proxy, वा firewall ले यसलाई रोकिरहेको हुन सक्छ) र पुनः प्रयास गर्नुहोस्।</value>
+    <value>{0} स्थापना गर्दा Windows Package Manager मा पुग्न सकिएन। आफ्नो इन्टरनेट जडान जाँच गर्नुहोस् (VPN, proxy, वा firewall ले यसलाई रोकिरहेको हुन सक्छ) र पुनः प्रयास गर्नुहोस्।</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ यो प्रणालीमा {0} का लागि कुनै उपयुक्त स्थापनाकर्ता उपलब्ध छैन (OS संस्करण वा आर्किटेक्चर समर्थित नहुन सक्छ)। {0} म्यानुअल रूपमा स्थापना गर्नुहोस्।</value>
+    <value>यो प्रणालीमा {0} का लागि कुनै उपयुक्त स्थापनाकर्ता उपलब्ध छैन (OS संस्करण वा आर्किटेक्चर समर्थित नहुन सक्छ)। {0} म्यानुअल रूपमा स्थापना गर्नुहोस्।</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager क्याटलगमा {0} फेला परेन। winget स्रोतहरू रिफ्रेस गर्ने प्रयास गर्नुहोस्, वा {0} म्यानुअल रूपमा स्थापना गर्नुहोस्।</value>
+    <value>Windows Package Manager क्याटलगमा {0} फेला परेन। winget स्रोतहरू रिफ्रेस गर्ने प्रयास गर्नुहोस्, वा {0} म्यानुअल रूपमा स्थापना गर्नुहोस्।</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} स्थापना गर्न 20 मिनेटभन्दा बढी समय लाग्यो। Intelligent Terminal ले पर्खन बन्द गर्‍यो, तर स्थापनाकर्ता अझै पनि पृष्ठभूमिमा चलिरहेको हुन सक्छ। Task Manager जाँच गर्नुहोस्, वा पछि पुनः प्रयास गर्नुहोस्।</value>
+    <value>{0} स्थापना गर्न 20 मिनेटभन्दा बढी समय लाग्यो। Intelligent Terminal ले पर्खन बन्द गर्‍यो, तर स्थापनाकर्ता अझै पनि पृष्ठभूमिमा चलिरहेको हुन सक्छ। Task Manager जाँच गर्नुहोस्, वा पछि पुनः प्रयास गर्नुहोस्।</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks स्थापना गर्न विफल भयो। सत्र व्यवस्थापन बन्द गरिएको छ। तपाईं यसलाई पुनः सक्षम गर्न सक्नुहुन्छ र पुनः प्रयास गर्न सक्नुहुन्छ, वा यसबिना जारी राख्न सेभ गर्नुहोस्।</value>
+    <value>session hooks स्थापना गर्न विफल भयो। सत्र व्यवस्थापन बन्द गरिएको छ। तपाईं यसलाई पुनः सक्षम गर्न सक्नुहुन्छ र पुनः प्रयास गर्न सक्नुहुन्छ, वा यसबिना जारी राख्न सेभ गर्नुहोस्।</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ शेल एकीकरण स्थापना गर्न विफल भयो। त्रुटि पत्ता लगाउने बन्द गरिएको छ। तपाईं यसलाई पुनः सक्षम गर्न सक्नुहुन्छ र पुनः प्रयास गर्न सक्नुहुन्छ, वा यसबिना जारी राख्न सेभ गर्नुहोस्।</value>
+    <value>शेल एकीकरण स्थापना गर्न विफल भयो। त्रुटि पत्ता लगाउने बन्द गरिएको छ। तपाईं यसलाई पुनः सक्षम गर्न सक्नुहुन्छ र पुनः प्रयास गर्न सक्नुहुन्छ, वा यसबिना जारी राख्न सेभ गर्नुहोस्।</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell कार्यान्वयन नीतिले स्क्रिप्टहरू रोक्दैछ। त्रुटि पत्ता लगाउने बन्द गरियो।</value>
+    <value>PowerShell कार्यान्वयन नीतिले स्क्रिप्टहरू रोक्दैछ। त्रुटि पत्ता लगाउने बन्द गरियो।</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) स्थापना गरिएको छैन वा उपलब्ध छैन। पहिले यसलाई स्थापना गर्नुहोस्, त्यसपछि पुनः प्रयास गर्नुहोस्।</value>
+    <value>Windows Package Manager (winget) स्थापना गरिएको छैन वा उपलब्ध छैन। पहिले यसलाई स्थापना गर्नुहोस्, त्यसपछि पुनः प्रयास गर्नुहोस्।</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nl-NL/Resources.resw
@@ -218,39 +218,39 @@
     <value>Instellen...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Installatie van {0} is geblokkeerd door een beleid van Windows Pakketbeheer. Als u een beheerd apparaat gebruikt, neemt u contact op met uw IT-beheerder.</value>
+    <value>Installatie van {0} is geblokkeerd door een beleid van Windows Pakketbeheer. Als u een beheerd apparaat gebruikt, neemt u contact op met uw IT-beheerder.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Kan {0} niet installeren (foutcode {1}). Raadpleeg het logboek voor details of installeer {0} handmatig.</value>
+    <value>Kan {0} niet installeren (foutcode {1}). Raadpleeg het logboek voor details of installeer {0} handmatig.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Kan {0} niet installeren. Raadpleeg het logboek voor details of installeer {0} handmatig.</value>
+    <value>Kan {0} niet installeren. Raadpleeg het logboek voor details of installeer {0} handmatig.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Het installatieprogramma voor {0} heeft een fout gerapporteerd (code {1}). Raadpleeg het logboek voor details of installeer {0} handmatig.</value>
+    <value>Het installatieprogramma voor {0} heeft een fout gerapporteerd (code {1}). Raadpleeg het logboek voor details of installeer {0} handmatig.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Windows Pakketbeheer kon niet worden bereikt tijdens het installeren van {0}. Controleer uw internetverbinding (VPN, proxy of firewall blokkeert deze mogelijk) en probeer het opnieuw.</value>
+    <value>Windows Pakketbeheer kon niet worden bereikt tijdens het installeren van {0}. Controleer uw internetverbinding (VPN, proxy of firewall blokkeert deze mogelijk) en probeer het opnieuw.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Er is geen compatibel installatieprogramma voor {0} beschikbaar op dit systeem (de versie van het besturingssysteem of de architectuur wordt mogelijk niet ondersteund). Installeer {0} handmatig.</value>
+    <value>Er is geen compatibel installatieprogramma voor {0} beschikbaar op dit systeem (de versie van het besturingssysteem of de architectuur wordt mogelijk niet ondersteund). Installeer {0} handmatig.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} is niet gevonden in de catalogus van Windows Pakketbeheer. Probeer de winget-bronnen te vernieuwen of installeer {0} handmatig.</value>
+    <value>{0} is niet gevonden in de catalogus van Windows Pakketbeheer. Probeer de winget-bronnen te vernieuwen of installeer {0} handmatig.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Het installeren van {0} duurde langer dan 20 minuten. Intelligent Terminal is gestopt met wachten, maar het installatieprogramma wordt mogelijk nog op de achtergrond uitgevoerd. Controleer Task Manager of probeer het later opnieuw.</value>
+    <value>Het installeren van {0} duurde langer dan 20 minuten. Intelligent Terminal is gestopt met wachten, maar het installatieprogramma wordt mogelijk nog op de achtergrond uitgevoerd. Controleer Task Manager of probeer het later opnieuw.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Pakketbeheer (winget) is niet geïnstalleerd of niet beschikbaar. Installeer het eerst en probeer het daarna opnieuw.</value>
+    <value>Windows Pakketbeheer (winget) is niet geïnstalleerd of niet beschikbaar. Installeer het eerst en probeer het daarna opnieuw.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -342,9 +342,9 @@
     <value>Geef Intelligent Terminal toestemming om toegang te krijgen tot uw shell en automatisch fouten te detecteren.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Het installeren van shellintegratie is mislukt. Foutdetectie is uitgeschakeld. U kunt het opnieuw inschakelen en het opnieuw proberen, of opslaan om verder te gaan zonder.</value>
+    <value>Het installeren van shellintegratie is mislukt. Foutdetectie is uitgeschakeld. U kunt het opnieuw inschakelen en het opnieuw proberen, of opslaan om verder te gaan zonder.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Het installeren van sessie-hooks is mislukt. Sessiebeheer is uitgeschakeld. U kunt het opnieuw inschakelen en het opnieuw proberen, of opslaan om verder te gaan zonder.</value>
+    <value>Het installeren van sessie-hooks is mislukt. Sessiebeheer is uitgeschakeld. U kunt het opnieuw inschakelen en het opnieuw proberen, of opslaan om verder te gaan zonder.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Meer informatie over hoe u dit handmatig kunt oplossen</value>
@@ -360,7 +360,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Het uitvoeringsbeleid van PowerShell blokkeert scripts. Foutdetectie uitgeschakeld.</value>
+    <value>Het uitvoeringsbeleid van PowerShell blokkeert scripts. Foutdetectie uitgeschakeld.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Gebruik</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/nn-NO/Resources.resw
@@ -224,39 +224,39 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Konfigurerer...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Installasjon av {0} vart blokkert av ein Windows Pakkebehandling-policy. Viss du brukar ei administrert eining, kontaktar du IT-administratoren.</value>
+    <value>Installasjon av {0} vart blokkert av ein Windows Pakkebehandling-policy. Viss du brukar ei administrert eining, kontaktar du IT-administratoren.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Kunne ikkje installere {0} (feilkode {1}). Sjekk loggen for detaljar, eller installer {0} manuelt.</value>
+    <value>Kunne ikkje installere {0} (feilkode {1}). Sjekk loggen for detaljar, eller installer {0} manuelt.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Kunne ikkje installere {0}. Sjekk loggen for detaljar, eller installer {0} manuelt.</value>
+    <value>Kunne ikkje installere {0}. Sjekk loggen for detaljar, eller installer {0} manuelt.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Installasjonsprogrammet for {0} rapporterte ein feil (kode {1}). Sjekk loggen for detaljar, eller installer {0} manuelt.</value>
+    <value>Installasjonsprogrammet for {0} rapporterte ein feil (kode {1}). Sjekk loggen for detaljar, eller installer {0} manuelt.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Fekk ikkje kontakt med Windows Pakkebehandling under installasjon av {0}. Sjekk internettilkoplinga (VPN, proxy eller brannmur kan blokkere henne) og prøv igjen.</value>
+    <value>Fekk ikkje kontakt med Windows Pakkebehandling under installasjon av {0}. Sjekk internettilkoplinga (VPN, proxy eller brannmur kan blokkere henne) og prøv igjen.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Det finst ikkje noko kompatibelt installasjonsprogram for {0} på dette systemet (OS-versjonen eller arkitekturen er kanskje ikkje støtta). Installer {0} manuelt.</value>
+    <value>Det finst ikkje noko kompatibelt installasjonsprogram for {0} på dette systemet (OS-versjonen eller arkitekturen er kanskje ikkje støtta). Installer {0} manuelt.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} vart ikkje funnen i katalogen til Windows Pakkebehandling. Prøv å oppdatere winget-kjeldene, eller installer {0} manuelt.</value>
+    <value>{0} vart ikkje funnen i katalogen til Windows Pakkebehandling. Prøv å oppdatere winget-kjeldene, eller installer {0} manuelt.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Installasjon av {0} tok meir enn 20 minutt. Intelligent Terminal slutta å vente, men installasjonsprogrammet kan framleis køyre i bakgrunnen. Sjekk Task Manager, eller prøv igjen seinare.</value>
+    <value>Installasjon av {0} tok meir enn 20 minutt. Intelligent Terminal slutta å vente, men installasjonsprogrammet kan framleis køyre i bakgrunnen. Sjekk Task Manager, eller prøv igjen seinare.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Pakkebehandling (winget) er ikkje installert eller ikkje tilgjengeleg. Installer han først, og prøv deretter på nytt.</value>
+    <value>Windows Pakkebehandling (winget) er ikkje installert eller ikkje tilgjengeleg. Installer han først, og prøv deretter på nytt.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Gi Intelligent Terminal løyve til å få tilgang til skalet og automatisk oppdage feil.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Kunne ikkje installere skalintegrasjon. Feiloppdaging er slått av. Du kan aktivere den på nytt og prøve igjen, eller lagre for å halde fram utan den.</value>
+    <value>Kunne ikkje installere skalintegrasjon. Feiloppdaging er slått av. Du kan aktivere den på nytt og prøve igjen, eller lagre for å halde fram utan den.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Kunne ikkje installere session hooks. Sesjonshandtering er slått av. Du kan aktivere den på nytt og prøve igjen, eller lagre for å halde fram utan den.</value>
+    <value>Kunne ikkje installere session hooks. Sesjonshandtering er slått av. Du kan aktivere den på nytt og prøve igjen, eller lagre for å halde fram utan den.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Finn ut korleis du løyser dette manuelt</value>
@@ -366,7 +366,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell-utføringspolicyen blokkerer skript. Feiloppdaging slått av.</value>
+    <value>PowerShell-utføringspolicyen blokkerer skript. Feiloppdaging slått av.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Bruk</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/or-IN/Resources.resw
@@ -224,50 +224,50 @@
     <value>ସେଟଅପ୍ ହେଉଛି...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager ନୀତି ଦ୍ୱାରା {0} ର ଇନ୍‌ଷ୍ଟଲେସନ୍ ଅବରୋଧ କରାଯାଇଛି। ଆପଣ ଯଦି ପରିଚାଳିତ ଡିଭାଇସ୍‌ରେ ଅଛନ୍ତି, ତେବେ ଆପଣଙ୍କ IT ଆଡମିନ୍‌ଙ୍କୁ ସମ୍ପର୍କ କରନ୍ତୁ।</value>
+    <value>Windows Package Manager ନୀତି ଦ୍ୱାରା {0} ର ଇନ୍‌ଷ୍ଟଲେସନ୍ ଅବରୋଧ କରାଯାଇଛି। ଆପଣ ଯଦି ପରିଚାଳିତ ଡିଭାଇସ୍‌ରେ ଅଛନ୍ତି, ତେବେ ଆପଣଙ୍କ IT ଆଡମିନ୍‌ଙ୍କୁ ସମ୍ପର୍କ କରନ୍ତୁ।</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} ଇନ୍‌ଷ୍ଟଲ୍ କରିପାରିଲା ନାହିଁ (ତ୍ରୁଟି କୋଡ୍ {1})। ବିବରଣୀ ପାଇଁ ଲଗ୍ ଦେଖନ୍ତୁ, କିମ୍ବା {0} କୁ ମାନୁଆଲ୍ ଭାବେ ଇନ୍‌ଷ୍ଟଲ୍ କରନ୍ତୁ।</value>
+    <value>{0} ଇନ୍‌ଷ୍ଟଲ୍ କରିପାରିଲା ନାହିଁ (ତ୍ରୁଟି କୋଡ୍ {1})। ବିବରଣୀ ପାଇଁ ଲଗ୍ ଦେଖନ୍ତୁ, କିମ୍ବା {0} କୁ ମାନୁଆଲ୍ ଭାବେ ଇନ୍‌ଷ୍ଟଲ୍ କରନ୍ତୁ।</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} ଇନ୍‌ଷ୍ଟଲ୍ କରିପାରିଲା ନାହିଁ। ବିବରଣୀ ପାଇଁ ଲଗ୍ ଦେଖନ୍ତୁ, କିମ୍ବା {0} କୁ ମାନୁଆଲ୍ ଭାବେ ଇନ୍‌ଷ୍ଟଲ୍ କରନ୍ତୁ।</value>
+    <value>{0} ଇନ୍‌ଷ୍ଟଲ୍ କରିପାରିଲା ନାହିଁ। ବିବରଣୀ ପାଇଁ ଲଗ୍ ଦେଖନ୍ତୁ, କିମ୍ବା {0} କୁ ମାନୁଆଲ୍ ଭାବେ ଇନ୍‌ଷ୍ଟଲ୍ କରନ୍ତୁ।</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} ଇନ୍‌ଷ୍ଟଲର୍ ଏକ ତ୍ରୁଟି ରିପୋର୍ଟ୍ କରିଛି (କୋଡ୍ {1})। ବିବରଣୀ ପାଇଁ ଲଗ୍ ଯାଞ୍ଚ କରନ୍ତୁ, କିମ୍ବା {0} କୁ ମାନୁଆଲ୍ ଭାବେ ଇନ୍‌ଷ୍ଟଲ୍ କରନ୍ତୁ।</value>
+    <value>{0} ଇନ୍‌ଷ୍ଟଲର୍ ଏକ ତ୍ରୁଟି ରିପୋର୍ଟ୍ କରିଛି (କୋଡ୍ {1})। ବିବରଣୀ ପାଇଁ ଲଗ୍ ଯାଞ୍ଚ କରନ୍ତୁ, କିମ୍ବା {0} କୁ ମାନୁଆଲ୍ ଭାବେ ଇନ୍‌ଷ୍ଟଲ୍ କରନ୍ତୁ।</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} ଇନ୍‌ଷ୍ଟଲ୍ କରୁଥିବାବେଳେ Windows Package Manager ସହିତ ସଂଯୋଗ ହୋଇପାରିଲା ନାହିଁ। ଆପଣଙ୍କ ଇଣ୍ଟରନେଟ୍ ସଂଯୋଗ ଯାଞ୍ଚ କରନ୍ତୁ (VPN, proxy, କିମ୍ବା firewall ଏହାକୁ ଅବରୋଧ କରୁଥାଇପାରେ) ଏବଂ ପୁଣି ଚେଷ୍ଟା କରନ୍ତୁ।</value>
+    <value>{0} ଇନ୍‌ଷ୍ଟଲ୍ କରୁଥିବାବେଳେ Windows Package Manager ସହିତ ସଂଯୋଗ ହୋଇପାରିଲା ନାହିଁ। ଆପଣଙ୍କ ଇଣ୍ଟରନେଟ୍ ସଂଯୋଗ ଯାଞ୍ଚ କରନ୍ତୁ (VPN, proxy, କିମ୍ବା firewall ଏହାକୁ ଅବରୋଧ କରୁଥାଇପାରେ) ଏବଂ ପୁଣି ଚେଷ୍ଟା କରନ୍ତୁ।</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ ଏହି ସିଷ୍ଟମ୍‌ରେ {0} ପାଇଁ କୌଣସି ସୁସଙ୍ଗତ ଇନ୍‌ଷ୍ଟଲର୍ ଉପଲବ୍ଧ ନାହିଁ (OS ସଂସ୍କରଣ କିମ୍ବା ଆର୍କିଟେକ୍ଚର ସମର୍ଥିତ ନ ହୋଇପାରେ)। {0} କୁ ମାନୁଆଲ୍ ଭାବେ ଇନ୍‌ଷ୍ଟଲ୍ କରନ୍ତୁ।</value>
+    <value>ଏହି ସିଷ୍ଟମ୍‌ରେ {0} ପାଇଁ କୌଣସି ସୁସଙ୍ଗତ ଇନ୍‌ଷ୍ଟଲର୍ ଉପଲବ୍ଧ ନାହିଁ (OS ସଂସ୍କରଣ କିମ୍ବା ଆର୍କିଟେକ୍ଚର ସମର୍ଥିତ ନ ହୋଇପାରେ)। {0} କୁ ମାନୁଆଲ୍ ଭାବେ ଇନ୍‌ଷ୍ଟଲ୍ କରନ୍ତୁ।</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager କ୍ୟାଟାଲଗ୍‌ରେ {0} ମିଳିଲା ନାହିଁ। winget ସ୍ରୋତଗୁଡ଼ିକୁ ରିଫ୍ରେଶ୍ କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ, କିମ୍ବା {0} କୁ ମାନୁଆଲ୍ ଭାବେ ଇନ୍‌ଷ୍ଟଲ୍ କରନ୍ତୁ।</value>
+    <value>Windows Package Manager କ୍ୟାଟାଲଗ୍‌ରେ {0} ମିଳିଲା ନାହିଁ। winget ସ୍ରୋତଗୁଡ଼ିକୁ ରିଫ୍ରେଶ୍ କରିବାକୁ ଚେଷ୍ଟା କରନ୍ତୁ, କିମ୍ବା {0} କୁ ମାନୁଆଲ୍ ଭାବେ ଇନ୍‌ଷ୍ଟଲ୍ କରନ୍ତୁ।</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} ଇନ୍‌ଷ୍ଟଲ୍ କରିବାକୁ 20 ମିନିଟ୍‌ରୁ ଅଧିକ ସମୟ ଲାଗିଲା। Intelligent Terminal ଅପେକ୍ଷା କରିବା ବନ୍ଦ କଲା, କିନ୍ତୁ ଇନ୍‌ଷ୍ଟଲର୍ ଏପର୍ଯ୍ୟନ୍ତ ପୃଷ୍ଠଭୂମିରେ ଚାଲୁଥାଇପାରେ। Task Manager ଯାଞ୍ଚ କରନ୍ତୁ, କିମ୍ବା ପରେ ପୁଣି ଚେଷ୍ଟା କରନ୍ତୁ।</value>
+    <value>{0} ଇନ୍‌ଷ୍ଟଲ୍ କରିବାକୁ 20 ମିନିଟ୍‌ରୁ ଅଧିକ ସମୟ ଲାଗିଲା। Intelligent Terminal ଅପେକ୍ଷା କରିବା ବନ୍ଦ କଲା, କିନ୍ତୁ ଇନ୍‌ଷ୍ଟଲର୍ ଏପର୍ଯ୍ୟନ୍ତ ପୃଷ୍ଠଭୂମିରେ ଚାଲୁଥାଇପାରେ। Task Manager ଯାଞ୍ଚ କରନ୍ତୁ, କିମ୍ବା ପରେ ପୁଣି ଚେଷ୍ଟା କରନ୍ତୁ।</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks ଇନ୍‌ଷ୍ଟଲ୍ କରିବାରେ ବିଫଳ। ସେସନ୍ ପରିଚାଳନା ବନ୍ଦ କରାଯାଇଛି। ଆପଣ ଏହାକୁ ପୁଣି ସକ୍ରିୟ କରି ପୁଣି ଚେଷ୍ଟା କରିପାରିବେ, କିମ୍ବା ଏହା ବିନା ଜାରି ରଖିବାକୁ ସେଭ୍ କରନ୍ତୁ।</value>
+    <value>session hooks ଇନ୍‌ଷ୍ଟଲ୍ କରିବାରେ ବିଫଳ। ସେସନ୍ ପରିଚାଳନା ବନ୍ଦ କରାଯାଇଛି। ଆପଣ ଏହାକୁ ପୁଣି ସକ୍ରିୟ କରି ପୁଣି ଚେଷ୍ଟା କରିପାରିବେ, କିମ୍ବା ଏହା ବିନା ଜାରି ରଖିବାକୁ ସେଭ୍ କରନ୍ତୁ।</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ ସେଲ୍ ଏକୀକରଣ ଇନ୍‌ଷ୍ଟଲ୍ କରିବାରେ ବିଫଳ। ତ୍ରୁଟି ଚିହ୍ନଟ ବନ୍ଦ କରାଯାଇଛି। ଆପଣ ଏହାକୁ ପୁଣି ସକ୍ରିୟ କରି ପୁଣି ଚେଷ୍ଟା କରିପାରିବେ, କିମ୍ବା ଏହା ବିନା ଜାରି ରଖିବାକୁ ସେଭ୍ କରନ୍ତୁ।</value>
+    <value>ସେଲ୍ ଏକୀକରଣ ଇନ୍‌ଷ୍ଟଲ୍ କରିବାରେ ବିଫଳ। ତ୍ରୁଟି ଚିହ୍ନଟ ବନ୍ଦ କରାଯାଇଛି। ଆପଣ ଏହାକୁ ପୁଣି ସକ୍ରିୟ କରି ପୁଣି ଚେଷ୍ଟା କରିପାରିବେ, କିମ୍ବା ଏହା ବିନା ଜାରି ରଖିବାକୁ ସେଭ୍ କରନ୍ତୁ।</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell କାର୍ଯ୍ୟକାରୀ ନୀତି ସ୍କ୍ରିପ୍ଟ୍‌କୁ ଅବରୋଧ କରୁଛି। ତ୍ରୁଟି ଚିହ୍ନଟ ବନ୍ଦ କରାଗଲା।</value>
+    <value>PowerShell କାର୍ଯ୍ୟକାରୀ ନୀତି ସ୍କ୍ରିପ୍ଟ୍‌କୁ ଅବରୋଧ କରୁଛି। ତ୍ରୁଟି ଚିହ୍ନଟ ବନ୍ଦ କରାଗଲା।</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) ଇନ୍‌ଷ୍ଟଲ୍ ହୋଇନାହିଁ କିମ୍ବା ଉପଲବ୍ଧ ନୁହେଁ। ପ୍ରଥମେ ଏହାକୁ ଇନ୍‌ଷ୍ଟଲ୍ କରନ୍ତୁ, ତାପରେ ପୁଣି ଚେଷ୍ଟା କରନ୍ତୁ।</value>
+    <value>Windows Package Manager (winget) ଇନ୍‌ଷ୍ଟଲ୍ ହୋଇନାହିଁ କିମ୍ବା ଉପଲବ୍ଧ ନୁହେଁ। ପ୍ରଥମେ ଏହାକୁ ଇନ୍‌ଷ୍ଟଲ୍ କରନ୍ତୁ, ତାପରେ ପୁଣି ଚେଷ୍ଟା କରନ୍ତୁ।</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pa-IN/Resources.resw
@@ -223,50 +223,50 @@
     <value>ਸੈੱਟ ਅੱਪ ਹੋ ਰਿਹਾ ਹੈ...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager ਨੀਤੀ ਦੁਆਰਾ {0} ਦੀ ਇੰਸਟਾਲੇਸ਼ਨ ਬਲੌਕ ਕੀਤੀ ਗਈ। ਜੇਕਰ ਤੁਸੀਂ ਪ੍ਰਬੰਧਿਤ ਡਿਵਾਈਸ 'ਤੇ ਹੋ, ਤਾਂ ਆਪਣੇ IT ਐਡਮਿਨ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।</value>
+    <value>Windows Package Manager ਨੀਤੀ ਦੁਆਰਾ {0} ਦੀ ਇੰਸਟਾਲੇਸ਼ਨ ਬਲੌਕ ਕੀਤੀ ਗਈ। ਜੇਕਰ ਤੁਸੀਂ ਪ੍ਰਬੰਧਿਤ ਡਿਵਾਈਸ 'ਤੇ ਹੋ, ਤਾਂ ਆਪਣੇ IT ਐਡਮਿਨ ਨਾਲ ਸੰਪਰਕ ਕਰੋ।</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} ਇੰਸਟਾਲ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ (ਗਲਤੀ ਕੋਡ {1})। ਵੇਰਵਿਆਂ ਲਈ ਲੌਗ ਵੇਖੋ, ਜਾਂ {0} ਨੂੰ ਮੈਨੂਅਲੀ ਇੰਸਟਾਲ ਕਰੋ।</value>
+    <value>{0} ਇੰਸਟਾਲ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ (ਗਲਤੀ ਕੋਡ {1})। ਵੇਰਵਿਆਂ ਲਈ ਲੌਗ ਵੇਖੋ, ਜਾਂ {0} ਨੂੰ ਮੈਨੂਅਲੀ ਇੰਸਟਾਲ ਕਰੋ।</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} ਇੰਸਟਾਲ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ। ਵੇਰਵਿਆਂ ਲਈ ਲੌਗ ਵੇਖੋ, ਜਾਂ {0} ਨੂੰ ਮੈਨੂਅਲੀ ਇੰਸਟਾਲ ਕਰੋ।</value>
+    <value>{0} ਇੰਸਟਾਲ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਿਆ। ਵੇਰਵਿਆਂ ਲਈ ਲੌਗ ਵੇਖੋ, ਜਾਂ {0} ਨੂੰ ਮੈਨੂਅਲੀ ਇੰਸਟਾਲ ਕਰੋ।</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} ਇੰਸਟਾਲਰ ਨੇ ਗਲਤੀ ਰਿਪੋਰਟ ਕੀਤੀ (ਕੋਡ {1})। ਵੇਰਵਿਆਂ ਲਈ ਲੌਗ ਜਾਂਚੋ, ਜਾਂ {0} ਨੂੰ ਮੈਨੂਅਲੀ ਇੰਸਟਾਲ ਕਰੋ।</value>
+    <value>{0} ਇੰਸਟਾਲਰ ਨੇ ਗਲਤੀ ਰਿਪੋਰਟ ਕੀਤੀ (ਕੋਡ {1})। ਵੇਰਵਿਆਂ ਲਈ ਲੌਗ ਜਾਂਚੋ, ਜਾਂ {0} ਨੂੰ ਮੈਨੂਅਲੀ ਇੰਸਟਾਲ ਕਰੋ।</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} ਇੰਸਟਾਲ ਕਰਦੇ ਸਮੇਂ Windows Package Manager ਤੱਕ ਨਹੀਂ ਪਹੁੰਚਿਆ ਜਾ ਸਕਿਆ। ਆਪਣਾ ਇੰਟਰਨੈੱਟ ਕਨੈਕਸ਼ਨ ਜਾਂਚੋ (VPN, proxy ਜਾਂ firewall ਇਸਨੂੰ ਬਲੌਕ ਕਰ ਸਕਦੇ ਹਨ) ਅਤੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।</value>
+    <value>{0} ਇੰਸਟਾਲ ਕਰਦੇ ਸਮੇਂ Windows Package Manager ਤੱਕ ਨਹੀਂ ਪਹੁੰਚਿਆ ਜਾ ਸਕਿਆ। ਆਪਣਾ ਇੰਟਰਨੈੱਟ ਕਨੈਕਸ਼ਨ ਜਾਂਚੋ (VPN, proxy ਜਾਂ firewall ਇਸਨੂੰ ਬਲੌਕ ਕਰ ਸਕਦੇ ਹਨ) ਅਤੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ ਇਸ ਸਿਸਟਮ 'ਤੇ {0} ਲਈ ਕੋਈ ਅਨੁਕੂਲ ਇੰਸਟਾਲਰ ਉਪਲਬਧ ਨਹੀਂ ਹੈ (OS ਵਰਜਨ ਜਾਂ ਆਰਕੀਟੈਕਚਰ ਸਮਰਥਿਤ ਨਹੀਂ ਹੋ ਸਕਦਾ)। {0} ਨੂੰ ਮੈਨੂਅਲੀ ਇੰਸਟਾਲ ਕਰੋ।</value>
+    <value>ਇਸ ਸਿਸਟਮ 'ਤੇ {0} ਲਈ ਕੋਈ ਅਨੁਕੂਲ ਇੰਸਟਾਲਰ ਉਪਲਬਧ ਨਹੀਂ ਹੈ (OS ਵਰਜਨ ਜਾਂ ਆਰਕੀਟੈਕਚਰ ਸਮਰਥਿਤ ਨਹੀਂ ਹੋ ਸਕਦਾ)। {0} ਨੂੰ ਮੈਨੂਅਲੀ ਇੰਸਟਾਲ ਕਰੋ।</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager ਕੈਟਾਲੌਗ ਵਿੱਚ {0} ਨਹੀਂ ਮਿਲਿਆ। winget ਸਰੋਤਾਂ ਨੂੰ ਰਿਫ੍ਰੈਸ਼ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ, ਜਾਂ {0} ਨੂੰ ਮੈਨੂਅਲੀ ਇੰਸਟਾਲ ਕਰੋ।</value>
+    <value>Windows Package Manager ਕੈਟਾਲੌਗ ਵਿੱਚ {0} ਨਹੀਂ ਮਿਲਿਆ। winget ਸਰੋਤਾਂ ਨੂੰ ਰਿਫ੍ਰੈਸ਼ ਕਰਨ ਦੀ ਕੋਸ਼ਿਸ਼ ਕਰੋ, ਜਾਂ {0} ਨੂੰ ਮੈਨੂਅਲੀ ਇੰਸਟਾਲ ਕਰੋ।</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} ਇੰਸਟਾਲ ਕਰਨ ਵਿੱਚ 20 ਮਿੰਟ ਤੋਂ ਵੱਧ ਸਮਾਂ ਲੱਗਿਆ। Intelligent Terminal ਨੇ ਉਡੀਕ ਕਰਨੀ ਬੰਦ ਕਰ ਦਿੱਤੀ, ਪਰ ਇੰਸਟਾਲਰ ਹਾਲੇ ਵੀ ਬੈਕਗ੍ਰਾਊਂਡ ਵਿੱਚ ਚੱਲ ਰਿਹਾ ਹੋ ਸਕਦਾ ਹੈ। Task Manager ਜਾਂਚੋ, ਜਾਂ ਬਾਅਦ ਵਿੱਚ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।</value>
+    <value>{0} ਇੰਸਟਾਲ ਕਰਨ ਵਿੱਚ 20 ਮਿੰਟ ਤੋਂ ਵੱਧ ਸਮਾਂ ਲੱਗਿਆ। Intelligent Terminal ਨੇ ਉਡੀਕ ਕਰਨੀ ਬੰਦ ਕਰ ਦਿੱਤੀ, ਪਰ ਇੰਸਟਾਲਰ ਹਾਲੇ ਵੀ ਬੈਕਗ੍ਰਾਊਂਡ ਵਿੱਚ ਚੱਲ ਰਿਹਾ ਹੋ ਸਕਦਾ ਹੈ। Task Manager ਜਾਂਚੋ, ਜਾਂ ਬਾਅਦ ਵਿੱਚ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks ਇੰਸਟਾਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ। ਸੈਸ਼ਨ ਪ੍ਰਬੰਧਨ ਬੰਦ ਕਰ ਦਿੱਤਾ ਗਿਆ ਹੈ। ਤੁਸੀਂ ਇਸਨੂੰ ਦੁਬਾਰਾ ਚਾਲੂ ਕਰ ਸਕਦੇ ਹੋ ਅਤੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰ ਸਕਦੇ ਹੋ, ਜਾਂ ਇਸ ਤੋਂ ਬਿਨਾਂ ਜਾਰੀ ਰੱਖਣ ਲਈ ਸੇਵ ਕਰੋ।</value>
+    <value>session hooks ਇੰਸਟਾਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ। ਸੈਸ਼ਨ ਪ੍ਰਬੰਧਨ ਬੰਦ ਕਰ ਦਿੱਤਾ ਗਿਆ ਹੈ। ਤੁਸੀਂ ਇਸਨੂੰ ਦੁਬਾਰਾ ਚਾਲੂ ਕਰ ਸਕਦੇ ਹੋ ਅਤੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰ ਸਕਦੇ ਹੋ, ਜਾਂ ਇਸ ਤੋਂ ਬਿਨਾਂ ਜਾਰੀ ਰੱਖਣ ਲਈ ਸੇਵ ਕਰੋ।</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ ਸ਼ੈੱਲ ਏਕੀਕਰਣ ਇੰਸਟਾਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ। ਗਲਤੀ ਖੋਜ ਬੰਦ ਕਰ ਦਿੱਤੀ ਗਈ ਹੈ। ਤੁਸੀਂ ਇਸਨੂੰ ਦੁਬਾਰਾ ਚਾਲੂ ਕਰ ਸਕਦੇ ਹੋ ਅਤੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰ ਸਕਦੇ ਹੋ, ਜਾਂ ਇਸ ਤੋਂ ਬਿਨਾਂ ਜਾਰੀ ਰੱਖਣ ਲਈ ਸੇਵ ਕਰੋ।</value>
+    <value>ਸ਼ੈੱਲ ਏਕੀਕਰਣ ਇੰਸਟਾਲ ਕਰਨ ਵਿੱਚ ਅਸਫਲ। ਗਲਤੀ ਖੋਜ ਬੰਦ ਕਰ ਦਿੱਤੀ ਗਈ ਹੈ। ਤੁਸੀਂ ਇਸਨੂੰ ਦੁਬਾਰਾ ਚਾਲੂ ਕਰ ਸਕਦੇ ਹੋ ਅਤੇ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰ ਸਕਦੇ ਹੋ, ਜਾਂ ਇਸ ਤੋਂ ਬਿਨਾਂ ਜਾਰੀ ਰੱਖਣ ਲਈ ਸੇਵ ਕਰੋ।</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell ਐਗਜ਼ੀਕਿਊਸ਼ਨ ਨੀਤੀ ਸਕ੍ਰਿਪਟਾਂ ਨੂੰ ਬਲੌਕ ਕਰ ਰਹੀ ਹੈ। ਗਲਤੀ ਖੋਜ ਬੰਦ ਕਰ ਦਿੱਤੀ।</value>
+    <value>PowerShell ਐਗਜ਼ੀਕਿਊਸ਼ਨ ਨੀਤੀ ਸਕ੍ਰਿਪਟਾਂ ਨੂੰ ਬਲੌਕ ਕਰ ਰਹੀ ਹੈ। ਗਲਤੀ ਖੋਜ ਬੰਦ ਕਰ ਦਿੱਤੀ।</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) ਇੰਸਟਾਲ ਨਹੀਂ ਹੈ ਜਾਂ ਉਪਲਬਧ ਨਹੀਂ ਹੈ। ਪਹਿਲਾਂ ਇਸਨੂੰ ਇੰਸਟਾਲ ਕਰੋ, ਫਿਰ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।</value>
+    <value>Windows Package Manager (winget) ਇੰਸਟਾਲ ਨਹੀਂ ਹੈ ਜਾਂ ਉਪਲਬਧ ਨਹੀਂ ਹੈ। ਪਹਿਲਾਂ ਇਸਨੂੰ ਇੰਸਟਾਲ ਕਰੋ, ਫਿਰ ਦੁਬਾਰਾ ਕੋਸ਼ਿਸ਼ ਕਰੋ।</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pl-PL/Resources.resw
@@ -223,39 +223,39 @@
     <value>Konfigurowanie...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Instalacja {0} została zablokowana przez zasady Menedżera pakietów systemu Windows. Jeśli używasz urządzenia zarządzanego, skontaktuj się z administratorem IT.</value>
+    <value>Instalacja {0} została zablokowana przez zasady Menedżera pakietów systemu Windows. Jeśli używasz urządzenia zarządzanego, skontaktuj się z administratorem IT.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Nie udało się zainstalować {0} (kod błędu {1}). Szczegóły znajdziesz w dzienniku albo zainstaluj {0} ręcznie.</value>
+    <value>Nie udało się zainstalować {0} (kod błędu {1}). Szczegóły znajdziesz w dzienniku albo zainstaluj {0} ręcznie.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Nie udało się zainstalować {0}. Szczegóły znajdziesz w dzienniku albo zainstaluj {0} ręcznie.</value>
+    <value>Nie udało się zainstalować {0}. Szczegóły znajdziesz w dzienniku albo zainstaluj {0} ręcznie.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Instalator {0} zgłosił błąd (kod {1}). Szczegóły znajdziesz w dzienniku albo zainstaluj {0} ręcznie.</value>
+    <value>Instalator {0} zgłosił błąd (kod {1}). Szczegóły znajdziesz w dzienniku albo zainstaluj {0} ręcznie.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Nie udało się połączyć z Menedżerem pakietów systemu Windows podczas instalowania {0}. Sprawdź połączenie internetowe (VPN, serwer proxy lub zapora mogą je blokować) i spróbuj ponownie.</value>
+    <value>Nie udało się połączyć z Menedżerem pakietów systemu Windows podczas instalowania {0}. Sprawdź połączenie internetowe (VPN, serwer proxy lub zapora mogą je blokować) i spróbuj ponownie.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Na tym systemie nie jest dostępny zgodny instalator dla {0} (wersja systemu operacyjnego lub architektura może nie być obsługiwana). Zainstaluj {0} ręcznie.</value>
+    <value>Na tym systemie nie jest dostępny zgodny instalator dla {0} (wersja systemu operacyjnego lub architektura może nie być obsługiwana). Zainstaluj {0} ręcznie.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Nie znaleziono {0} w katalogu Menedżera pakietów systemu Windows. Spróbuj odświeżyć źródła winget albo zainstaluj {0} ręcznie.</value>
+    <value>Nie znaleziono {0} w katalogu Menedżera pakietów systemu Windows. Spróbuj odświeżyć źródła winget albo zainstaluj {0} ręcznie.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Instalowanie {0} trwało dłużej niż 20 minut. Intelligent Terminal przestał czekać, ale instalator może nadal działać w tle. Sprawdź Task Manager albo spróbuj ponownie później.</value>
+    <value>Instalowanie {0} trwało dłużej niż 20 minut. Intelligent Terminal przestał czekać, ale instalator może nadal działać w tle. Sprawdź Task Manager albo spróbuj ponownie później.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Menedżer pakietów systemu Windows (winget) nie jest zainstalowany lub nie jest dostępny. Najpierw go zainstaluj, a następnie spróbuj ponownie.</value>
+    <value>Menedżer pakietów systemu Windows (winget) nie jest zainstalowany lub nie jest dostępny. Najpierw go zainstaluj, a następnie spróbuj ponownie.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>Zezwól aplikacji Intelligent Terminal na dostęp do powłoki i automatyczne wykrywanie błędów.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Nie udało się zainstalować integracji powłoki. Wykrywanie błędów zostało wyłączone. Możesz je ponownie włączyć i spróbować ponownie lub zapisać, aby kontynuować bez nich.</value>
+    <value>Nie udało się zainstalować integracji powłoki. Wykrywanie błędów zostało wyłączone. Możesz je ponownie włączyć i spróbować ponownie lub zapisać, aby kontynuować bez nich.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Nie udało się zainstalować session hooks. Zarządzanie sesjami zostało wyłączone. Możesz je ponownie włączyć i spróbować ponownie lub zapisać, aby kontynuować bez nich.</value>
+    <value>Nie udało się zainstalować session hooks. Zarządzanie sesjami zostało wyłączone. Możesz je ponownie włączyć i spróbować ponownie lub zapisać, aby kontynuować bez nich.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Dowiedz się, jak to ręcznie naprawić</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Zasady wykonywania programu PowerShell blokują skrypty. Wykrywanie błędów wyłączone.</value>
+    <value>Zasady wykonywania programu PowerShell blokują skrypty. Wykrywanie błędów wyłączone.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Użycie</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-BR/Resources.resw
@@ -1141,39 +1141,39 @@
     <value>Configurando...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ A instalação de {0} foi bloqueada por uma política do Gerenciador de Pacotes do Windows. Se você estiver em um dispositivo gerenciado, entre em contato com seu administrador de TI.</value>
+    <value>A instalação de {0} foi bloqueada por uma política do Gerenciador de Pacotes do Windows. Se você estiver em um dispositivo gerenciado, entre em contato com seu administrador de TI.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Não foi possível instalar {0} (código de erro {1}). Confira o log para obter detalhes ou instale {0} manualmente.</value>
+    <value>Não foi possível instalar {0} (código de erro {1}). Confira o log para obter detalhes ou instale {0} manualmente.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Não foi possível instalar {0}. Confira o log para obter detalhes ou instale {0} manualmente.</value>
+    <value>Não foi possível instalar {0}. Confira o log para obter detalhes ou instale {0} manualmente.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ O instalador de {0} relatou um erro (código {1}). Confira o log para obter detalhes ou instale {0} manualmente.</value>
+    <value>O instalador de {0} relatou um erro (código {1}). Confira o log para obter detalhes ou instale {0} manualmente.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Não foi possível acessar o Gerenciador de Pacotes do Windows ao instalar {0}. Verifique sua conexão com a Internet (VPN, proxy ou firewall podem estar bloqueando) e tente novamente.</value>
+    <value>Não foi possível acessar o Gerenciador de Pacotes do Windows ao instalar {0}. Verifique sua conexão com a Internet (VPN, proxy ou firewall podem estar bloqueando) e tente novamente.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Nenhum instalador compatível para {0} está disponível neste sistema (talvez a versão do sistema operacional ou a arquitetura não tenha suporte). Instale {0} manualmente.</value>
+    <value>Nenhum instalador compatível para {0} está disponível neste sistema (talvez a versão do sistema operacional ou a arquitetura não tenha suporte). Instale {0} manualmente.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} não foi encontrado no catálogo do Gerenciador de Pacotes do Windows. Tente atualizar as fontes do winget ou instale {0} manualmente.</value>
+    <value>{0} não foi encontrado no catálogo do Gerenciador de Pacotes do Windows. Tente atualizar as fontes do winget ou instale {0} manualmente.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ A instalação de {0} levou mais de 20 minutos. Intelligent Terminal parou de aguardar, mas o instalador ainda pode estar em execução em segundo plano. Verifique Task Manager ou tente novamente mais tarde.</value>
+    <value>A instalação de {0} levou mais de 20 minutos. Intelligent Terminal parou de aguardar, mas o instalador ainda pode estar em execução em segundo plano. Verifique Task Manager ou tente novamente mais tarde.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ O Gerenciador de Pacotes do Windows (winget) não está instalado ou não está disponível. Instale-o primeiro e tente novamente.</value>
+    <value>O Gerenciador de Pacotes do Windows (winget) não está instalado ou não está disponível. Instale-o primeiro e tente novamente.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1185,11 +1185,11 @@
     <comment>{Locked="Node.js","LTS"} Product display name substituted into the FreOverlay_InstallError_* templates when reporting a winget install failure for the Node.js prerequisite.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Falha ao instalar os hooks de sessão. O gerenciamento de sessões foi desativado. Você pode reativá-lo e tentar novamente, ou salvar para continuar sem ele.</value>
+    <value>Falha ao instalar os hooks de sessão. O gerenciamento de sessões foi desativado. Você pode reativá-lo e tentar novamente, ou salvar para continuar sem ele.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Falha ao instalar a integração do shell. A detecção de erros foi desativada. Você pode reativá-la e tentar novamente, ou salvar para continuar sem ela.</value>
+    <value>Falha ao instalar a integração do shell. A detecção de erros foi desativada. Você pode reativá-la e tentar novamente, ou salvar para continuar sem ela.</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Saiba como corrigir isso manualmente</value>
@@ -1298,7 +1298,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ A política de execução do PowerShell está bloqueando scripts. Detecção de erros desativada.</value>
+    <value>A política de execução do PowerShell está bloqueando scripts. Detecção de erros desativada.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Uso</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/pt-PT/Resources.resw
@@ -218,39 +218,39 @@
     <value>A configurar...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ A instalação de {0} foi bloqueada por uma política do Gestor de Pacotes do Windows. Se estiver num dispositivo gerido, contacte o seu administrador de TI.</value>
+    <value>A instalação de {0} foi bloqueada por uma política do Gestor de Pacotes do Windows. Se estiver num dispositivo gerido, contacte o seu administrador de TI.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Não foi possível instalar {0} (código de erro {1}). Consulte o registo para obter detalhes, ou instale {0} manualmente.</value>
+    <value>Não foi possível instalar {0} (código de erro {1}). Consulte o registo para obter detalhes, ou instale {0} manualmente.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Não foi possível instalar {0}. Consulte o registo para obter detalhes, ou instale {0} manualmente.</value>
+    <value>Não foi possível instalar {0}. Consulte o registo para obter detalhes, ou instale {0} manualmente.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ O instalador de {0} comunicou um erro (código {1}). Consulte o registo para obter detalhes, ou instale {0} manualmente.</value>
+    <value>O instalador de {0} comunicou um erro (código {1}). Consulte o registo para obter detalhes, ou instale {0} manualmente.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Não foi possível aceder ao Gestor de Pacotes do Windows ao instalar {0}. Verifique a sua ligação à Internet (VPN, proxy ou firewall podem estar a bloquear) e tente novamente.</value>
+    <value>Não foi possível aceder ao Gestor de Pacotes do Windows ao instalar {0}. Verifique a sua ligação à Internet (VPN, proxy ou firewall podem estar a bloquear) e tente novamente.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Nenhum instalador compatível para {0} está disponível neste sistema (a versão do sistema operativo ou a arquitetura poderá não ser suportada). Instale {0} manualmente.</value>
+    <value>Nenhum instalador compatível para {0} está disponível neste sistema (a versão do sistema operativo ou a arquitetura poderá não ser suportada). Instale {0} manualmente.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} não foi encontrado no catálogo do Gestor de Pacotes do Windows. Tente atualizar as origens do winget, ou instale {0} manualmente.</value>
+    <value>{0} não foi encontrado no catálogo do Gestor de Pacotes do Windows. Tente atualizar as origens do winget, ou instale {0} manualmente.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ A instalação de {0} demorou mais de 20 minutos. Intelligent Terminal deixou de aguardar, mas o instalador poderá ainda estar em execução em segundo plano. Consulte Task Manager, ou tente novamente mais tarde.</value>
+    <value>A instalação de {0} demorou mais de 20 minutos. Intelligent Terminal deixou de aguardar, mas o instalador poderá ainda estar em execução em segundo plano. Consulte Task Manager, ou tente novamente mais tarde.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ O Gestor de Pacotes do Windows (winget) não está instalado ou não está disponível. Instale-o primeiro e tente novamente.</value>
+    <value>O Gestor de Pacotes do Windows (winget) não está instalado ou não está disponível. Instale-o primeiro e tente novamente.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -342,9 +342,9 @@
     <value>Permita que o Intelligent Terminal aceda à shell e detete erros automaticamente.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Falha ao instalar a integração da shell. A deteção de erros foi desativada. Pode reativá-la e tentar novamente, ou guardar para continuar sem ela.</value>
+    <value>Falha ao instalar a integração da shell. A deteção de erros foi desativada. Pode reativá-la e tentar novamente, ou guardar para continuar sem ela.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Falha ao instalar os hooks de sessão. A gestão de sessões foi desativada. Pode reativá-la e tentar novamente, ou guardar para continuar sem ela.</value>
+    <value>Falha ao instalar os hooks de sessão. A gestão de sessões foi desativada. Pode reativá-la e tentar novamente, ou guardar para continuar sem ela.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Saiba como corrigir isto manualmente</value>
@@ -360,7 +360,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ A política de execução do PowerShell está a bloquear scripts. Deteção de erros desativada.</value>
+    <value>A política de execução do PowerShell está a bloquear scripts. Deteção de erros desativada.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Utilização</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploc/Resources.resw
@@ -1110,39 +1110,39 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Setting up...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Installation of {0} was blocked by a Windows Package Manager policy. If you're on a managed device, contact your IT admin.</value>
+    <value>Installation of {0} was blocked by a Windows Package Manager policy. If you're on a managed device, contact your IT admin.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Couldn't install {0} (error code {1}). See the log for details, or install {0} manually.</value>
+    <value>Couldn't install {0} (error code {1}). See the log for details, or install {0} manually.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Couldn't install {0}. See the log for details, or install {0} manually.</value>
+    <value>Couldn't install {0}. See the log for details, or install {0} manually.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ The {0} installer reported an error (code {1}). Check the log for details, or install {0} manually.</value>
+    <value>The {0} installer reported an error (code {1}). Check the log for details, or install {0} manually.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Couldn't reach the Windows Package Manager while installing {0}. Check your internet connection (VPN, proxy, or firewall may be blocking it) and try again.</value>
+    <value>Couldn't reach the Windows Package Manager while installing {0}. Check your internet connection (VPN, proxy, or firewall may be blocking it) and try again.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ No compatible installer for {0} is available on this system (OS version or architecture may not be supported). Install {0} manually.</value>
+    <value>No compatible installer for {0} is available on this system (OS version or architecture may not be supported). Install {0} manually.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} wasn't found in the Windows Package Manager catalog. Try refreshing winget sources, or install {0} manually.</value>
+    <value>{0} wasn't found in the Windows Package Manager catalog. Try refreshing winget sources, or install {0} manually.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Installing {0} took longer than 20 minutes. Intelligent Terminal stopped waiting, but the installer may still be running in the background. Check Task Manager, or try again later.</value>
+    <value>Installing {0} took longer than 20 minutes. Intelligent Terminal stopped waiting, but the installer may still be running in the background. Check Task Manager, or try again later.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) is not installed or not available. Install it first, then try again.</value>
+    <value>Windows Package Manager (winget) is not installed or not available. Install it first, then try again.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1154,11 +1154,11 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>{Locked="Node.js","LTS"} Product display name substituted into the FRE install error templates when reporting a winget install failure for the Node.js prerequisite.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Failed to install session hooks. Session management has been turned off. You can re-enable it and try again, or save to continue without it.</value>
+    <value>Failed to install session hooks. Session management has been turned off. You can re-enable it and try again, or save to continue without it.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Failed to install shell integration. Error detection has been turned off. You can re-enable it and try again, or save to continue without it.</value>
+    <value>Failed to install shell integration. Error detection has been turned off. You can re-enable it and try again, or save to continue without it.</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Learn how to fix this manually</value>
@@ -1267,7 +1267,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell execution policy is blocking scripts. Error detection turned off.</value>
+    <value>PowerShell execution policy is blocking scripts. Error detection turned off.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Usage</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-ploca/Resources.resw
@@ -1110,39 +1110,39 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Setting up...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Installation of {0} was blocked by a Windows Package Manager policy. If you're on a managed device, contact your IT admin.</value>
+    <value>Installation of {0} was blocked by a Windows Package Manager policy. If you're on a managed device, contact your IT admin.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Couldn't install {0} (error code {1}). See the log for details, or install {0} manually.</value>
+    <value>Couldn't install {0} (error code {1}). See the log for details, or install {0} manually.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Couldn't install {0}. See the log for details, or install {0} manually.</value>
+    <value>Couldn't install {0}. See the log for details, or install {0} manually.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ The {0} installer reported an error (code {1}). Check the log for details, or install {0} manually.</value>
+    <value>The {0} installer reported an error (code {1}). Check the log for details, or install {0} manually.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Couldn't reach the Windows Package Manager while installing {0}. Check your internet connection (VPN, proxy, or firewall may be blocking it) and try again.</value>
+    <value>Couldn't reach the Windows Package Manager while installing {0}. Check your internet connection (VPN, proxy, or firewall may be blocking it) and try again.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ No compatible installer for {0} is available on this system (OS version or architecture may not be supported). Install {0} manually.</value>
+    <value>No compatible installer for {0} is available on this system (OS version or architecture may not be supported). Install {0} manually.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} wasn't found in the Windows Package Manager catalog. Try refreshing winget sources, or install {0} manually.</value>
+    <value>{0} wasn't found in the Windows Package Manager catalog. Try refreshing winget sources, or install {0} manually.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Installing {0} took longer than 20 minutes. Intelligent Terminal stopped waiting, but the installer may still be running in the background. Check Task Manager, or try again later.</value>
+    <value>Installing {0} took longer than 20 minutes. Intelligent Terminal stopped waiting, but the installer may still be running in the background. Check Task Manager, or try again later.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) is not installed or not available. Install it first, then try again.</value>
+    <value>Windows Package Manager (winget) is not installed or not available. Install it first, then try again.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1154,11 +1154,11 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>{Locked="Node.js","LTS"} Product display name substituted into the FRE install error templates when reporting a winget install failure for the Node.js prerequisite.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Failed to install session hooks. Session management has been turned off. You can re-enable it and try again, or save to continue without it.</value>
+    <value>Failed to install session hooks. Session management has been turned off. You can re-enable it and try again, or save to continue without it.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Failed to install shell integration. Error detection has been turned off. You can re-enable it and try again, or save to continue without it.</value>
+    <value>Failed to install shell integration. Error detection has been turned off. You can re-enable it and try again, or save to continue without it.</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Learn how to fix this manually</value>
@@ -1267,7 +1267,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell execution policy is blocking scripts. Error detection turned off.</value>
+    <value>PowerShell execution policy is blocking scripts. Error detection turned off.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Usage</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/qps-plocm/Resources.resw
@@ -1110,39 +1110,39 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Setting up...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Installation of {0} was blocked by a Windows Package Manager policy. If you're on a managed device, contact your IT admin.</value>
+    <value>Installation of {0} was blocked by a Windows Package Manager policy. If you're on a managed device, contact your IT admin.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Couldn't install {0} (error code {1}). See the log for details, or install {0} manually.</value>
+    <value>Couldn't install {0} (error code {1}). See the log for details, or install {0} manually.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Couldn't install {0}. See the log for details, or install {0} manually.</value>
+    <value>Couldn't install {0}. See the log for details, or install {0} manually.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ The {0} installer reported an error (code {1}). Check the log for details, or install {0} manually.</value>
+    <value>The {0} installer reported an error (code {1}). Check the log for details, or install {0} manually.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Couldn't reach the Windows Package Manager while installing {0}. Check your internet connection (VPN, proxy, or firewall may be blocking it) and try again.</value>
+    <value>Couldn't reach the Windows Package Manager while installing {0}. Check your internet connection (VPN, proxy, or firewall may be blocking it) and try again.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ No compatible installer for {0} is available on this system (OS version or architecture may not be supported). Install {0} manually.</value>
+    <value>No compatible installer for {0} is available on this system (OS version or architecture may not be supported). Install {0} manually.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} wasn't found in the Windows Package Manager catalog. Try refreshing winget sources, or install {0} manually.</value>
+    <value>{0} wasn't found in the Windows Package Manager catalog. Try refreshing winget sources, or install {0} manually.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Installing {0} took longer than 20 minutes. Intelligent Terminal stopped waiting, but the installer may still be running in the background. Check Task Manager, or try again later.</value>
+    <value>Installing {0} took longer than 20 minutes. Intelligent Terminal stopped waiting, but the installer may still be running in the background. Check Task Manager, or try again later.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) is not installed or not available. Install it first, then try again.</value>
+    <value>Windows Package Manager (winget) is not installed or not available. Install it first, then try again.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1154,11 +1154,11 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>{Locked="Node.js","LTS"} Product display name substituted into the FRE install error templates when reporting a winget install failure for the Node.js prerequisite.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Failed to install session hooks. Session management has been turned off. You can re-enable it and try again, or save to continue without it.</value>
+    <value>Failed to install session hooks. Session management has been turned off. You can re-enable it and try again, or save to continue without it.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Failed to install shell integration. Error detection has been turned off. You can re-enable it and try again, or save to continue without it.</value>
+    <value>Failed to install shell integration. Error detection has been turned off. You can re-enable it and try again, or save to continue without it.</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Learn how to fix this manually</value>
@@ -1267,7 +1267,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell execution policy is blocking scripts. Error detection turned off.</value>
+    <value>PowerShell execution policy is blocking scripts. Error detection turned off.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Usage</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/quz-PE/Resources.resw
@@ -110,39 +110,39 @@
     <value>Churachkan...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ {0} churay Windows Package Manager kamachiywan hark'asqa karqa. Kamachisqa dispositivopi kaspa, IT admin-niykiman rimay.</value>
+    <value>{0} churay Windows Package Manager kamachiywan hark'asqa karqa. Kamachisqa dispositivopi kaspa, IT admin-niykiman rimay.</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} mana churayta atirqanchu (pantay código {1}). Aswan sut'inkunapaq log nisqata qhaway, utaq {0} makillawan churay.</value>
+    <value>{0} mana churayta atirqanchu (pantay código {1}). Aswan sut'inkunapaq log nisqata qhaway, utaq {0} makillawan churay.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} mana churayta atirqanchu. Aswan sut'inkunapaq log nisqata qhaway, utaq {0} makillawan churay.</value>
+    <value>{0} mana churayta atirqanchu. Aswan sut'inkunapaq log nisqata qhaway, utaq {0} makillawan churay.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} installer pantayta willarqa (código {1}). Aswan sut'inkunapaq log nisqata qhaway, utaq {0} makillawan churay.</value>
+    <value>{0} installer pantayta willarqa (código {1}). Aswan sut'inkunapaq log nisqata qhaway, utaq {0} makillawan churay.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} churachkaspa Windows Package Manager-man mana chayakuyta atirqanchu. Internet tinkisqaykita qhaway (VPN, proxy utaq firewall hark'achkanman), chaymanta watiqmanta ruwarinapaq.</value>
+    <value>{0} churachkaspa Windows Package Manager-man mana chayakuyta atirqanchu. Internet tinkisqaykita qhaway (VPN, proxy utaq firewall hark'achkanman), chaymanta watiqmanta ruwarinapaq.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Kay sistemapi {0}paq tinkuq installer mana kachkanchu (OS version utaq architecture yanapasqa mana kanmanchu). {0} makillawan churay.</value>
+    <value>Kay sistemapi {0}paq tinkuq installer mana kachkanchu (OS version utaq architecture yanapasqa mana kanmanchu). {0} makillawan churay.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} Windows Package Manager catalog nisqapi mana tarikusqachu. Ñawpaqta winget sources nisqakunata musuqyachiy, utaq {0} makillawan churay.</value>
+    <value>{0} Windows Package Manager catalog nisqapi mana tarikusqachu. Ñawpaqta winget sources nisqakunata musuqyachiy, utaq {0} makillawan churay.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} churay 20 minutomanta aswan unayta apakurqa. Intelligent Terminal suyayta saqirqa, ichaqa installerqa qhipa llamk'aypi hina purichkanman. Task Manager qhaway, utaq qhipaman watiqmanta ruwariy.</value>
+    <value>{0} churay 20 minutomanta aswan unayta apakurqa. Intelligent Terminal suyayta saqirqa, ichaqa installerqa qhipa llamk'aypi hina purichkanman. Task Manager qhaway, utaq qhipaman watiqmanta ruwariy.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) mana churasqachu icha mana tarikuqchu. Ñawpaqta churaruy, chaymanta watiqmanta ruwarinapaq.</value>
+    <value>Windows Package Manager (winget) mana churasqachu icha mana tarikuqchu. Ñawpaqta churaruy, chaymanta watiqmanta ruwarinapaq.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -234,9 +234,9 @@
     <value>Intelligent Terminal-man saqiy shell-niykiman yaykunanpaq hinaspa pantasqakunata unaylla tarinanpaq.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Shell tinkiynin churay mana allinchu karqa. Pantay taripay wichqasqa karqa. Watiqmanta atichiy ruwarinapaq, utaq waqaychay mana paywan hina siginapaq.</value>
+    <value>Shell tinkiynin churay mana allinchu karqa. Pantay taripay wichqasqa karqa. Watiqmanta atichiy ruwarinapaq, utaq waqaychay mana paywan hina siginapaq.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Session hooks churay mana allinchu karqa. Sesión kamachiykuna wichqasqa karqa. Watiqmanta atichiy ruwarinapaq, utaq waqaychay mana paywan hina siginapaq.</value>
+    <value>Session hooks churay mana allinchu karqa. Sesión kamachiykuna wichqasqa karqa. Watiqmanta atichiy ruwarinapaq, utaq waqaychay mana paywan hina siginapaq.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Kayta makillawan imayna allichanaykita yachay</value>
@@ -252,7 +252,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell ruwana kamachiy script-kunata hark'achkan. Pantay taripay wichqasqa.</value>
+    <value>PowerShell ruwana kamachiy script-kunata hark'achkan. Pantay taripay wichqasqa.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Llamk'achiy</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ro-RO/Resources.resw
@@ -223,39 +223,39 @@
     <value>Se configurează...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Instalarea {0} a fost blocată de o politică a Managerului de pachete Windows. Dacă sunteți pe un dispozitiv gestionat, contactați administratorul IT.</value>
+    <value>Instalarea {0} a fost blocată de o politică a Managerului de pachete Windows. Dacă sunteți pe un dispozitiv gestionat, contactați administratorul IT.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Nu s-a putut instala {0} (cod de eroare {1}). Consultați jurnalul pentru detalii sau instalați {0} manual.</value>
+    <value>Nu s-a putut instala {0} (cod de eroare {1}). Consultați jurnalul pentru detalii sau instalați {0} manual.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Nu s-a putut instala {0}. Consultați jurnalul pentru detalii sau instalați {0} manual.</value>
+    <value>Nu s-a putut instala {0}. Consultați jurnalul pentru detalii sau instalați {0} manual.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Programul de instalare pentru {0} a raportat o eroare (cod {1}). Consultați jurnalul pentru detalii sau instalați {0} manual.</value>
+    <value>Programul de instalare pentru {0} a raportat o eroare (cod {1}). Consultați jurnalul pentru detalii sau instalați {0} manual.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Nu s-a putut contacta Managerul de pachete Windows în timpul instalării {0}. Verificați conexiunea la internet (VPN, proxy sau firewall o pot bloca) și încercați din nou.</value>
+    <value>Nu s-a putut contacta Managerul de pachete Windows în timpul instalării {0}. Verificați conexiunea la internet (VPN, proxy sau firewall o pot bloca) și încercați din nou.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Nu este disponibil niciun program de instalare compatibil pentru {0} pe acest sistem (este posibil ca versiunea sistemului de operare sau arhitectura să nu fie acceptată). Instalați {0} manual.</value>
+    <value>Nu este disponibil niciun program de instalare compatibil pentru {0} pe acest sistem (este posibil ca versiunea sistemului de operare sau arhitectura să nu fie acceptată). Instalați {0} manual.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} nu a fost găsit în catalogul Managerului de pachete Windows. Încercați să reîmprospătați sursele winget sau instalați {0} manual.</value>
+    <value>{0} nu a fost găsit în catalogul Managerului de pachete Windows. Încercați să reîmprospătați sursele winget sau instalați {0} manual.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Instalarea {0} a durat mai mult de 20 de minute. Intelligent Terminal a încetat să mai aștepte, dar programul de instalare poate rula încă în fundal. Verificați Task Manager sau încercați din nou mai târziu.</value>
+    <value>Instalarea {0} a durat mai mult de 20 de minute. Intelligent Terminal a încetat să mai aștepte, dar programul de instalare poate rula încă în fundal. Verificați Task Manager sau încercați din nou mai târziu.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Managerul de pachete Windows (winget) nu este instalat sau nu este disponibil. Instalați-l mai întâi, apoi încercați din nou.</value>
+    <value>Managerul de pachete Windows (winget) nu este instalat sau nu este disponibil. Instalați-l mai întâi, apoi încercați din nou.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -347,9 +347,9 @@
     <value>Permiteți Intelligent Terminal să acceseze shell-ul și să detecteze automat erorile.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Instalarea integrării shell a eșuat. Detectarea erorilor a fost dezactivată. Puteți să o reactivați și să încercați din nou, sau să salvați pentru a continua fără aceasta.</value>
+    <value>Instalarea integrării shell a eșuat. Detectarea erorilor a fost dezactivată. Puteți să o reactivați și să încercați din nou, sau să salvați pentru a continua fără aceasta.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Instalarea session hooks a eșuat. Gestionarea sesiunilor a fost dezactivată. Puteți să o reactivați și să încercați din nou, sau să salvați pentru a continua fără aceasta.</value>
+    <value>Instalarea session hooks a eșuat. Gestionarea sesiunilor a fost dezactivată. Puteți să o reactivați și să încercați din nou, sau să salvați pentru a continua fără aceasta.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Aflați cum să remediați manual</value>
@@ -365,7 +365,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Politica de execuție PowerShell blochează scripturile. Detectarea erorilor dezactivată.</value>
+    <value>Politica de execuție PowerShell blochează scripturile. Detectarea erorilor dezactivată.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Utilizare</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ru-RU/Resources.resw
@@ -1147,39 +1147,39 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Настройка...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Установка {0} заблокирована политикой Диспетчера пакетов Windows. Если вы используете управляемое устройство, обратитесь к ИТ-администратору.</value>
+    <value>Установка {0} заблокирована политикой Диспетчера пакетов Windows. Если вы используете управляемое устройство, обратитесь к ИТ-администратору.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Не удалось установить {0} (код ошибки {1}). Подробности см. в журнале или установите {0} вручную.</value>
+    <value>Не удалось установить {0} (код ошибки {1}). Подробности см. в журнале или установите {0} вручную.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Не удалось установить {0}. Подробности см. в журнале или установите {0} вручную.</value>
+    <value>Не удалось установить {0}. Подробности см. в журнале или установите {0} вручную.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Установщик {0} сообщил об ошибке (код {1}). Подробности см. в журнале или установите {0} вручную.</value>
+    <value>Установщик {0} сообщил об ошибке (код {1}). Подробности см. в журнале или установите {0} вручную.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Не удалось связаться с Диспетчером пакетов Windows при установке {0}. Проверьте подключение к Интернету (VPN, прокси-сервер или брандмауэр могут его блокировать) и повторите попытку.</value>
+    <value>Не удалось связаться с Диспетчером пакетов Windows при установке {0}. Проверьте подключение к Интернету (VPN, прокси-сервер или брандмауэр могут его блокировать) и повторите попытку.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ В этой системе нет совместимого установщика для {0} (версия ОС или архитектура могут не поддерживаться). Установите {0} вручную.</value>
+    <value>В этой системе нет совместимого установщика для {0} (версия ОС или архитектура могут не поддерживаться). Установите {0} вручную.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} не найден в каталоге Диспетчера пакетов Windows. Попробуйте обновить источники winget или установите {0} вручную.</value>
+    <value>{0} не найден в каталоге Диспетчера пакетов Windows. Попробуйте обновить источники winget или установите {0} вручную.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Установка {0} заняла более 20 минут. Intelligent Terminal перестал ожидать, но установщик может по-прежнему выполняться в фоновом режиме. Проверьте Task Manager или повторите попытку позже.</value>
+    <value>Установка {0} заняла более 20 минут. Intelligent Terminal перестал ожидать, но установщик может по-прежнему выполняться в фоновом режиме. Проверьте Task Manager или повторите попытку позже.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Диспетчер пакетов Windows (winget) не установлен или недоступен. Сначала установите его, а затем повторите попытку.</value>
+    <value>Диспетчер пакетов Windows (winget) не установлен или недоступен. Сначала установите его, а затем повторите попытку.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1192,11 +1192,11 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
 
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Не удалось установить session hooks. Управление сеансами отключено. Вы можете повторно включить его и попробовать снова или сохранить, чтобы продолжить без него.</value>
+    <value>Не удалось установить session hooks. Управление сеансами отключено. Вы можете повторно включить его и попробовать снова или сохранить, чтобы продолжить без него.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Не удалось установить интеграцию с оболочкой. Обнаружение ошибок отключено. Вы можете повторно включить его и попробовать снова или сохранить, чтобы продолжить без него.</value>
+    <value>Не удалось установить интеграцию с оболочкой. Обнаружение ошибок отключено. Вы можете повторно включить его и попробовать снова или сохранить, чтобы продолжить без него.</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Узнайте, как исправить это вручную</value>
@@ -1305,7 +1305,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Политика выполнения PowerShell блокирует скрипты. Обнаружение ошибок отключено.</value>
+    <value>Политика выполнения PowerShell блокирует скрипты. Обнаружение ошибок отключено.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Использование</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sk-SK/Resources.resw
@@ -223,39 +223,39 @@
     <value>Nastavovanie...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Inštalácia {0} bola zablokovaná politikou Správcu balíkov Windows. Ak používate spravované zariadenie, obráťte sa na správcu IT.</value>
+    <value>Inštalácia {0} bola zablokovaná politikou Správcu balíkov Windows. Ak používate spravované zariadenie, obráťte sa na správcu IT.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Nepodarilo sa nainštalovať {0} (kód chyby {1}). Podrobnosti nájdete v denníku, alebo nainštalujte {0} manuálne.</value>
+    <value>Nepodarilo sa nainštalovať {0} (kód chyby {1}). Podrobnosti nájdete v denníku, alebo nainštalujte {0} manuálne.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Nepodarilo sa nainštalovať {0}. Podrobnosti nájdete v denníku, alebo nainštalujte {0} manuálne.</value>
+    <value>Nepodarilo sa nainštalovať {0}. Podrobnosti nájdete v denníku, alebo nainštalujte {0} manuálne.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Inštalátor {0} nahlásil chybu (kód {1}). Podrobnosti nájdete v denníku, alebo nainštalujte {0} manuálne.</value>
+    <value>Inštalátor {0} nahlásil chybu (kód {1}). Podrobnosti nájdete v denníku, alebo nainštalujte {0} manuálne.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Počas inštalácie {0} sa nepodarilo spojiť so Správcom balíkov Windows. Skontrolujte internetové pripojenie (VPN, proxy server alebo brána firewall ho môžu blokovať) a skúste to znova.</value>
+    <value>Počas inštalácie {0} sa nepodarilo spojiť so Správcom balíkov Windows. Skontrolujte internetové pripojenie (VPN, proxy server alebo brána firewall ho môžu blokovať) a skúste to znova.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ V tomto systéme nie je k dispozícii žiadny kompatibilný inštalátor pre {0} (verzia operačného systému alebo architektúra nemusí byť podporovaná). Nainštalujte {0} manuálne.</value>
+    <value>V tomto systéme nie je k dispozícii žiadny kompatibilný inštalátor pre {0} (verzia operačného systému alebo architektúra nemusí byť podporovaná). Nainštalujte {0} manuálne.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} sa nenašiel v katalógu Správcu balíkov Windows. Skúste obnoviť zdroje winget alebo nainštalujte {0} manuálne.</value>
+    <value>{0} sa nenašiel v katalógu Správcu balíkov Windows. Skúste obnoviť zdroje winget alebo nainštalujte {0} manuálne.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Inštalácia {0} trvala dlhšie ako 20 minút. Intelligent Terminal prestal čakať, ale inštalátor môže stále bežať na pozadí. Skontrolujte Task Manager alebo to skúste znova neskôr.</value>
+    <value>Inštalácia {0} trvala dlhšie ako 20 minút. Intelligent Terminal prestal čakať, ale inštalátor môže stále bežať na pozadí. Skontrolujte Task Manager alebo to skúste znova neskôr.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Správca balíkov Windows (winget) nie je nainštalovaný alebo nie je k dispozícii. Najskôr ho nainštalujte a potom to skúste znova.</value>
+    <value>Správca balíkov Windows (winget) nie je nainštalovaný alebo nie je k dispozícii. Najskôr ho nainštalujte a potom to skúste znova.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>Povoľte aplikácii Intelligent Terminal prístup k prostrediu shell a automatickú detekciu chýb.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Nepodarilo sa nainštalovať integráciu shellu. Detekcia chýb bola vypnutá. Môžete ju znova zapnúť a skúsiť to znova, alebo uložiť a pokračovať bez nej.</value>
+    <value>Nepodarilo sa nainštalovať integráciu shellu. Detekcia chýb bola vypnutá. Môžete ju znova zapnúť a skúsiť to znova, alebo uložiť a pokračovať bez nej.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Nepodarilo sa nainštalovať session hooks. Správa relácií bola vypnutá. Môžete ju znova zapnúť a skúsiť to znova, alebo uložiť a pokračovať bez nej.</value>
+    <value>Nepodarilo sa nainštalovať session hooks. Správa relácií bola vypnutá. Môžete ju znova zapnúť a skúsiť to znova, alebo uložiť a pokračovať bez nej.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Zistite, ako to ručne opraviť</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Politika spúšťania PowerShellu blokuje skripty. Detekcia chýb vypnutá.</value>
+    <value>Politika spúšťania PowerShellu blokuje skripty. Detekcia chýb vypnutá.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Použitie</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sl-SI/Resources.resw
@@ -223,39 +223,39 @@
     <value>Nastavljanje...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Namestitev {0} je blokiral pravilnik Upravitelja paketov za Windows. Če uporabljate upravljano napravo, se obrnite na skrbnika za IT.</value>
+    <value>Namestitev {0} je blokiral pravilnik Upravitelja paketov za Windows. Če uporabljate upravljano napravo, se obrnite na skrbnika za IT.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Ni bilo mogoče namestiti {0} (koda napake {1}). Za podrobnosti preverite dnevnik ali namestite {0} ročno.</value>
+    <value>Ni bilo mogoče namestiti {0} (koda napake {1}). Za podrobnosti preverite dnevnik ali namestite {0} ročno.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Ni bilo mogoče namestiti {0}. Za podrobnosti preverite dnevnik ali namestite {0} ročno.</value>
+    <value>Ni bilo mogoče namestiti {0}. Za podrobnosti preverite dnevnik ali namestite {0} ročno.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Namestitveni program za {0} je sporočil napako (koda {1}). Za podrobnosti preverite dnevnik ali namestite {0} ročno.</value>
+    <value>Namestitveni program za {0} je sporočil napako (koda {1}). Za podrobnosti preverite dnevnik ali namestite {0} ročno.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Med nameščanjem {0} ni bilo mogoče vzpostaviti stika z Upraviteljem paketov za Windows. Preverite internetno povezavo (VPN, posredniški strežnik ali požarni zid jo morda blokira) in poskusite znova.</value>
+    <value>Med nameščanjem {0} ni bilo mogoče vzpostaviti stika z Upraviteljem paketov za Windows. Preverite internetno povezavo (VPN, posredniški strežnik ali požarni zid jo morda blokira) in poskusite znova.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ V tem sistemu ni na voljo združljivega namestitvenega programa za {0} (različica OS ali arhitektura morda ni podprta). Namestite {0} ročno.</value>
+    <value>V tem sistemu ni na voljo združljivega namestitvenega programa za {0} (različica OS ali arhitektura morda ni podprta). Namestite {0} ročno.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} ni bilo mogoče najti v katalogu Upravitelja paketov za Windows. Poskusite osvežiti vire winget ali namestite {0} ročno.</value>
+    <value>{0} ni bilo mogoče najti v katalogu Upravitelja paketov za Windows. Poskusite osvežiti vire winget ali namestite {0} ročno.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Namestitev {0} je trajala dlje kot 20 minut. Intelligent Terminal je nehal čakati, vendar se namestitveni program morda še vedno izvaja v ozadju. Preverite Task Manager ali poskusite znova pozneje.</value>
+    <value>Namestitev {0} je trajala dlje kot 20 minut. Intelligent Terminal je nehal čakati, vendar se namestitveni program morda še vedno izvaja v ozadju. Preverite Task Manager ali poskusite znova pozneje.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Upravitelj paketov za Windows (winget) ni nameščen ali ni na voljo. Najprej ga namestite, nato poskusite znova.</value>
+    <value>Upravitelj paketov za Windows (winget) ni nameščen ali ni na voljo. Najprej ga namestite, nato poskusite znova.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>Dovolite aplikaciji Intelligent Terminal dostop do lupine in samodejno zaznavanje napak.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Namestitev integracije lupine ni uspela. Zaznavanje napak je bilo izklopljeno. Lahko ga znova omogočite in poskusite znova ali shranite, da nadaljujete brez njega.</value>
+    <value>Namestitev integracije lupine ni uspela. Zaznavanje napak je bilo izklopljeno. Lahko ga znova omogočite in poskusite znova ali shranite, da nadaljujete brez njega.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Namestitev session hooks ni uspela. Upravljanje sej je bilo izklopljeno. Lahko ga znova omogočite in poskusite znova ali shranite, da nadaljujete brez njega.</value>
+    <value>Namestitev session hooks ni uspela. Upravljanje sej je bilo izklopljeno. Lahko ga znova omogočite in poskusite znova ali shranite, da nadaljujete brez njega.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Naučite se, kako to popraviti ročno</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Pravilnik o izvajanju PowerShell blokira skripte. Zaznavanje napak izklopljeno.</value>
+    <value>Pravilnik o izvajanju PowerShell blokira skripte. Zaznavanje napak izklopljeno.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Uporaba</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sq-AL/Resources.resw
@@ -223,39 +223,39 @@
     <value>Po konfigurohet...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Instalimi i {0} u bllokua nga një politikë e Menaxherit të paketave të Windows. Nëse jeni në një pajisje të menaxhuar, kontaktoni administratorin tuaj të IT-së.</value>
+    <value>Instalimi i {0} u bllokua nga një politikë e Menaxherit të paketave të Windows. Nëse jeni në një pajisje të menaxhuar, kontaktoni administratorin tuaj të IT-së.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Nuk mund të instalohej {0} (kodi i gabimit {1}). Shikoni regjistrin për hollësi ose instaloni {0} manualisht.</value>
+    <value>Nuk mund të instalohej {0} (kodi i gabimit {1}). Shikoni regjistrin për hollësi ose instaloni {0} manualisht.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Nuk mund të instalohej {0}. Shikoni regjistrin për hollësi ose instaloni {0} manualisht.</value>
+    <value>Nuk mund të instalohej {0}. Shikoni regjistrin për hollësi ose instaloni {0} manualisht.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Instaluesi i {0} raportoi një gabim (kodi {1}). Shikoni regjistrin për hollësi ose instaloni {0} manualisht.</value>
+    <value>Instaluesi i {0} raportoi një gabim (kodi {1}). Shikoni regjistrin për hollësi ose instaloni {0} manualisht.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Nuk u arrit të kontaktohej Menaxheri i paketave të Windows gjatë instalimit të {0}. Kontrolloni lidhjen e internetit (VPN, proxy ose muri mbrojtës mund ta bllokojë) dhe provoni përsëri.</value>
+    <value>Nuk u arrit të kontaktohej Menaxheri i paketave të Windows gjatë instalimit të {0}. Kontrolloni lidhjen e internetit (VPN, proxy ose muri mbrojtës mund ta bllokojë) dhe provoni përsëri.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Nuk disponohet asnjë instalues i përputhshëm për {0} në këtë sistem (versioni i OS ose arkitektura mund të mos mbështeten). Instaloni {0} manualisht.</value>
+    <value>Nuk disponohet asnjë instalues i përputhshëm për {0} në këtë sistem (versioni i OS ose arkitektura mund të mos mbështeten). Instaloni {0} manualisht.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} nuk u gjet në katalogun e Menaxherit të paketave të Windows. Provoni të rifreskoni burimet e winget ose instaloni {0} manualisht.</value>
+    <value>{0} nuk u gjet në katalogun e Menaxherit të paketave të Windows. Provoni të rifreskoni burimet e winget ose instaloni {0} manualisht.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Instalimi i {0} zgjati më shumë se 20 minuta. Intelligent Terminal ndaloi së prituri, por instaluesi mund të jetë ende duke u ekzekutuar në sfond. Kontrolloni Task Manager ose provoni përsëri më vonë.</value>
+    <value>Instalimi i {0} zgjati më shumë se 20 minuta. Intelligent Terminal ndaloi së prituri, por instaluesi mund të jetë ende duke u ekzekutuar në sfond. Kontrolloni Task Manager ose provoni përsëri më vonë.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Menaxheri i paketave të Windows (winget) nuk është i instaluar ose nuk është i disponueshëm. Instalojeni fillimisht, pastaj provoni përsëri.</value>
+    <value>Menaxheri i paketave të Windows (winget) nuk është i instaluar ose nuk është i disponueshëm. Instalojeni fillimisht, pastaj provoni përsëri.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>Lejoni Intelligent Terminal të hyjë në guaskën tuaj dhe të zbulojë gabimet automatikisht.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Instalimi i integrimit të shell-it dështoi. Zbulimi i gabimeve është çaktivizuar. Mund ta riaktivizoni dhe të provoni përsëri, ose të ruani për të vazhduar pa të.</value>
+    <value>Instalimi i integrimit të shell-it dështoi. Zbulimi i gabimeve është çaktivizuar. Mund ta riaktivizoni dhe të provoni përsëri, ose të ruani për të vazhduar pa të.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Instalimi i session hooks dështoi. Menaxhimi i sesioneve është çaktivizuar. Mund ta riaktivizoni dhe të provoni përsëri, ose të ruani për të vazhduar pa të.</value>
+    <value>Instalimi i session hooks dështoi. Menaxhimi i sesioneve është çaktivizuar. Mund ta riaktivizoni dhe të provoni përsëri, ose të ruani për të vazhduar pa të.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Mësoni si ta rregulloni këtë manualisht</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Politika e ekzekutimit të PowerShell po bllokon skriptet. Zbulimi i gabimeve u çaktivizua.</value>
+    <value>Politika e ekzekutimit të PowerShell po bllokon skriptet. Zbulimi i gabimeve u çaktivizua.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Përdorimi</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-BA/Resources.resw
@@ -110,39 +110,39 @@
     <value>Подешавање...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Инсталацију {0} блокирала је политика Windows Package Manager-а. Ако користите управљани уређај, обратите се IT администратору.</value>
+    <value>Инсталацију {0} блокирала је политика Windows Package Manager-а. Ако користите управљани уређај, обратите се IT администратору.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Инсталација {0} није успјела (код грешке {1}). Детаље потражите у евиденцији или ручно инсталирајте {0}.</value>
+    <value>Инсталација {0} није успјела (код грешке {1}). Детаље потражите у евиденцији или ручно инсталирајте {0}.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Инсталација {0} није успјела. Детаље потражите у евиденцији или ручно инсталирајте {0}.</value>
+    <value>Инсталација {0} није успјела. Детаље потражите у евиденцији или ручно инсталирајте {0}.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Инсталатор за {0} је пријавио грешку (код {1}). Детаље потражите у евиденцији или ручно инсталирајте {0}.</value>
+    <value>Инсталатор за {0} је пријавио грешку (код {1}). Детаље потражите у евиденцији или ручно инсталирајте {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Није било могуће приступити Windows Package Manager-у током инсталације {0}. Провјерите интернетску везу (VPN, прокси или заштитни зид је можда блокирају) и покушајте поново.</value>
+    <value>Није било могуће приступити Windows Package Manager-у током инсталације {0}. Провјерите интернетску везу (VPN, прокси или заштитни зид је можда блокирају) и покушајте поново.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ На овом систему није доступан компатибилан инсталатор за {0} (верзија ОС-а или архитектура можда нису подржани). Ручно инсталирајте {0}.</value>
+    <value>На овом систему није доступан компатибилан инсталатор за {0} (верзија ОС-а или архитектура можда нису подржани). Ручно инсталирајте {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} није пронађен у каталогу Windows Package Manager-а. Покушајте освјежити изворе winget или ручно инсталирајте {0}.</value>
+    <value>{0} није пронађен у каталогу Windows Package Manager-а. Покушајте освјежити изворе winget или ручно инсталирајте {0}.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Инсталација {0} трајала је дуже од 20 минута. Intelligent Terminal је престао да чека, али инсталатор можда још ради у позадини. Провјерите Task Manager или покушајте поново касније.</value>
+    <value>Инсталација {0} трајала је дуже од 20 минута. Intelligent Terminal је престао да чека, али инсталатор можда још ради у позадини. Провјерите Task Manager или покушајте поново касније.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) није инсталиран или није доступан. Прво га инсталирајте, а затим покушајте поново.</value>
+    <value>Windows Package Manager (winget) није инсталиран или није доступан. Прво га инсталирајте, а затим покушајте поново.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -235,9 +235,9 @@
     <value>Дозволите да Intelligent Terminal приступи вашој командној линији и аутоматски открива грешке.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Инсталација интеграције љуске није успјела. Откривање грешака је искључено. Можете га поново укључити и покушати поново, или сачувати да наставите без њега.</value>
+    <value>Инсталација интеграције љуске није успјела. Откривање грешака је искључено. Можете га поново укључити и покушати поново, или сачувати да наставите без њега.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Инсталација session hooks није успјела. Управљање сесијама је искључено. Можете га поново укључити и покушати поново, или сачувати да наставите без њега.</value>
+    <value>Инсталација session hooks није успјела. Управљање сесијама је искључено. Можете га поново укључити и покушати поново, или сачувати да наставите без њега.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Сазнајте како да ово ручно поправите</value>
@@ -253,7 +253,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell политика извршавања блокира скрипте. Откривање грешака је искључено.</value>
+    <value>PowerShell политика извршавања блокира скрипте. Откривање грешака је искључено.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Употреба</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Cyrl-RS/Resources.resw
@@ -1104,39 +1104,39 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Подешавање...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Инсталацију {0} блокирала је политика Windows Package Manager-а. Ако користите управљани уређај, обратите се IT администратору.</value>
+    <value>Инсталацију {0} блокирала је политика Windows Package Manager-а. Ако користите управљани уређај, обратите се IT администратору.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Инсталација {0} није успела (код грешке {1}). Детаље потражите у евиденцији или ручно инсталирајте {0}.</value>
+    <value>Инсталација {0} није успела (код грешке {1}). Детаље потражите у евиденцији или ручно инсталирајте {0}.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Инсталација {0} није успела. Детаље потражите у евиденцији или ручно инсталирајте {0}.</value>
+    <value>Инсталација {0} није успела. Детаље потражите у евиденцији или ручно инсталирајте {0}.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Инсталатор за {0} је пријавио грешку (код {1}). Детаље потражите у евиденцији или ручно инсталирајте {0}.</value>
+    <value>Инсталатор за {0} је пријавио грешку (код {1}). Детаље потражите у евиденцији или ручно инсталирајте {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Није било могуће приступити Windows Package Manager-у током инсталације {0}. Проверите интернетску везу (VPN, прокси или заштитни зид је можда блокирају) и покушајте поново.</value>
+    <value>Није било могуће приступити Windows Package Manager-у током инсталације {0}. Проверите интернетску везу (VPN, прокси или заштитни зид је можда блокирају) и покушајте поново.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ На овом систему није доступан компатибилан инсталатор за {0} (верзија ОС-а или архитектура можда нису подржани). Ручно инсталирајте {0}.</value>
+    <value>На овом систему није доступан компатибилан инсталатор за {0} (верзија ОС-а или архитектура можда нису подржани). Ручно инсталирајте {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} није пронађен у каталогу Windows Package Manager-а. Покушајте да освежите изворе winget или ручно инсталирајте {0}.</value>
+    <value>{0} није пронађен у каталогу Windows Package Manager-а. Покушајте да освежите изворе winget или ручно инсталирајте {0}.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Инсталација {0} трајала је дуже од 20 минута. Intelligent Terminal је престао да чека, али инсталатор можда још ради у позадини. Проверите Task Manager или покушајте поново касније.</value>
+    <value>Инсталација {0} трајала је дуже од 20 минута. Intelligent Terminal је престао да чека, али инсталатор можда још ради у позадини. Проверите Task Manager или покушајте поново касније.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) није инсталиран или није доступан. Прво га инсталирајте, а затим покушајте поново.</value>
+    <value>Windows Package Manager (winget) није инсталиран или није доступан. Прво га инсталирајте, а затим покушајте поново.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1149,11 +1149,11 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
 
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Инсталација session hooks није успела. Управљање сесијама је искључено. Можете га поново укључити и покушати поново, или сачувати да наставите без њега.</value>
+    <value>Инсталација session hooks није успела. Управљање сесијама је искључено. Можете га поново укључити и покушати поново, или сачувати да наставите без њега.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Инсталација интеграције љуске није успела. Откривање грешака је искључено. Можете га поново укључити и покушати поново, или сачувати да наставите без њега.</value>
+    <value>Инсталација интеграције љуске није успела. Откривање грешака је искључено. Можете га поново укључити и покушати поново, или сачувати да наставите без њега.</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Сазнајте како да ово ручно поправите</value>
@@ -1285,7 +1285,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell политика извршавања блокира скрипте. Откривање грешака је искључено.</value>
+    <value>PowerShell политика извршавања блокира скрипте. Откривање грешака је искључено.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Употреба</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sr-Latn-RS/Resources.resw
@@ -110,39 +110,39 @@
     <value>Podešavanje...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Instalaciju {0} blokirala je politika Windows Package Manager-a. Ako koristite upravljani uređaj, obratite se IT administratoru.</value>
+    <value>Instalaciju {0} blokirala je politika Windows Package Manager-a. Ako koristite upravljani uređaj, obratite se IT administratoru.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Instalacija {0} nije uspela (kod greške {1}). Detalje potražite u evidenciji ili ručno instalirajte {0}.</value>
+    <value>Instalacija {0} nije uspela (kod greške {1}). Detalje potražite u evidenciji ili ručno instalirajte {0}.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Instalacija {0} nije uspela. Detalje potražite u evidenciji ili ručno instalirajte {0}.</value>
+    <value>Instalacija {0} nije uspela. Detalje potražite u evidenciji ili ručno instalirajte {0}.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Instalator za {0} je prijavio grešku (kod {1}). Detalje potražite u evidenciji ili ručno instalirajte {0}.</value>
+    <value>Instalator za {0} je prijavio grešku (kod {1}). Detalje potražite u evidenciji ili ručno instalirajte {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Nije bilo moguće pristupiti Windows Package Manager-u tokom instalacije {0}. Proverite internet vezu (VPN, proksi ili zaštitni zid je možda blokiraju) i pokušajte ponovo.</value>
+    <value>Nije bilo moguće pristupiti Windows Package Manager-u tokom instalacije {0}. Proverite internet vezu (VPN, proksi ili zaštitni zid je možda blokiraju) i pokušajte ponovo.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Na ovom sistemu nije dostupan kompatibilan instalator za {0} (verzija OS-a ili arhitektura možda nisu podržani). Ručno instalirajte {0}.</value>
+    <value>Na ovom sistemu nije dostupan kompatibilan instalator za {0} (verzija OS-a ili arhitektura možda nisu podržani). Ručno instalirajte {0}.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} nije pronađen u katalogu Windows Package Manager-a. Pokušajte da osvežite izvore winget ili ručno instalirajte {0}.</value>
+    <value>{0} nije pronađen u katalogu Windows Package Manager-a. Pokušajte da osvežite izvore winget ili ručno instalirajte {0}.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Instalacija {0} trajala je duže od 20 minuta. Intelligent Terminal je prestao da čeka, ali instalator možda još radi u pozadini. Proverite Task Manager ili pokušajte ponovo kasnije.</value>
+    <value>Instalacija {0} trajala je duže od 20 minuta. Intelligent Terminal je prestao da čeka, ali instalator možda još radi u pozadini. Proverite Task Manager ili pokušajte ponovo kasnije.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) nije instaliran ili nije dostupan. Prvo ga instalirajte, a zatim pokušajte ponovo.</value>
+    <value>Windows Package Manager (winget) nije instaliran ili nije dostupan. Prvo ga instalirajte, a zatim pokušajte ponovo.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -235,9 +235,9 @@
     <value>Dozvolite da Intelligent Terminal pristupi vašoj komandnoj liniji i automatski otkriva greške.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Instalacija integracije ljuske nije uspela. Otkrivanje grešaka je isključeno. Možete ga ponovo uključiti i pokušati ponovo, ili sačuvati da nastavite bez njega.</value>
+    <value>Instalacija integracije ljuske nije uspela. Otkrivanje grešaka je isključeno. Možete ga ponovo uključiti i pokušati ponovo, ili sačuvati da nastavite bez njega.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Instalacija session hooks nije uspela. Upravljanje sesijama je isključeno. Možete ga ponovo uključiti i pokušati ponovo, ili sačuvati da nastavite bez njega.</value>
+    <value>Instalacija session hooks nije uspela. Upravljanje sesijama je isključeno. Možete ga ponovo uključiti i pokušati ponovo, ili sačuvati da nastavite bez njega.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Saznajte kako da ovo ručno popravite</value>
@@ -253,7 +253,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell politika izvršavanja blokira skripte. Otkrivanje grešaka je isključeno.</value>
+    <value>PowerShell politika izvršavanja blokira skripte. Otkrivanje grešaka je isključeno.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Upotreba</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/sv-SE/Resources.resw
@@ -224,39 +224,39 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Konfigurerar...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Installationen av {0} blockerades av en princip för Windows Paketshanterare. Om du använder en hanterad enhet kontaktar du IT-administratören.</value>
+    <value>Installationen av {0} blockerades av en princip för Windows Paketshanterare. Om du använder en hanterad enhet kontaktar du IT-administratören.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Det gick inte att installera {0} (felkod {1}). Se loggen för information eller installera {0} manuellt.</value>
+    <value>Det gick inte att installera {0} (felkod {1}). Se loggen för information eller installera {0} manuellt.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Det gick inte att installera {0}. Se loggen för information eller installera {0} manuellt.</value>
+    <value>Det gick inte att installera {0}. Se loggen för information eller installera {0} manuellt.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Installationsprogrammet för {0} rapporterade ett fel (kod {1}). Se loggen för information eller installera {0} manuellt.</value>
+    <value>Installationsprogrammet för {0} rapporterade ett fel (kod {1}). Se loggen för information eller installera {0} manuellt.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Det gick inte att nå Windows Paketshanterare när {0} installerades. Kontrollera din internetanslutning (VPN, proxy eller brandvägg kan blockera den) och försök igen.</value>
+    <value>Det gick inte att nå Windows Paketshanterare när {0} installerades. Kontrollera din internetanslutning (VPN, proxy eller brandvägg kan blockera den) och försök igen.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Det finns inget kompatibelt installationsprogram för {0} på det här systemet (OS-versionen eller arkitekturen kanske inte stöds). Installera {0} manuellt.</value>
+    <value>Det finns inget kompatibelt installationsprogram för {0} på det här systemet (OS-versionen eller arkitekturen kanske inte stöds). Installera {0} manuellt.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} hittades inte i katalogen för Windows Paketshanterare. Försök att uppdatera winget-källorna eller installera {0} manuellt.</value>
+    <value>{0} hittades inte i katalogen för Windows Paketshanterare. Försök att uppdatera winget-källorna eller installera {0} manuellt.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Installationen av {0} tog längre än 20 minuter. Intelligent Terminal slutade vänta, men installationsprogrammet kan fortfarande köras i bakgrunden. Kontrollera Task Manager eller försök igen senare.</value>
+    <value>Installationen av {0} tog längre än 20 minuter. Intelligent Terminal slutade vänta, men installationsprogrammet kan fortfarande köras i bakgrunden. Kontrollera Task Manager eller försök igen senare.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Paketshanterare (winget) är inte installerad eller inte tillgänglig. Installera den först och försök sedan igen.</value>
+    <value>Windows Paketshanterare (winget) är inte installerad eller inte tillgänglig. Installera den först och försök sedan igen.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Ge Intelligent Terminal behörighet att komma åt skalet och automatiskt identifiera fel.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Det gick inte att installera skalintegrering. Feldetektering har inaktiverats. Du kan aktivera det igen och försöka på nytt, eller spara för att fortsätta utan det.</value>
+    <value>Det gick inte att installera skalintegrering. Feldetektering har inaktiverats. Du kan aktivera det igen och försöka på nytt, eller spara för att fortsätta utan det.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Det gick inte att installera session hooks. Sessionshantering har inaktiverats. Du kan aktivera det igen och försöka på nytt, eller spara för att fortsätta utan det.</value>
+    <value>Det gick inte att installera session hooks. Sessionshantering har inaktiverats. Du kan aktivera det igen och försöka på nytt, eller spara för att fortsätta utan det.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Lär dig hur du åtgärdar detta manuellt</value>
@@ -366,7 +366,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShells körningsprincip blockerar skript. Feldetektering inaktiverad.</value>
+    <value>PowerShells körningsprincip blockerar skript. Feldetektering inaktiverad.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Användning</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ta-IN/Resources.resw
@@ -223,50 +223,50 @@
     <value>அமைக்கப்படுகிறது...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager கொள்கையால் {0} நிறுவல் தடுக்கப்பட்டது. நீங்கள் நிர்வகிக்கப்படும் சாதனத்தில் இருந்தால், உங்கள் IT நிர்வாகியைத் தொடர்புகொள்ளவும்.</value>
+    <value>Windows Package Manager கொள்கையால் {0} நிறுவல் தடுக்கப்பட்டது. நீங்கள் நிர்வகிக்கப்படும் சாதனத்தில் இருந்தால், உங்கள் IT நிர்வாகியைத் தொடர்புகொள்ளவும்.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} ஐ நிறுவ முடியவில்லை (பிழை குறியீடு {1}). விவரங்களுக்கு பதிவைப் பார்க்கவும், அல்லது {0} ஐ கைமுறையாக நிறுவவும்.</value>
+    <value>{0} ஐ நிறுவ முடியவில்லை (பிழை குறியீடு {1}). விவரங்களுக்கு பதிவைப் பார்க்கவும், அல்லது {0} ஐ கைமுறையாக நிறுவவும்.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} ஐ நிறுவ முடியவில்லை. விவரங்களுக்கு பதிவைப் பார்க்கவும், அல்லது {0} ஐ கைமுறையாக நிறுவவும்.</value>
+    <value>{0} ஐ நிறுவ முடியவில்லை. விவரங்களுக்கு பதிவைப் பார்க்கவும், அல்லது {0} ஐ கைமுறையாக நிறுவவும்.</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} நிறுவி பிழையை அறிவித்தது (குறியீடு {1}). விவரங்களுக்கு பதிவைச் சரிபார்க்கவும், அல்லது {0} ஐ கைமுறையாக நிறுவவும்.</value>
+    <value>{0} நிறுவி பிழையை அறிவித்தது (குறியீடு {1}). விவரங்களுக்கு பதிவைச் சரிபார்க்கவும், அல்லது {0} ஐ கைமுறையாக நிறுவவும்.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} நிறுவும் போது Windows Package Manager-ஐ அணுக முடியவில்லை. உங்கள் இணைய இணைப்பைச் சரிபார்க்கவும் (VPN, proxy அல்லது firewall இதைத் தடுக்கலாம்) பின்னர் மீண்டும் முயற்சிக்கவும்.</value>
+    <value>{0} நிறுவும் போது Windows Package Manager-ஐ அணுக முடியவில்லை. உங்கள் இணைய இணைப்பைச் சரிபார்க்கவும் (VPN, proxy அல்லது firewall இதைத் தடுக்கலாம்) பின்னர் மீண்டும் முயற்சிக்கவும்.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ இந்த கணினியில் {0} க்கு இணக்கமான நிறுவி எதுவும் கிடைக்கவில்லை (OS பதிப்பு அல்லது கட்டமைப்பு ஆதரிக்கப்படாமல் இருக்கலாம்). {0} ஐ கைமுறையாக நிறுவவும்.</value>
+    <value>இந்த கணினியில் {0} க்கு இணக்கமான நிறுவி எதுவும் கிடைக்கவில்லை (OS பதிப்பு அல்லது கட்டமைப்பு ஆதரிக்கப்படாமல் இருக்கலாம்). {0} ஐ கைமுறையாக நிறுவவும்.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager பட்டியலில் {0} காணப்படவில்லை. winget மூலங்களைப் புதுப்பிக்க முயற்சிக்கவும், அல்லது {0} ஐ கைமுறையாக நிறுவவும்.</value>
+    <value>Windows Package Manager பட்டியலில் {0} காணப்படவில்லை. winget மூலங்களைப் புதுப்பிக்க முயற்சிக்கவும், அல்லது {0} ஐ கைமுறையாக நிறுவவும்.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} நிறுவுவதற்கு 20 நிமிடங்களுக்கு மேல் எடுத்துக்கொண்டது. Intelligent Terminal காத்திருப்பதை நிறுத்தியது, ஆனால் நிறுவி இன்னும் பின்னணியில் இயங்கிக்கொண்டிருக்கலாம். Task Manager ஐச் சரிபார்க்கவும், அல்லது பின்னர் மீண்டும் முயற்சிக்கவும்.</value>
+    <value>{0} நிறுவுவதற்கு 20 நிமிடங்களுக்கு மேல் எடுத்துக்கொண்டது. Intelligent Terminal காத்திருப்பதை நிறுத்தியது, ஆனால் நிறுவி இன்னும் பின்னணியில் இயங்கிக்கொண்டிருக்கலாம். Task Manager ஐச் சரிபார்க்கவும், அல்லது பின்னர் மீண்டும் முயற்சிக்கவும்.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks நிறுவுவதில் தோல்வி. அமர்வு மேலாண்மை முடக்கப்பட்டுள்ளது. நீங்கள் அதை மீண்டும் இயக்கி மீண்டும் முயற்சிக்கலாம், அல்லது அது இல்லாமல் தொடர சேமிக்கலாம்.</value>
+    <value>session hooks நிறுவுவதில் தோல்வி. அமர்வு மேலாண்மை முடக்கப்பட்டுள்ளது. நீங்கள் அதை மீண்டும் இயக்கி மீண்டும் முயற்சிக்கலாம், அல்லது அது இல்லாமல் தொடர சேமிக்கலாம்.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ ஷெல் ஒருங்கிணைப்பை நிறுவுவதில் தோல்வி. பிழை கண்டறிதல் முடக்கப்பட்டுள்ளது. நீங்கள் அதை மீண்டும் இயக்கி மீண்டும் முயற்சிக்கலாம், அல்லது அது இல்லாமல் தொடர சேமிக்கலாம்.</value>
+    <value>ஷெல் ஒருங்கிணைப்பை நிறுவுவதில் தோல்வி. பிழை கண்டறிதல் முடக்கப்பட்டுள்ளது. நீங்கள் அதை மீண்டும் இயக்கி மீண்டும் முயற்சிக்கலாம், அல்லது அது இல்லாமல் தொடர சேமிக்கலாம்.</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell செயல்படுத்தல் கொள்கை ஸ்கிரிப்ட்களைத் தடுக்கிறது. பிழை கண்டறிதல் முடக்கப்பட்டது.</value>
+    <value>PowerShell செயல்படுத்தல் கொள்கை ஸ்கிரிப்ட்களைத் தடுக்கிறது. பிழை கண்டறிதல் முடக்கப்பட்டது.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) நிறுவப்படவில்லை அல்லது கிடைக்கவில்லை. முதலில் அதை நிறுவி, பின்னர் மீண்டும் முயற்சிக்கவும்.</value>
+    <value>Windows Package Manager (winget) நிறுவப்படவில்லை அல்லது கிடைக்கவில்லை. முதலில் அதை நிறுவி, பின்னர் மீண்டும் முயற்சிக்கவும்.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/te-IN/Resources.resw
@@ -223,50 +223,50 @@
     <value>సెటప్ అవుతోంది...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager విధానం ద్వారా {0} ఇన్‌స్టాలేషన్ నిరోధించబడింది. మీరు నిర్వహిత పరికరంలో ఉంటే, మీ IT అడ్మిన్‌ను సంప్రదించండి.</value>
+    <value>Windows Package Manager విధానం ద్వారా {0} ఇన్‌స్టాలేషన్ నిరోధించబడింది. మీరు నిర్వహిత పరికరంలో ఉంటే, మీ IT అడ్మిన్‌ను సంప్రదించండి.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} ఇన్‌స్టాల్ చేయలేకపోయాం (లోపం కోడ్ {1}). వివరాల కోసం లాగ్‌ను చూడండి, లేదా {0} ను మాన్యువల్‌గా ఇన్‌స్టాల్ చేయండి.</value>
+    <value>{0} ఇన్‌స్టాల్ చేయలేకపోయాం (లోపం కోడ్ {1}). వివరాల కోసం లాగ్‌ను చూడండి, లేదా {0} ను మాన్యువల్‌గా ఇన్‌స్టాల్ చేయండి.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} ఇన్‌స్టాల్ చేయలేకపోయాం. వివరాల కోసం లాగ్‌ను చూడండి, లేదా {0} ను మాన్యువల్‌గా ఇన్‌స్టాల్ చేయండి.</value>
+    <value>{0} ఇన్‌స్టాల్ చేయలేకపోయాం. వివరాల కోసం లాగ్‌ను చూడండి, లేదా {0} ను మాన్యువల్‌గా ఇన్‌స్టాల్ చేయండి.</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} ఇన్‌స్టాలర్ లోపాన్ని నివేదించింది (కోడ్ {1}). వివరాల కోసం లాగ్‌ను తనిఖీ చేయండి, లేదా {0} ను మాన్యువల్‌గా ఇన్‌స్టాల్ చేయండి.</value>
+    <value>{0} ఇన్‌స్టాలర్ లోపాన్ని నివేదించింది (కోడ్ {1}). వివరాల కోసం లాగ్‌ను తనిఖీ చేయండి, లేదా {0} ను మాన్యువల్‌గా ఇన్‌స్టాల్ చేయండి.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} ఇన్‌స్టాల్ చేస్తున్నప్పుడు Windows Package Manager‌ను చేరుకోలేకపోయాం. మీ ఇంటర్నెట్ కనెక్షన్‌ను తనిఖీ చేయండి (VPN, proxy, లేదా firewall దీన్ని నిరోధిస్తుండవచ్చు) మరియు మళ్లీ ప్రయత్నించండి.</value>
+    <value>{0} ఇన్‌స్టాల్ చేస్తున్నప్పుడు Windows Package Manager‌ను చేరుకోలేకపోయాం. మీ ఇంటర్నెట్ కనెక్షన్‌ను తనిఖీ చేయండి (VPN, proxy, లేదా firewall దీన్ని నిరోధిస్తుండవచ్చు) మరియు మళ్లీ ప్రయత్నించండి.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ ఈ సిస్టమ్‌లో {0} కోసం అనుకూల ఇన్‌స్టాలర్ అందుబాటులో లేదు (OS వెర్షన్ లేదా ఆర్కిటెక్చర్‌కు మద్దతు లేకపోవచ్చు). {0} ను మాన్యువల్‌గా ఇన్‌స్టాల్ చేయండి.</value>
+    <value>ఈ సిస్టమ్‌లో {0} కోసం అనుకూల ఇన్‌స్టాలర్ అందుబాటులో లేదు (OS వెర్షన్ లేదా ఆర్కిటెక్చర్‌కు మద్దతు లేకపోవచ్చు). {0} ను మాన్యువల్‌గా ఇన్‌స్టాల్ చేయండి.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager కాటలాగ్‌లో {0} కనుగొనబడలేదు. winget మూలాలను రిఫ్రెష్ చేయడానికి ప్రయత్నించండి, లేదా {0} ను మాన్యువల్‌గా ఇన్‌స్టాల్ చేయండి.</value>
+    <value>Windows Package Manager కాటలాగ్‌లో {0} కనుగొనబడలేదు. winget మూలాలను రిఫ్రెష్ చేయడానికి ప్రయత్నించండి, లేదా {0} ను మాన్యువల్‌గా ఇన్‌స్టాల్ చేయండి.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} ఇన్‌స్టాల్ చేయడానికి 20 నిమిషాలకంటే ఎక్కువ సమయం పట్టింది. Intelligent Terminal వేచి ఉండటం ఆపింది, కానీ ఇన్‌స్టాలర్ ఇంకా నేపథ్యంలో నడుస్తుండవచ్చు. Task Manager‌ను తనిఖీ చేయండి, లేదా తరువాత మళ్లీ ప్రయత్నించండి.</value>
+    <value>{0} ఇన్‌స్టాల్ చేయడానికి 20 నిమిషాలకంటే ఎక్కువ సమయం పట్టింది. Intelligent Terminal వేచి ఉండటం ఆపింది, కానీ ఇన్‌స్టాలర్ ఇంకా నేపథ్యంలో నడుస్తుండవచ్చు. Task Manager‌ను తనిఖీ చేయండి, లేదా తరువాత మళ్లీ ప్రయత్నించండి.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks ఇన్‌స్టాల్ చేయడం విఫలమైంది. సెషన్ నిర్వహణ ఆపివేయబడింది. మీరు దాన్ని మళ్ళీ ప్రారంభించి మళ్ళీ ప్రయత్నించవచ్చు, లేదా అది లేకుండా కొనసాగించడానికి సేవ్ చేయవచ్చు.</value>
+    <value>session hooks ఇన్‌స్టాల్ చేయడం విఫలమైంది. సెషన్ నిర్వహణ ఆపివేయబడింది. మీరు దాన్ని మళ్ళీ ప్రారంభించి మళ్ళీ ప్రయత్నించవచ్చు, లేదా అది లేకుండా కొనసాగించడానికి సేవ్ చేయవచ్చు.</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ షెల్ ఇంటిగ్రేషన్‌ను ఇన్‌స్టాల్ చేయడం విఫలమైంది. లోపం గుర్తింపు ఆపివేయబడింది. మీరు దాన్ని మళ్ళీ ప్రారంభించి మళ్ళీ ప్రయత్నించవచ్చు, లేదా అది లేకుండా కొనసాగించడానికి సేవ్ చేయవచ్చు.</value>
+    <value>షెల్ ఇంటిగ్రేషన్‌ను ఇన్‌స్టాల్ చేయడం విఫలమైంది. లోపం గుర్తింపు ఆపివేయబడింది. మీరు దాన్ని మళ్ళీ ప్రారంభించి మళ్ళీ ప్రయత్నించవచ్చు, లేదా అది లేకుండా కొనసాగించడానికి సేవ్ చేయవచ్చు.</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell ఎగ్జిక్యూషన్ విధానం స్క్రిప్ట్‌లను నిరోధిస్తోంది. లోపం గుర్తింపు ఆపివేయబడింది.</value>
+    <value>PowerShell ఎగ్జిక్యూషన్ విధానం స్క్రిప్ట్‌లను నిరోధిస్తోంది. లోపం గుర్తింపు ఆపివేయబడింది.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) ఇన్‌స్టాల్ చేయబడలేదు లేదా అందుబాటులో లేదు. ముందుగా దాన్ని ఇన్‌స్టాల్ చేసి, తరువాత మళ్లీ ప్రయత్నించండి.</value>
+    <value>Windows Package Manager (winget) ఇన్‌స్టాల్ చేయబడలేదు లేదా అందుబాటులో లేదు. ముందుగా దాన్ని ఇన్‌స్టాల్ చేసి, తరువాత మళ్లీ ప్రయత్నించండి.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/th-TH/Resources.resw
@@ -223,39 +223,39 @@
     <value>กำลังตั้งค่า...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ การติดตั้ง {0} ถูกบล็อกโดยนโยบาย Windows Package Manager หากคุณใช้อุปกรณ์ที่มีการจัดการ โปรดติดต่อผู้ดูแลระบบ IT ของคุณ</value>
+    <value>การติดตั้ง {0} ถูกบล็อกโดยนโยบาย Windows Package Manager หากคุณใช้อุปกรณ์ที่มีการจัดการ โปรดติดต่อผู้ดูแลระบบ IT ของคุณ</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ ไม่สามารถติดตั้ง {0} ได้ (รหัสข้อผิดพลาด {1}) ตรวจสอบบันทึกเพื่อดูรายละเอียด หรือติดตั้ง {0} ด้วยตนเอง</value>
+    <value>ไม่สามารถติดตั้ง {0} ได้ (รหัสข้อผิดพลาด {1}) ตรวจสอบบันทึกเพื่อดูรายละเอียด หรือติดตั้ง {0} ด้วยตนเอง</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ ไม่สามารถติดตั้ง {0} ได้ ตรวจสอบบันทึกเพื่อดูรายละเอียด หรือติดตั้ง {0} ด้วยตนเอง</value>
+    <value>ไม่สามารถติดตั้ง {0} ได้ ตรวจสอบบันทึกเพื่อดูรายละเอียด หรือติดตั้ง {0} ด้วยตนเอง</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ ตัวติดตั้ง {0} รายงานข้อผิดพลาด (รหัส {1}) ตรวจสอบบันทึกเพื่อดูรายละเอียด หรือติดตั้ง {0} ด้วยตนเอง</value>
+    <value>ตัวติดตั้ง {0} รายงานข้อผิดพลาด (รหัส {1}) ตรวจสอบบันทึกเพื่อดูรายละเอียด หรือติดตั้ง {0} ด้วยตนเอง</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ ไม่สามารถเชื่อมต่อกับ Windows Package Manager ขณะติดตั้ง {0} ได้ ตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณ (VPN, proxy หรือไฟร์วอลล์อาจบล็อกอยู่) แล้วลองอีกครั้ง</value>
+    <value>ไม่สามารถเชื่อมต่อกับ Windows Package Manager ขณะติดตั้ง {0} ได้ ตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณ (VPN, proxy หรือไฟร์วอลล์อาจบล็อกอยู่) แล้วลองอีกครั้ง</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ ไม่มีตัวติดตั้งที่เข้ากันได้สำหรับ {0} บนระบบนี้ (อาจไม่รองรับเวอร์ชัน OS หรือสถาปัตยกรรม) ติดตั้ง {0} ด้วยตนเอง</value>
+    <value>ไม่มีตัวติดตั้งที่เข้ากันได้สำหรับ {0} บนระบบนี้ (อาจไม่รองรับเวอร์ชัน OS หรือสถาปัตยกรรม) ติดตั้ง {0} ด้วยตนเอง</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ ไม่พบ {0} ในแค็ตตาล็อก Windows Package Manager ลองรีเฟรชแหล่งที่มาของ winget หรือติดตั้ง {0} ด้วยตนเอง</value>
+    <value>ไม่พบ {0} ในแค็ตตาล็อก Windows Package Manager ลองรีเฟรชแหล่งที่มาของ winget หรือติดตั้ง {0} ด้วยตนเอง</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ การติดตั้ง {0} ใช้เวลานานกว่า 20 นาที Intelligent Terminal หยุดรอแล้ว แต่ตัวติดตั้งอาจยังคงทำงานอยู่เบื้องหลัง ตรวจสอบ Task Manager หรือลองอีกครั้งในภายหลัง</value>
+    <value>การติดตั้ง {0} ใช้เวลานานกว่า 20 นาที Intelligent Terminal หยุดรอแล้ว แต่ตัวติดตั้งอาจยังคงทำงานอยู่เบื้องหลัง ตรวจสอบ Task Manager หรือลองอีกครั้งในภายหลัง</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) ไม่ได้ติดตั้งหรือไม่พร้อมใช้งาน ติดตั้งก่อน แล้วลองอีกครั้ง</value>
+    <value>Windows Package Manager (winget) ไม่ได้ติดตั้งหรือไม่พร้อมใช้งาน ติดตั้งก่อน แล้วลองอีกครั้ง</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -279,9 +279,9 @@
     <value>อนุญาตให้ Intelligent Terminal เข้าถึงเชลล์ของคุณและตรวจหาข้อผิดพลาดโดยอัตโนมัติ</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ ติดตั้งการรวมเชลล์ล้มเหลว การตรวจจับข้อผิดพลาดถูกปิดใช้งาน คุณสามารถเปิดใช้งานอีกครั้งแล้วลองใหม่ หรือบันทึกเพื่อดำเนินการต่อโดยไม่ใช้</value>
+    <value>ติดตั้งการรวมเชลล์ล้มเหลว การตรวจจับข้อผิดพลาดถูกปิดใช้งาน คุณสามารถเปิดใช้งานอีกครั้งแล้วลองใหม่ หรือบันทึกเพื่อดำเนินการต่อโดยไม่ใช้</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ ติดตั้ง session hooksล้มเหลว การจัดการเซสชันถูกปิดใช้งาน คุณสามารถเปิดใช้งานอีกครั้งแล้วลองใหม่ หรือบันทึกเพื่อดำเนินการต่อโดยไม่ใช้</value>
+    <value>ติดตั้ง session hooksล้มเหลว การจัดการเซสชันถูกปิดใช้งาน คุณสามารถเปิดใช้งานอีกครั้งแล้วลองใหม่ หรือบันทึกเพื่อดำเนินการต่อโดยไม่ใช้</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>เรียนรู้วิธีแก้ไขปัญหานี้ด้วยตนเอง</value>
@@ -297,7 +297,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ นโยบายการดำเนินการของ PowerShell กำลังบล็อกสคริปต์ การตรวจจับข้อผิดพลาดถูกปิดใช้งาน</value>
+    <value>นโยบายการดำเนินการของ PowerShell กำลังบล็อกสคริปต์ การตรวจจับข้อผิดพลาดถูกปิดใช้งาน</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>การใช้งาน</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tr-TR/Resources.resw
@@ -223,39 +223,39 @@
     <value>Ayarlanıyor...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ {0} yüklemesi bir Windows Paket Yöneticisi ilkesi tarafından engellendi. Yönetilen bir cihaz kullanıyorsanız IT yöneticinizle iletişime geçin.</value>
+    <value>{0} yüklemesi bir Windows Paket Yöneticisi ilkesi tarafından engellendi. Yönetilen bir cihaz kullanıyorsanız IT yöneticinizle iletişime geçin.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} yüklenemedi (hata kodu {1}). Ayrıntılar için günlüğe bakın veya {0} paketini el ile yükleyin.</value>
+    <value>{0} yüklenemedi (hata kodu {1}). Ayrıntılar için günlüğe bakın veya {0} paketini el ile yükleyin.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} yüklenemedi. Ayrıntılar için günlüğe bakın veya {0} paketini el ile yükleyin.</value>
+    <value>{0} yüklenemedi. Ayrıntılar için günlüğe bakın veya {0} paketini el ile yükleyin.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} yükleyicisi bir hata bildirdi (kod {1}). Ayrıntılar için günlüğe bakın veya {0} paketini el ile yükleyin.</value>
+    <value>{0} yükleyicisi bir hata bildirdi (kod {1}). Ayrıntılar için günlüğe bakın veya {0} paketini el ile yükleyin.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Windows Paket Yöneticisi'ne {0} yüklenirken ulaşılamadı. İnternet bağlantınızı kontrol edin (VPN, proxy veya güvenlik duvarı engelliyor olabilir) ve tekrar deneyin.</value>
+    <value>Windows Paket Yöneticisi'ne {0} yüklenirken ulaşılamadı. İnternet bağlantınızı kontrol edin (VPN, proxy veya güvenlik duvarı engelliyor olabilir) ve tekrar deneyin.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Bu sistemde {0} için uyumlu bir yükleyici yok (OS sürümü veya mimari desteklenmiyor olabilir). {0} paketini el ile yükleyin.</value>
+    <value>Bu sistemde {0} için uyumlu bir yükleyici yok (OS sürümü veya mimari desteklenmiyor olabilir). {0} paketini el ile yükleyin.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0}, Windows Paket Yöneticisi kataloğunda bulunamadı. winget kaynaklarını yenilemeyi deneyin veya {0} paketini el ile yükleyin.</value>
+    <value>{0}, Windows Paket Yöneticisi kataloğunda bulunamadı. winget kaynaklarını yenilemeyi deneyin veya {0} paketini el ile yükleyin.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} yüklemesi 20 dakikadan uzun sürdü. Intelligent Terminal beklemeyi durdurdu, ancak yükleyici arka planda hâlâ çalışıyor olabilir. Task Manager uygulamasını kontrol edin veya daha sonra tekrar deneyin.</value>
+    <value>{0} yüklemesi 20 dakikadan uzun sürdü. Intelligent Terminal beklemeyi durdurdu, ancak yükleyici arka planda hâlâ çalışıyor olabilir. Task Manager uygulamasını kontrol edin veya daha sonra tekrar deneyin.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Paket Yöneticisi (winget) yüklü değil veya kullanılamıyor. Önce yükleyin, ardından tekrar deneyin.</value>
+    <value>Windows Paket Yöneticisi (winget) yüklü değil veya kullanılamıyor. Önce yükleyin, ardından tekrar deneyin.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -348,9 +348,9 @@
     <value>Intelligent Terminal uygulamasının kabuğunuza erişmesine ve hataları otomatik olarak algılamasına izin verin.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Kabuk tümleştirmesi yüklenemedi. Hata algılama kapatıldı. Yeniden etkinleştirip tekrar deneyebilir veya bu özellik olmadan devam etmek için kaydedebilirsiniz.</value>
+    <value>Kabuk tümleştirmesi yüklenemedi. Hata algılama kapatıldı. Yeniden etkinleştirip tekrar deneyebilir veya bu özellik olmadan devam etmek için kaydedebilirsiniz.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Session hooks yüklenemedi. Oturum yönetimi kapatıldı. Yeniden etkinleştirip tekrar deneyebilir veya bu özellik olmadan devam etmek için kaydedebilirsiniz.</value>
+    <value>Session hooks yüklenemedi. Oturum yönetimi kapatıldı. Yeniden etkinleştirip tekrar deneyebilir veya bu özellik olmadan devam etmek için kaydedebilirsiniz.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Bunu el ile nasıl düzelteceğinizi öğrenin</value>
@@ -366,7 +366,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell yürütme ilkesi betikleri engelliyor. Hata algılama kapatıldı.</value>
+    <value>PowerShell yürütme ilkesi betikleri engelliyor. Hata algılama kapatıldı.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Kullanım</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/tt-RU/Resources.resw
@@ -223,39 +223,39 @@
     <value>Көйләнә...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ {0} урнату Windows Package Manager сәясәте тарафыннан блокланды. Әгәр идарә ителә торган җайланмада булсагыз, IT администраторыгызга мөрәҗәгать итегез.</value>
+    <value>{0} урнату Windows Package Manager сәясәте тарафыннан блокланды. Әгәр идарә ителә торган җайланмада булсагыз, IT администраторыгызга мөрәҗәгать итегез.</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} урнатып булмады (хата коды {1}). Тулырак мәгълүмат өчен журналны карагыз яки {0} кулдан урнатыгыз.</value>
+    <value>{0} урнатып булмады (хата коды {1}). Тулырак мәгълүмат өчен журналны карагыз яки {0} кулдан урнатыгыз.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} урнатып булмады. Тулырак мәгълүмат өчен журналны карагыз яки {0} кулдан урнатыгыз.</value>
+    <value>{0} урнатып булмады. Тулырак мәгълүмат өчен журналны карагыз яки {0} кулдан урнатыгыз.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} урнаткычы хата турында хәбәр итте (код {1}). Тулырак мәгълүмат өчен журналны тикшерегез яки {0} кулдан урнатыгыз.</value>
+    <value>{0} урнаткычы хата турында хәбәр итте (код {1}). Тулырак мәгълүмат өчен журналны тикшерегез яки {0} кулдан урнатыгыз.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} урнатканда Windows Package Manager белән бәйләнеп булмады. Интернет тоташуын тикшерегез (VPN, прокси яки брандмауэр аны блоклый ала) һәм яңадан тырышыгыз.</value>
+    <value>{0} урнатканда Windows Package Manager белән бәйләнеп булмады. Интернет тоташуын тикшерегез (VPN, прокси яки брандмауэр аны блоклый ала) һәм яңадан тырышыгыз.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Бу системада {0} өчен туры килә торган урнаткыч юк (OS версиясе яки архитектура хупланмаска мөмкин). {0} кулдан урнатыгыз.</value>
+    <value>Бу системада {0} өчен туры килә торган урнаткыч юк (OS версиясе яки архитектура хупланмаска мөмкин). {0} кулдан урнатыгыз.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} Windows Package Manager каталогында табылмады. winget чыганакларын яңартып карагыз яки {0} кулдан урнатыгыз.</value>
+    <value>{0} Windows Package Manager каталогында табылмады. winget чыганакларын яңартып карагыз яки {0} кулдан урнатыгыз.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} урнату 20 минуттан озагракка сузылды. Intelligent Terminal көтүдән туктады, ләкин урнаткыч әле дә фонда эшли торган булырга мөмкин. Task Manager-ны тикшерегез яки соңрак яңадан тырышыгыз.</value>
+    <value>{0} урнату 20 минуттан озагракка сузылды. Intelligent Terminal көтүдән туктады, ләкин урнаткыч әле дә фонда эшли торган булырга мөмкин. Task Manager-ны тикшерегез яки соңрак яңадан тырышыгыз.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) урнатылмаган яки мөмкин түгел. Башта аны урнатыгыз, аннары яңадан тырышыгыз.</value>
+    <value>Windows Package Manager (winget) урнатылмаган яки мөмкин түгел. Башта аны урнатыгыз, аннары яңадан тырышыгыз.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -347,9 +347,9 @@
     <value>Intelligent Terminal'га кабыгыгызга керергә һәм хаталарны автоматик рәвештә ачыкларга рөхсәт итегез.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Кабык интеграциясен урнату уңышсыз булды. Хата ачыклау сүндерелде. Аны яңадан кушып тырышырга яки аның бик булмавына карамастан дәвам итәр өчен саклый аласыз.</value>
+    <value>Кабык интеграциясен урнату уңышсыз булды. Хата ачыклау сүндерелде. Аны яңадан кушып тырышырга яки аның бик булмавына карамастан дәвам итәр өчен саклый аласыз.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Session hooks урнату уңышсыз булды. Сессияләрне идарә итү сүндерелде. Аны яңадан кушып тырышырга яки аның бик булмавына карамастан дәвам итәр өчен саклый аласыз.</value>
+    <value>Session hooks урнату уңышсыз булды. Сессияләрне идарә итү сүндерелде. Аны яңадан кушып тырышырга яки аның бик булмавына карамастан дәвам итәр өчен саклый аласыз.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Моны кулдан ничек төзәтергә икәнен өйрәнегез</value>
@@ -365,7 +365,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell үтәү сәясәте скриптларны блоклый. Хата ачыклау сүндерелде.</value>
+    <value>PowerShell үтәү сәясәте скриптларны блоклый. Хата ачыклау сүндерелде.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Куллану</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ug-CN/Resources.resw
@@ -110,39 +110,39 @@
     <value>تەڭشەلىۋاتىدۇ...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ {0} نى ئورنىتىش Windows Package Manager سىياسىتى تەرىپىدىن چەكلەندى. ئەگەر باشقۇرۇلىدىغان ئۈسكۈنىدە بولسىڭىز، IT باشقۇرغۇچىڭىز بىلەن ئالاقىلىشىڭ.</value>
+    <value>{0} نى ئورنىتىش Windows Package Manager سىياسىتى تەرىپىدىن چەكلەندى. ئەگەر باشقۇرۇلىدىغان ئۈسكۈنىدە بولسىڭىز، IT باشقۇرغۇچىڭىز بىلەن ئالاقىلىشىڭ.</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} نى ئورنىتالمىدى (خاتالىق كودى {1}). تەپسىلاتلار ئۈچۈن خاتىرىنى كۆرۈڭ، ياكى {0} نى قولدا ئورنىتىڭ.</value>
+    <value>{0} نى ئورنىتالمىدى (خاتالىق كودى {1}). تەپسىلاتلار ئۈچۈن خاتىرىنى كۆرۈڭ، ياكى {0} نى قولدا ئورنىتىڭ.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} نى ئورنىتالمىدى. تەپسىلاتلار ئۈچۈن خاتىرىنى كۆرۈڭ، ياكى {0} نى قولدا ئورنىتىڭ.</value>
+    <value>{0} نى ئورنىتالمىدى. تەپسىلاتلار ئۈچۈن خاتىرىنى كۆرۈڭ، ياكى {0} نى قولدا ئورنىتىڭ.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} ئورنىتىش پروگراممىسى خاتالىق مەلۇم قىلدى (كود {1}). تەپسىلاتلار ئۈچۈن خاتىرىنى تەكشۈرۈڭ، ياكى {0} نى قولدا ئورنىتىڭ.</value>
+    <value>{0} ئورنىتىش پروگراممىسى خاتالىق مەلۇم قىلدى (كود {1}). تەپسىلاتلار ئۈچۈن خاتىرىنى تەكشۈرۈڭ، ياكى {0} نى قولدا ئورنىتىڭ.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} نى ئورنىتىۋاتقاندا Windows Package Manager غا يېتىپ بارالمىدى. ئىنتېرنېت باغلىنىشىڭىزنى تەكشۈرۈڭ (VPN، ۋاكالەتچى ياكى مۇداپىئە تېمى ئۇنى توسۇۋاتقان بولۇشى مۇمكىن) ۋە قايتا سىناڭ.</value>
+    <value>{0} نى ئورنىتىۋاتقاندا Windows Package Manager غا يېتىپ بارالمىدى. ئىنتېرنېت باغلىنىشىڭىزنى تەكشۈرۈڭ (VPN، ۋاكالەتچى ياكى مۇداپىئە تېمى ئۇنى توسۇۋاتقان بولۇشى مۇمكىن) ۋە قايتا سىناڭ.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ بۇ سىستېمىدا {0} ئۈچۈن ماس كېلىدىغان ئورنىتىش پروگراممىسى يوق (OS نەشرى ياكى قۇرۇلما قوللىماسلىقى مۇمكىن). {0} نى قولدا ئورنىتىڭ.</value>
+    <value>بۇ سىستېمىدا {0} ئۈچۈن ماس كېلىدىغان ئورنىتىش پروگراممىسى يوق (OS نەشرى ياكى قۇرۇلما قوللىماسلىقى مۇمكىن). {0} نى قولدا ئورنىتىڭ.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} Windows Package Manager كاتالوگىدىن تېپىلمىدى. winget مەنبەلىرىنى يېڭىلاپ بېقىڭ، ياكى {0} نى قولدا ئورنىتىڭ.</value>
+    <value>{0} Windows Package Manager كاتالوگىدىن تېپىلمىدى. winget مەنبەلىرىنى يېڭىلاپ بېقىڭ، ياكى {0} نى قولدا ئورنىتىڭ.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} نى ئورنىتىش 20 مىنۇتتىن ئۇزۇن داۋاملاشتى. Intelligent Terminal كۈتۈشنى توختاتتى، لېكىن ئورنىتىش پروگراممىسى يەنىلا ئارقا سۇپىدا ئىجرا بولۇۋاتقان بولۇشى مۇمكىن. Task Manager نى تەكشۈرۈڭ، ياكى كېيىن قايتا سىناڭ.</value>
+    <value>{0} نى ئورنىتىش 20 مىنۇتتىن ئۇزۇن داۋاملاشتى. Intelligent Terminal كۈتۈشنى توختاتتى، لېكىن ئورنىتىش پروگراممىسى يەنىلا ئارقا سۇپىدا ئىجرا بولۇۋاتقان بولۇشى مۇمكىن. Task Manager نى تەكشۈرۈڭ، ياكى كېيىن قايتا سىناڭ.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) ئورنىتىلمىغان ياكى ئىشلەتكىلى بولمايدۇ. ئالدى بىلەن ئۇنى ئورنىتىڭ، ئاندىن قايتا سىناڭ.</value>
+    <value>Windows Package Manager (winget) ئورنىتىلمىغان ياكى ئىشلەتكىلى بولمايدۇ. ئالدى بىلەن ئۇنى ئورنىتىڭ، ئاندىن قايتا سىناڭ.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -234,9 +234,9 @@
     <value>Intelligent Terminal غا شېلىڭىزنى زىيارەت قىلىش ۋە خاتالىقلارنى ئاپتوماتىك بايقاشقا رۇخسەت بېرىڭ.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ شېل بىرلەشتۈرۈشنى ئورنىتىش مەغلۇب بولدى. خاتالىق بايقاش تاقالدى. ئۇنى قايتا ئېچىپ قايتا سىنىيالايسىز، ياكى ئۇنىڭسىز داۋاملاشتۇرۇش ئۈچۈن ساقلىيالايسىز.</value>
+    <value>شېل بىرلەشتۈرۈشنى ئورنىتىش مەغلۇب بولدى. خاتالىق بايقاش تاقالدى. ئۇنى قايتا ئېچىپ قايتا سىنىيالايسىز، ياكى ئۇنىڭسىز داۋاملاشتۇرۇش ئۈچۈن ساقلىيالايسىز.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks ئورنىتىش مەغلۇب بولدى. ئەڭگىمە باشقۇرۇش تاقالدى. ئۇنى قايتا ئېچىپ قايتا سىنىيالايسىز، ياكى ئۇنىڭسىز داۋاملاشتۇرۇش ئۈچۈن ساقلىيالايسىز.</value>
+    <value>session hooks ئورنىتىش مەغلۇب بولدى. ئەڭگىمە باشقۇرۇش تاقالدى. ئۇنى قايتا ئېچىپ قايتا سىنىيالايسىز، ياكى ئۇنىڭسىز داۋاملاشتۇرۇش ئۈچۈن ساقلىيالايسىز.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>بۇنى قولدا قانداق ئوڭشاشنى ئۆگىنىڭ</value>
@@ -252,7 +252,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell ئىجرا سىياسىتى قوليازمىلارنى چەكلەۋاتىدۇ. خاتالىق بايقاش تاقالدى.</value>
+    <value>PowerShell ئىجرا سىياسىتى قوليازمىلارنى چەكلەۋاتىدۇ. خاتالىق بايقاش تاقالدى.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>ئىشلىتىش</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uk-UA/Resources.resw
@@ -1115,39 +1115,39 @@
     <value>Налаштування...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Інсталяцію {0} заблоковано політикою Диспетчера пакетів Windows. Якщо ви використовуєте керований пристрій, зверніться до ІТ-адміністратора.</value>
+    <value>Інсталяцію {0} заблоковано політикою Диспетчера пакетів Windows. Якщо ви використовуєте керований пристрій, зверніться до ІТ-адміністратора.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Не вдалося інсталювати {0} (код помилки {1}). Перегляньте журнал, щоб дізнатися подробиці, або інсталюйте {0} вручну.</value>
+    <value>Не вдалося інсталювати {0} (код помилки {1}). Перегляньте журнал, щоб дізнатися подробиці, або інсталюйте {0} вручну.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Не вдалося інсталювати {0}. Перегляньте журнал, щоб дізнатися подробиці, або інсталюйте {0} вручну.</value>
+    <value>Не вдалося інсталювати {0}. Перегляньте журнал, щоб дізнатися подробиці, або інсталюйте {0} вручну.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Інсталятор {0} повідомив про помилку (код {1}). Перегляньте журнал, щоб дізнатися подробиці, або інсталюйте {0} вручну.</value>
+    <value>Інсталятор {0} повідомив про помилку (код {1}). Перегляньте журнал, щоб дізнатися подробиці, або інсталюйте {0} вручну.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Не вдалося зв’язатися з Диспетчером пакетів Windows під час інсталяції {0}. Перевірте підключення до Інтернету (VPN, проксі або брандмауер можуть його блокувати) і спробуйте знову.</value>
+    <value>Не вдалося зв’язатися з Диспетчером пакетів Windows під час інсталяції {0}. Перевірте підключення до Інтернету (VPN, проксі або брандмауер можуть його блокувати) і спробуйте знову.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ У цій системі немає сумісного інсталятора для {0} (версія ОС або архітектура може не підтримуватися). Інсталюйте {0} вручну.</value>
+    <value>У цій системі немає сумісного інсталятора для {0} (версія ОС або архітектура може не підтримуватися). Інсталюйте {0} вручну.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} не знайдено в каталозі Диспетчера пакетів Windows. Спробуйте оновити джерела winget або інсталюйте {0} вручну.</value>
+    <value>{0} не знайдено в каталозі Диспетчера пакетів Windows. Спробуйте оновити джерела winget або інсталюйте {0} вручну.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Інсталяція {0} тривала довше ніж 20 хвилин. Intelligent Terminal припинив очікування, але інсталятор може й досі працювати у фоновому режимі. Перевірте Task Manager або спробуйте знову пізніше.</value>
+    <value>Інсталяція {0} тривала довше ніж 20 хвилин. Intelligent Terminal припинив очікування, але інсталятор може й досі працювати у фоновому режимі. Перевірте Task Manager або спробуйте знову пізніше.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Диспетчер пакетів Windows (winget) не інстальовано або він недоступний. Спочатку інсталюйте його, а потім спробуйте знову.</value>
+    <value>Диспетчер пакетів Windows (winget) не інстальовано або він недоступний. Спочатку інсталюйте його, а потім спробуйте знову.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1252,9 +1252,9 @@
     <value>Дозвольте Intelligent Terminal отримати доступ до оболонки та автоматично виявляти помилки.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Не вдалося встановити інтеграцію оболонки. Виявлення помилок вимкнено. Ви можете повторно увімкнути його та спробувати знову, або зберегти, щоб продовжити без нього.</value>
+    <value>Не вдалося встановити інтеграцію оболонки. Виявлення помилок вимкнено. Ви можете повторно увімкнути його та спробувати знову, або зберегти, щоб продовжити без нього.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Не вдалося встановити session hooks. Керування сеансами вимкнено. Ви можете повторно увімкнути його та спробувати знову, або зберегти, щоб продовжити без нього.</value>
+    <value>Не вдалося встановити session hooks. Керування сеансами вимкнено. Ви можете повторно увімкнути його та спробувати знову, або зберегти, щоб продовжити без нього.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Дізнайтеся, як виправити це вручну</value>
@@ -1270,7 +1270,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Політика виконання PowerShell блокує сценарії. Виявлення помилок вимкнено.</value>
+    <value>Політика виконання PowerShell блокує сценарії. Виявлення помилок вимкнено.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Використання</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/ur-PK/Resources.resw
@@ -224,50 +224,50 @@
     <value>سیٹ اپ ہو رہا ہے...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows Package Manager پالیسی نے {0} کی انسٹالیشن کو بلاک کر دیا۔ اگر آپ مینیجڈ ڈیوائس پر ہیں، تو اپنے IT ایڈمن سے رابطہ کریں۔</value>
+    <value>Windows Package Manager پالیسی نے {0} کی انسٹالیشن کو بلاک کر دیا۔ اگر آپ مینیجڈ ڈیوائس پر ہیں، تو اپنے IT ایڈمن سے رابطہ کریں۔</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy (group policy disabled the operation).</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} انسٹال نہیں ہو سکا (خرابی کوڈ {1})۔ تفصیلات کے لیے لاگ دیکھیں، یا {0} کو دستی طور پر انسٹال کریں۔</value>
+    <value>{0} انسٹال نہیں ہو سکا (خرابی کوڈ {1})۔ تفصیلات کے لیے لاگ دیکھیں، یا {0} کو دستی طور پر انسٹال کریں۔</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194". Shown for failure causes we don't have a more specific message for.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} انسٹال نہیں ہو سکا۔ تفصیلات کے لیے لاگ دیکھیں، یا {0} کو دستی طور پر انسٹال کریں۔</value>
+    <value>{0} انسٹال نہیں ہو سکا۔ تفصیلات کے لیے لاگ دیکھیں، یا {0} کو دستی طور پر انسٹال کریں۔</value>
     <comment>FRE setup error fallback used when no actionable error code is available (e.g. the catalog connect/search failed before an installer ever ran). {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} انسٹالر نے ایک خرابی رپورٹ کی (کوڈ {1})۔ تفصیلات کے لیے لاگ چیک کریں، یا {0} کو دستی طور پر انسٹال کریں۔</value>
+    <value>{0} انسٹالر نے ایک خرابی رپورٹ کی (کوڈ {1})۔ تفصیلات کے لیے لاگ چیک کریں، یا {0} کو دستی طور پر انسٹال کریں۔</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603). Shown when winget reached the install phase but the installer itself failed.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} انسٹال کرتے وقت Windows Package Manager تک رسائی نہیں ہو سکی۔ اپنا انٹرنیٹ کنکشن چیک کریں (VPN، proxy، یا firewall اسے بلاک کر رہے ہو سکتے ہیں) اور دوبارہ کوشش کریں۔</value>
+    <value>{0} انسٹال کرتے وقت Windows Package Manager تک رسائی نہیں ہو سکی۔ اپنا انٹرنیٹ کنکشن چیک کریں (VPN، proxy، یا firewall اسے بلاک کر رہے ہو سکتے ہیں) اور دوبارہ کوشش کریں۔</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name (FreOverlay_PackageDisplayName_Copilot or _Node). Shown when winget couldn't reach its catalog or the package download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ اس سسٹم پر {0} کے لیے کوئی مطابقت پذیر انسٹالر دستیاب نہیں ہے (OS ورژن یا آرکیٹیکچر سپورٹڈ نہیں ہو سکتا)۔ {0} کو دستی طور پر انسٹال کریں۔</value>
+    <value>اس سسٹم پر {0} کے لیے کوئی مطابقت پذیر انسٹالر دستیاب نہیں ہے (OS ورژن یا آرکیٹیکچر سپورٹڈ نہیں ہو سکتا)۔ {0} کو دستی طور پر انسٹال کریں۔</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). Shown when winget returned NoApplicableInstallers — the manifest exists but no installer entry matches this OS/arch/scope.</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Windows Package Manager کیٹلاگ میں {0} نہیں ملا۔ winget سورسز ریفریش کرنے کی کوشش کریں، یا {0} کو دستی طور پر انسٹال کریں۔</value>
+    <value>Windows Package Manager کیٹلاگ میں {0} نہیں ملا۔ winget سورسز ریفریش کرنے کی کوشش کریں، یا {0} کو دستی طور پر انسٹال کریں۔</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice). Shown when no manifest with the requested package ID was returned from the catalog search.</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} انسٹال ہونے میں 20 منٹ سے زیادہ وقت لگا۔ Intelligent Terminal نے انتظار کرنا بند کر دیا، لیکن انسٹالر اب بھی پس منظر میں چل رہا ہو سکتا ہے۔ Task Manager چیک کریں، یا بعد میں دوبارہ کوشش کریں۔</value>
+    <value>{0} انسٹال ہونے میں 20 منٹ سے زیادہ وقت لگا۔ Intelligent Terminal نے انتظار کرنا بند کر دیا، لیکن انسٹالر اب بھی پس منظر میں چل رہا ہو سکتا ہے۔ Task Manager چیک کریں، یا بعد میں دوبارہ کوشش کریں۔</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name. Shown when our 20-minute hard timeout expired before the install completed.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ session hooks انسٹال کرنے میں ناکامی۔ سیشن کا انتظام بند کر دیا گیا ہے۔ آپ اسے دوبارہ فعال کر کے دوبارہ کوشش کر سکتے ہیں، یا اس کے بغیر جاری رکھنے کے لیے محفوظ کر سکتے ہیں۔</value>
+    <value>session hooks انسٹال کرنے میں ناکامی۔ سیشن کا انتظام بند کر دیا گیا ہے۔ آپ اسے دوبارہ فعال کر کے دوبارہ کوشش کر سکتے ہیں، یا اس کے بغیر جاری رکھنے کے لیے محفوظ کر سکتے ہیں۔</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ شیل انضمام انسٹال کرنے میں ناکامی۔ خرابی کی نشاندہی بند کر دی گئی ہے۔ آپ اسے دوبارہ فعال کر کے دوبارہ کوشش کر سکتے ہیں، یا اس کے بغیر جاری رکھنے کے لیے محفوظ کر سکتے ہیں۔</value>
+    <value>شیل انضمام انسٹال کرنے میں ناکامی۔ خرابی کی نشاندہی بند کر دی گئی ہے۔ آپ اسے دوبارہ فعال کر کے دوبارہ کوشش کر سکتے ہیں، یا اس کے بغیر جاری رکھنے کے لیے محفوظ کر سکتے ہیں۔</value>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell ایگزیکیوشن پالیسی اسکرپٹس کو بلاک کر رہی ہے۔ خرابی کی نشاندہی بند کر دی گئی۔</value>
+    <value>PowerShell ایگزیکیوشن پالیسی اسکرپٹس کو بلاک کر رہی ہے۔ خرابی کی نشاندہی بند کر دی گئی۔</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) انسٹال نہیں ہے یا دستیاب نہیں ہے۔ پہلے اسے انسٹال کریں، پھر دوبارہ کوشش کریں۔</value>
+    <value>Windows Package Manager (winget) انسٹال نہیں ہے یا دستیاب نہیں ہے۔ پہلے اسے انسٹال کریں، پھر دوبارہ کوشش کریں۔</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">

--- a/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/uz-Latn-UZ/Resources.resw
@@ -223,39 +223,39 @@
     <value>Sozlanmoqda...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ {0} oʻrnatilishi Windows Package Manager siyosati tomonidan bloklandi. Agar boshqariladigan qurilmada boʻlsangiz, IT administratoringizga murojaat qiling.</value>
+    <value>{0} oʻrnatilishi Windows Package Manager siyosati tomonidan bloklandi. Agar boshqariladigan qurilmada boʻlsangiz, IT administratoringizga murojaat qiling.</value>
     <comment>FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ {0} oʻrnatib boʻlmadi (xato kodi {1}). Tafsilotlar uchun jurnalni koʻring yoki {0} paketini qoʻlda oʻrnating.</value>
+    <value>{0} oʻrnatib boʻlmadi (xato kodi {1}). Tafsilotlar uchun jurnalni koʻring yoki {0} paketini qoʻlda oʻrnating.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string.</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ {0} oʻrnatib boʻlmadi. Tafsilotlar uchun jurnalni koʻring yoki {0} paketini qoʻlda oʻrnating.</value>
+    <value>{0} oʻrnatib boʻlmadi. Tafsilotlar uchun jurnalni koʻring yoki {0} paketini qoʻlda oʻrnating.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} oʻrnatuvchisi xato haqida xabar berdi (kod {1}). Tafsilotlar uchun jurnalni tekshiring yoki {0} paketini qoʻlda oʻrnating.</value>
+    <value>{0} oʻrnatuvchisi xato haqida xabar berdi (kod {1}). Tafsilotlar uchun jurnalni tekshiring yoki {0} paketini qoʻlda oʻrnating.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is decimal error code.</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ {0} oʻrnatilayotganda Windows Package Manager bilan bogʻlanib boʻlmadi. Internet ulanishingizni tekshiring (VPN, proksi yoki xavfsizlik devori uni bloklayotgan boʻlishi mumkin) va qayta urinib koʻring.</value>
+    <value>{0} oʻrnatilayotganda Windows Package Manager bilan bogʻlanib boʻlmadi. Internet ulanishingizni tekshiring (VPN, proksi yoki xavfsizlik devori uni bloklayotgan boʻlishi mumkin) va qayta urinib koʻring.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Bu tizimda {0} uchun mos oʻrnatuvchi mavjud emas (OS versiyasi yoki arxitektura qoʻllab-quvvatlanmasligi mumkin). {0} paketini qoʻlda oʻrnating.</value>
+    <value>Bu tizimda {0} uchun mos oʻrnatuvchi mavjud emas (OS versiyasi yoki arxitektura qoʻllab-quvvatlanmasligi mumkin). {0} paketini qoʻlda oʻrnating.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ {0} Windows Package Manager katalogida topilmadi. winget manbalarini yangilab koʻring yoki {0} paketini qoʻlda oʻrnating.</value>
+    <value>{0} Windows Package Manager katalogida topilmadi. winget manbalarini yangilab koʻring yoki {0} paketini qoʻlda oʻrnating.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ {0} oʻrnatilishi 20 daqiqadan uzoq davom etdi. Intelligent Terminal kutishni toʻxtatdi, lekin oʻrnatuvchi hali ham fonda ishlayotgan boʻlishi mumkin. Task Manager-ni tekshiring yoki keyinroq qayta urinib koʻring.</value>
+    <value>{0} oʻrnatilishi 20 daqiqadan uzoq davom etdi. Intelligent Terminal kutishni toʻxtatdi, lekin oʻrnatuvchi hali ham fonda ishlayotgan boʻlishi mumkin. Task Manager-ni tekshiring yoki keyinroq qayta urinib koʻring.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) oʻrnatilmagan yoki mavjud emas. Avval uni oʻrnating, soʻng qayta urinib koʻring.</value>
+    <value>Windows Package Manager (winget) oʻrnatilmagan yoki mavjud emas. Avval uni oʻrnating, soʻng qayta urinib koʻring.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -347,9 +347,9 @@
     <value>Intelligent Terminal'ga qobig'ingizga kirish va xatolarni avtomatik aniqlashga ruxsat bering.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Shell integratsiyasini oʻrnatish amalga oshmadi. Xatolarni aniqlash oʻchirildi. Uni qayta yoqish va qayta urinib koʻrishingiz yoki usiz davom etish uchun saqlashingiz mumkin.</value>
+    <value>Shell integratsiyasini oʻrnatish amalga oshmadi. Xatolarni aniqlash oʻchirildi. Uni qayta yoqish va qayta urinib koʻrishingiz yoki usiz davom etish uchun saqlashingiz mumkin.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Session hooks oʻrnatish amalga oshmadi. Seanslarni boshqarish oʻchirildi. Uni qayta yoqish va qayta urinib koʻrishingiz yoki usiz davom etish uchun saqlashingiz mumkin.</value>
+    <value>Session hooks oʻrnatish amalga oshmadi. Seanslarni boshqarish oʻchirildi. Uni qayta yoqish va qayta urinib koʻrishingiz yoki usiz davom etish uchun saqlashingiz mumkin.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Buni qoʻlda qanday tuzatishni oʻrganing</value>
@@ -365,7 +365,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell bajarish siyosati skriptlarni bloklamoqda. Xatolarni aniqlash oʻchirildi.</value>
+    <value>PowerShell bajarish siyosati skriptlarni bloklamoqda. Xatolarni aniqlash oʻchirildi.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Foydalanish</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/vi-VN/Resources.resw
@@ -223,39 +223,39 @@
     <value>Đang thiết lập...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Việc cài đặt {0} đã bị chặn bởi chính sách Windows Package Manager. Nếu bạn đang dùng thiết bị được quản lý, hãy liên hệ với quản trị viên IT.</value>
+    <value>Việc cài đặt {0} đã bị chặn bởi chính sách Windows Package Manager. Nếu bạn đang dùng thiết bị được quản lý, hãy liên hệ với quản trị viên IT.</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ Không thể cài đặt {0} (mã lỗi {1}). Xem nhật ký để biết chi tiết, hoặc cài đặt {0} theo cách thủ công.</value>
+    <value>Không thể cài đặt {0} (mã lỗi {1}). Xem nhật ký để biết chi tiết, hoặc cài đặt {0} theo cách thủ công.</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ Không thể cài đặt {0}. Xem nhật ký để biết chi tiết, hoặc cài đặt {0} theo cách thủ công.</value>
+    <value>Không thể cài đặt {0}. Xem nhật ký để biết chi tiết, hoặc cài đặt {0} theo cách thủ công.</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ Trình cài đặt {0} đã báo cáo lỗi (mã {1}). Xem nhật ký để biết chi tiết, hoặc cài đặt {0} theo cách thủ công.</value>
+    <value>Trình cài đặt {0} đã báo cáo lỗi (mã {1}). Xem nhật ký để biết chi tiết, hoặc cài đặt {0} theo cách thủ công.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ Không thể kết nối với Windows Package Manager trong khi cài đặt {0}. Kiểm tra kết nối Internet của bạn (VPN, proxy hoặc tường lửa có thể đang chặn) rồi thử lại.</value>
+    <value>Không thể kết nối với Windows Package Manager trong khi cài đặt {0}. Kiểm tra kết nối Internet của bạn (VPN, proxy hoặc tường lửa có thể đang chặn) rồi thử lại.</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ Không có trình cài đặt tương thích cho {0} trên hệ thống này (phiên bản OS hoặc kiến trúc có thể không được hỗ trợ). Cài đặt {0} theo cách thủ công.</value>
+    <value>Không có trình cài đặt tương thích cho {0} trên hệ thống này (phiên bản OS hoặc kiến trúc có thể không được hỗ trợ). Cài đặt {0} theo cách thủ công.</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ Không tìm thấy {0} trong danh mục Windows Package Manager. Hãy thử làm mới các nguồn winget, hoặc cài đặt {0} theo cách thủ công.</value>
+    <value>Không tìm thấy {0} trong danh mục Windows Package Manager. Hãy thử làm mới các nguồn winget, hoặc cài đặt {0} theo cách thủ công.</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ Cài đặt {0} mất hơn 20 phút. Intelligent Terminal đã ngừng chờ, nhưng trình cài đặt vẫn có thể đang chạy trong nền. Kiểm tra Task Manager, hoặc thử lại sau.</value>
+    <value>Cài đặt {0} mất hơn 20 phút. Intelligent Terminal đã ngừng chờ, nhưng trình cài đặt vẫn có thể đang chạy trong nền. Kiểm tra Task Manager, hoặc thử lại sau.</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows Package Manager (winget) chưa được cài đặt hoặc không khả dụng. Hãy cài đặt trước, rồi thử lại.</value>
+    <value>Windows Package Manager (winget) chưa được cài đặt hoặc không khả dụng. Hãy cài đặt trước, rồi thử lại.</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -279,9 +279,9 @@
     <value>Cho phép Intelligent Terminal truy cập shell của bạn và tự động phát hiện lỗi.</value>
   </data>
 <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ Không thể cài đặt tích hợp shell. Phát hiện lỗi đã bị tắt. Bạn có thể bật lại và thử lại, hoặc lưu để tiếp tục mà không có nó.</value>
+    <value>Không thể cài đặt tích hợp shell. Phát hiện lỗi đã bị tắt. Bạn có thể bật lại và thử lại, hoặc lưu để tiếp tục mà không có nó.</value>
   </data><data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ Không thể cài đặt session hooks. Quản lý phiên đã bị tắt. Bạn có thể bật lại và thử lại, hoặc lưu để tiếp tục mà không có nó.</value>
+    <value>Không thể cài đặt session hooks. Quản lý phiên đã bị tắt. Bạn có thể bật lại và thử lại, hoặc lưu để tiếp tục mà không có nó.</value>
     <comment>{Locked="hooks"}</comment>
   </data><data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>Tìm hiểu cách khắc phục theo cách thủ công</value>
@@ -297,7 +297,7 @@
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ Chính sách thực thi PowerShell đang chặn các tập lệnh. Phát hiện lỗi đã bị tắt.</value>
+    <value>Chính sách thực thi PowerShell đang chặn các tập lệnh. Phát hiện lỗi đã bị tắt.</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>Mức sử dụng</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-CN/Resources.resw
@@ -1155,39 +1155,39 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>正在设置...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows 程序包管理器策略阻止了 {0} 的安装。如果你使用的是受管理设备，请联系 IT 管理员。</value>
+    <value>Windows 程序包管理器策略阻止了 {0} 的安装。如果你使用的是受管理设备，请联系 IT 管理员。</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ 无法安装 {0}（错误代码 {1}）。请查看日志了解详细信息，或手动安装 {0}。</value>
+    <value>无法安装 {0}（错误代码 {1}）。请查看日志了解详细信息，或手动安装 {0}。</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ 无法安装 {0}。请查看日志了解详细信息，或手动安装 {0}。</value>
+    <value>无法安装 {0}。请查看日志了解详细信息，或手动安装 {0}。</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} 安装程序报告了错误（代码 {1}）。请查看日志了解详细信息，或手动安装 {0}。</value>
+    <value>{0} 安装程序报告了错误（代码 {1}）。请查看日志了解详细信息，或手动安装 {0}。</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ 安装 {0} 时无法访问 Windows 程序包管理器。请检查 Internet 连接（VPN、代理或防火墙可能会阻止连接），然后重试。</value>
+    <value>安装 {0} 时无法访问 Windows 程序包管理器。请检查 Internet 连接（VPN、代理或防火墙可能会阻止连接），然后重试。</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ 此系统上没有可用的 {0} 兼容安装程序（可能不支持 OS 版本或体系结构）。请手动安装 {0}。</value>
+    <value>此系统上没有可用的 {0} 兼容安装程序（可能不支持 OS 版本或体系结构）。请手动安装 {0}。</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ 在 Windows 程序包管理器目录中找不到 {0}。请尝试刷新 winget 源，或手动安装 {0}。</value>
+    <value>在 Windows 程序包管理器目录中找不到 {0}。请尝试刷新 winget 源，或手动安装 {0}。</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ 安装 {0} 花费的时间超过 20 分钟。Intelligent Terminal 已停止等待，但安装程序可能仍在后台运行。请查看 Task Manager，或稍后重试。</value>
+    <value>安装 {0} 花费的时间超过 20 分钟。Intelligent Terminal 已停止等待，但安装程序可能仍在后台运行。请查看 Task Manager，或稍后重试。</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows 程序包管理器 (winget) 未安装或不可用。请先安装它，然后重试。</value>
+    <value>Windows 程序包管理器 (winget) 未安装或不可用。请先安装它，然后重试。</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1199,11 +1199,11 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>{Locked="Node.js","LTS"} Product display name substituted into the FRE install error templates when reporting a winget install failure for the Node.js prerequisite.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ 安装 session hooks 失败。会话管理已关闭。您可以重新启用并重试，或保存以继续而不使用它。</value>
+    <value>安装 session hooks 失败。会话管理已关闭。您可以重新启用并重试，或保存以继续而不使用它。</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ 安装 Shell 集成失败。错误检测已关闭。您可以重新启用并重试，或保存以继续而不使用它。</value>
+    <value>安装 Shell 集成失败。错误检测已关闭。您可以重新启用并重试，或保存以继续而不使用它。</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>了解如何手动修复此问题</value>
@@ -1312,7 +1312,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell 执行策略正在阻止脚本。错误检测已关闭。</value>
+    <value>PowerShell 执行策略正在阻止脚本。错误检测已关闭。</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>用量</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>

--- a/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalApp/Resources/zh-TW/Resources.resw
@@ -1125,39 +1125,39 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>正在設定...</value>
   </data>
   <data name="FreOverlay_InstallError_BlockedByPolicy" xml:space="preserve">
-    <value>⚠ Windows 套件管理員原則封鎖了 {0} 的安裝。如果您使用的是受管理裝置，請連絡您的 IT 管理員。</value>
+    <value>Windows 套件管理員原則封鎖了 {0} 的安裝。如果您使用的是受管理裝置，請連絡您的 IT 管理員。</value>
     <comment>FRE setup error. {0} is the package display name. Shown when winget returned BlockedByPolicy.</comment>
   </data>
   <data name="FreOverlay_InstallError_Generic" xml:space="preserve">
-    <value>⚠ 無法安裝 {0} (錯誤碼 {1})。請查看記錄檔以取得詳細資料，或手動安裝 {0}。</value>
+    <value>無法安裝 {0} (錯誤碼 {1})。請查看記錄檔以取得詳細資料，或手動安裝 {0}。</value>
     <comment>FRE setup error fallback. {0} is the package display name (appears twice). {1} is a pre-formatted HRESULT string like "0x80190194".</comment>
   </data>
   <data name="FreOverlay_InstallError_GenericNoCode" xml:space="preserve">
-    <value>⚠ 無法安裝 {0}。請查看記錄檔以取得詳細資料，或手動安裝 {0}。</value>
+    <value>無法安裝 {0}。請查看記錄檔以取得詳細資料，或手動安裝 {0}。</value>
     <comment>FRE setup error fallback used when no actionable error code is available. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_InstallerFailed" xml:space="preserve">
-    <value>⚠ {0} 安裝程式回報錯誤 (代碼 {1})。請查看記錄檔以取得詳細資料，或手動安裝 {0}。</value>
+    <value>{0} 安裝程式回報錯誤 (代碼 {1})。請查看記錄檔以取得詳細資料，或手動安裝 {0}。</value>
     <comment>FRE setup error. {0} is the package display name (appears twice). {1} is the installer-reported error code as a decimal number (e.g. MSI 1603).</comment>
   </data>
   <data name="FreOverlay_InstallError_Network" xml:space="preserve">
-    <value>⚠ 安裝 {0} 時無法連線到 Windows 套件管理員。請檢查您的網際網路連線 (VPN、Proxy 或防火牆可能封鎖它)，然後再試一次。</value>
+    <value>安裝 {0} 時無法連線到 Windows 套件管理員。請檢查您的網際網路連線 (VPN、Proxy 或防火牆可能封鎖它)，然後再試一次。</value>
     <comment>{Locked="VPN"} FRE setup error. {0} is the package display name. Shown when winget couldn't reach its catalog or download failed with a network-class HRESULT.</comment>
   </data>
   <data name="FreOverlay_InstallError_NoCompatibleInstaller" xml:space="preserve">
-    <value>⚠ 此系統上沒有可用的 {0} 相容安裝程式 (可能不支援 OS 版本或架構)。請手動安裝 {0}。</value>
+    <value>此系統上沒有可用的 {0} 相容安裝程式 (可能不支援 OS 版本或架構)。請手動安裝 {0}。</value>
     <comment>FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_PackageNotFound" xml:space="preserve">
-    <value>⚠ 在 Windows 套件管理員目錄中找不到 {0}。請嘗試重新整理 winget 來源，或手動安裝 {0}。</value>
+    <value>在 Windows 套件管理員目錄中找不到 {0}。請嘗試重新整理 winget 來源，或手動安裝 {0}。</value>
     <comment>{Locked="winget"} FRE setup error. {0} is the package display name (appears twice).</comment>
   </data>
   <data name="FreOverlay_InstallError_Timeout" xml:space="preserve">
-    <value>⚠ 安裝 {0} 花費的時間超過 20 分鐘。Intelligent Terminal 已停止等待，但安裝程式可能仍在背景執行。請查看 Task Manager，或稍後再試。</value>
+    <value>安裝 {0} 花費的時間超過 20 分鐘。Intelligent Terminal 已停止等待，但安裝程式可能仍在背景執行。請查看 Task Manager，或稍後再試。</value>
     <comment>{Locked="Intelligent Terminal","Task Manager"} FRE setup error. {0} is the package display name.</comment>
   </data>
   <data name="FreOverlay_InstallErrorWingetMissing" xml:space="preserve">
-    <value>⚠ Windows 套件管理員 (winget) 未安裝或無法使用。請先安裝，然後再試一次。</value>
+    <value>Windows 套件管理員 (winget) 未安裝或無法使用。請先安裝，然後再試一次。</value>
     <comment>{Locked="winget"} Error shown in the FRE setup overlay when a prerequisite install was attempted but winget itself is not available on this system.</comment>
   </data>
   <data name="FreOverlay_PackageDisplayName_Copilot" xml:space="preserve">
@@ -1169,11 +1169,11 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>{Locked="Node.js","LTS"} Product display name substituted into the FRE install error templates when reporting a winget install failure for the Node.js prerequisite.</comment>
   </data>
   <data name="FreOverlay_InstallErrorHooks" xml:space="preserve">
-    <value>⚠ 安裝 session hooks 失敗。工作階段管理已關閉。您可以重新啟用並重試，或儲存以繼續而不使用它。</value>
+    <value>安裝 session hooks 失敗。工作階段管理已關閉。您可以重新啟用並重試，或儲存以繼續而不使用它。</value>
     <comment>{Locked="hooks"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegration" xml:space="preserve">
-    <value>⚠ 安裝殼層整合失敗。錯誤偵測已關閉。您可以重新啟用並重試，或儲存以繼續而不使用它。</value>
+    <value>安裝殼層整合失敗。錯誤偵測已關閉。您可以重新啟用並重試，或儲存以繼續而不使用它。</value>
   </data>
   <data name="FreOverlay_ErrorHelpLink" xml:space="preserve">
     <value>了解如何手動修正此問題</value>
@@ -1278,7 +1278,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>Body of an error dialog shown after the user tries to install PowerShell shell integration but their PowerShell execution policy (Restricted or AllSigned) is blocking scripts. A separate "Learn how to fix this manually" hyperlink (FreOverlay_ErrorHelpLink) is rendered on its own line below this sentence. {Locked="PowerShell"}</comment>
   </data>
   <data name="FreOverlay_InstallErrorShellIntegrationExecutionPolicy" xml:space="preserve">
-    <value>⚠ PowerShell 執行原則正在封鎖指令碼。錯誤偵測已關閉。</value>
+    <value>PowerShell 執行原則正在封鎖指令碼。錯誤偵測已關閉。</value>
     <comment>{Locked="PowerShell"}</comment>
   </data>
   <data name="UsageGroup/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name" xml:space="preserve"><value>使用量</value><comment>Accessibility name for the session usage summary in the terminal bottom bar.</comment></data>


### PR DESCRIPTION
## Summary of the Pull Request

Moves FRE setup-error warning glyphs out of localized strings and renders them as a monochrome XAML `FontIcon`.

This prevents Windows from rendering the embedded `⚠` character as a colored emoji and keeps FRE iconography consistent with the existing info hints.

## References and Relevant Issues

Addresses review feedback that `FreOverlay_InstallError*` strings still embedded a leading warning emoji.

## Detailed Description of the Pull Request / Additional comments

- Wraps `ErrorText` in a two-column Grid containing:
  - A warning `FontIcon` using `SymbolThemeFontFamily`
  - The existing wrapping and assertive-live-region `TextBlock`
- Uses the existing error foreground color for both the icon and text.
- Removes the leading `⚠ ` from all 12 FRE install-error strings across all 89 TerminalApp locales.
- Covers every error displayed through the shared `ErrorPanel`, avoiding duplicate icons on non-winget setup failures.
- Preserves the existing localized text, help links, text wrapping, and accessibility behavior.

## Validation Steps Performed

- Built `TerminalAppLib` successfully in the x64 Debug configuration.
- Reset the FRE and manually verified the error layout using a temporary debug-only error trigger, which was removed after testing.
- Verified that the error area displays one monochrome warning icon and no embedded emoji.
- Verified that long error text wraps alongside the icon rather than underneath it.
- Exercised the real PowerShell execution-policy failure path using a temporary `Restricted` CurrentUser policy.
- Restored the CurrentUser execution policy to `Undefined` after testing.
- Validated all 1,068 localized `FreOverlay_InstallError*` values and confirmed that none retain the warning prefix.

## PR Checklist

- [ ] Closes #xxx
- [x] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)