### PR TITLE
Recover agent restart after startup failure

### DIFF
--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -1004,6 +1004,10 @@ pub struct App {
     /// Synchronizes a failed post-login ACP task with replacement-master
     /// readiness without letting a late disconnect start a duplicate client.
     auth_recovery_state: AuthRecoveryState,
+    /// `/restart` could not reach an ACP task because its lifecycle receiver
+    /// had already closed. The replacement-master readiness event must start
+    /// a fresh pipe client because no transport disconnect remains to do so.
+    restart_without_acp_pending: bool,
     /// Agent ID selected by user (FRE/preflight) — sent to C++ once connected.
     pending_agent_selection: Option<String>,
     /// Show first-run welcome hint until user sends first message.
@@ -1357,6 +1361,7 @@ impl App {
             needs_post_login_authenticate: false,
             auth_recovery_generation: 0,
             auth_recovery_state: AuthRecoveryState::Idle,
+            restart_without_acp_pending: false,
             pending_agent_selection: None,
             show_welcome_hint: false,
             deferred_acp: None,
@@ -5558,7 +5563,18 @@ impl App {
         for tab_id in self.tab_sessions.keys().cloned().collect::<Vec<_>>() {
             self.project_tab_state(&tab_id);
         }
-        let _ = self.restart_tx.send(AgentLifecycleRequest::RestartMaster);
+        if self
+            .restart_tx
+            .send(AgentLifecycleRequest::RestartMaster)
+            .is_err()
+        {
+            self.restart_without_acp_pending = true;
+            tracing::warn!(
+                target: "helper",
+                "restart lifecycle receiver is closed; asking WT to replace the shared master directly"
+            );
+            crate::wt_protocol_events::send(crate::wt_protocol_events::restart_agent_stack_event());
+        }
         self.publish_agent_status();
     }
 

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -2036,7 +2036,10 @@ impl App {
                     let recovers_retirement_failure =
                         matches!(&self.auth_recovery_state, AuthRecoveryState::Idle)
                             && matches!(&self.state, ConnectionState::Failed(_));
-                    if !completes_auth_recovery && !recovers_retirement_failure {
+                    if !completes_auth_recovery
+                        && !recovers_retirement_failure
+                        && !self.restart_without_acp_pending
+                    {
                         return;
                     }
                     if self.deferred_acp.is_none() {
@@ -2053,6 +2056,7 @@ impl App {
                         %request_id,
                         "replacement master is ready; reconnecting retained helper"
                     );
+                    self.restart_without_acp_pending = false;
                     if completes_auth_recovery {
                         // Invalidate the longer master-readiness timer and arm
                         // the normal connection deadline for this new phase.

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -407,6 +407,19 @@ fn slash_sessions_opens_agents_view() {
 #[test]
 fn slash_restart_resets_connection_and_clears_sessions() {
     let mut app = test_app();
+    let shell_mgr = Arc::clone(&app.shell_mgr);
+    app.set_master_pipe_acp_params(
+        r"\\.\pipe\test-master".into(),
+        "test-agent".into(),
+        Some("claude".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some("owner-tab".into()),
+        shell_mgr,
+        true,
+    );
     app.state = ConnectionState::Connected;
     app.session_id = "live-sid".to_string();
     app.current_tab_mut().session_id = Some("tab-sid".into());
@@ -433,6 +446,23 @@ fn slash_restart_resets_connection_and_clears_sessions() {
         app.current_tab().messages.is_empty(),
         "/restart must wipe per-tab chat history"
     );
+    assert!(
+        app.restart_without_acp_pending,
+        "a closed lifecycle receiver must leave the helper waiting for replacement-master readiness"
+    );
+
+    app.handle_event(AppEvent::WtEvent {
+        method: "agent_master_restarted".into(),
+        pane_id: String::new(),
+        tab_id: None,
+        params: serde_json::json!({ "operation_id": "restart-after-failed-startup" }),
+    });
+
+    assert!(
+        app.pending_acp_start,
+        "replacement-master readiness must reconnect when the original ACP task already exited"
+    );
+    assert!(!app.restart_without_acp_pending);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- fall back to requesting a shared master replacement when `/restart` finds that the failed ACP task already dropped its lifecycle receiver
- reconnect the retained helper after Terminal reports the replacement master ready
- cover the startup-failure restart path with a regression test

## Root cause
After an ACP initialize timeout, the client task exited and dropped the lifecycle receiver. `/restart` ignored the resulting send failure, changed the UI to `Restarting agent...`, and never triggered another connection attempt.

## Testing
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools\wta\Cargo.toml` (1,887 passed, 1 ignored)