### PR TITLE
Clear autofix state when source pane closes

### DIFF
--- a/tools/wta/src/app/autofix.rs
+++ b/tools/wta/src/app/autofix.rs
@@ -479,6 +479,45 @@ impl App {
         self.recompute_chip_override(&active_tab);
     }
 
+    /// Clear autofix state whose source pane has closed. Cancelling a matching
+    /// turn also advances its generation so late agent output cannot restore
+    /// a result for a pane that no longer exists.
+    pub(super) fn handle_autofix_pane_closed(&mut self, target_tab_id: &str, pane_id: &str) {
+        let Some(tab) = self.tab_sessions.get(target_tab_id) else {
+            return;
+        };
+        let turn_matches = tab.turn.prompt().is_some_and(|prompt| {
+            prompt.autofix.is_some() && prompt.context.target_pane_id() == Some(pane_id)
+        });
+        let snapshot_matches = match &tab.autofix.bar_snapshot {
+            AutofixBarSnapshot::Detected {
+                pane_id: source, ..
+            }
+            | AutofixBarSnapshot::Pending {
+                pane_id: source, ..
+            }
+            | AutofixBarSnapshot::Review {
+                pane_id: source, ..
+            } => source == pane_id,
+            AutofixBarSnapshot::Idle => false,
+        };
+        let state_matches = tab.autofix.pane_id.as_deref() == Some(pane_id)
+            || tab.autofix.suggested_pane_id.as_deref() == Some(pane_id)
+            || snapshot_matches;
+
+        if turn_matches {
+            self.turn_cancel_for_tab(target_tab_id);
+        } else if state_matches {
+            let tab = self.tab_mut(target_tab_id);
+            tab.autofix.generation = tab.autofix.generation.wrapping_add(1);
+            if tab.autofix.pane_id.as_deref() == Some(pane_id) {
+                tab.autofix.pane_id = None;
+                tab.autofix.armed_at = None;
+            }
+            self.emit_autofix_state_cleared(target_tab_id);
+        }
+    }
+
     pub(super) fn emit_autofix_state_cleared(&mut self, target_tab_id: &str) {
         // `cleared` carries no pane info — C++ clears its
         // `lastErrorSessionId` based on the state alone. Reusing the

--- a/tools/wta/src/app/autofix.rs
+++ b/tools/wta/src/app/autofix.rs
@@ -78,6 +78,28 @@ pub enum AutofixBarSnapshot {
     },
 }
 
+fn autofix_pane_matches(tab: &TabSession, pane_id: &str) -> (bool, bool) {
+    let turn_matches = tab.turn.prompt().is_some_and(|prompt| {
+        prompt.autofix.is_some() && prompt.context.target_pane_id() == Some(pane_id)
+    });
+    let snapshot_matches = match &tab.autofix.bar_snapshot {
+        AutofixBarSnapshot::Detected {
+            pane_id: source, ..
+        }
+        | AutofixBarSnapshot::Pending {
+            pane_id: source, ..
+        }
+        | AutofixBarSnapshot::Review {
+            pane_id: source, ..
+        } => source == pane_id,
+        AutofixBarSnapshot::Idle => false,
+    };
+    let state_matches = tab.autofix.pane_id.as_deref() == Some(pane_id)
+        || tab.autofix.suggested_pane_id.as_deref() == Some(pane_id)
+        || snapshot_matches;
+    (turn_matches, state_matches)
+}
+
 impl App {
     /// Auto-fix: when a command fails in another pane, ask the coordinator
     /// agent to suggest a fix. The user confirms before execution.
@@ -482,39 +504,31 @@ impl App {
     /// Clear autofix state whose source pane has closed. Cancelling a matching
     /// turn also advances its generation so late agent output cannot restore
     /// a result for a pane that no longer exists.
-    pub(super) fn handle_autofix_pane_closed(&mut self, target_tab_id: &str, pane_id: &str) {
-        let Some(tab) = self.tab_sessions.get(target_tab_id) else {
+    pub(super) fn handle_autofix_pane_closed(&mut self, event_tab_id: Option<&str>, pane_id: &str) {
+        let target_tab_id = event_tab_id.map(str::to_string).or_else(|| {
+            self.tab_sessions.iter().find_map(|(tab_id, tab)| {
+                let (turn_matches, state_matches) = autofix_pane_matches(tab, pane_id);
+                (turn_matches || state_matches).then(|| tab_id.clone())
+            })
+        });
+        let Some(target_tab_id) = target_tab_id else {
             return;
         };
-        let turn_matches = tab.turn.prompt().is_some_and(|prompt| {
-            prompt.autofix.is_some() && prompt.context.target_pane_id() == Some(pane_id)
-        });
-        let snapshot_matches = match &tab.autofix.bar_snapshot {
-            AutofixBarSnapshot::Detected {
-                pane_id: source, ..
-            }
-            | AutofixBarSnapshot::Pending {
-                pane_id: source, ..
-            }
-            | AutofixBarSnapshot::Review {
-                pane_id: source, ..
-            } => source == pane_id,
-            AutofixBarSnapshot::Idle => false,
+        let Some(tab) = self.tab_sessions.get(&target_tab_id) else {
+            return;
         };
-        let state_matches = tab.autofix.pane_id.as_deref() == Some(pane_id)
-            || tab.autofix.suggested_pane_id.as_deref() == Some(pane_id)
-            || snapshot_matches;
+        let (turn_matches, state_matches) = autofix_pane_matches(tab, pane_id);
 
         if turn_matches {
-            self.turn_cancel_for_tab(target_tab_id);
+            self.turn_cancel_for_tab(&target_tab_id);
         } else if state_matches {
-            let tab = self.tab_mut(target_tab_id);
+            let tab = self.tab_mut(&target_tab_id);
             tab.autofix.generation = tab.autofix.generation.wrapping_add(1);
             if tab.autofix.pane_id.as_deref() == Some(pane_id) {
                 tab.autofix.pane_id = None;
                 tab.autofix.armed_at = None;
             }
-            self.emit_autofix_state_cleared(target_tab_id);
+            self.emit_autofix_state_cleared(&target_tab_id);
         }
     }
 

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -2806,9 +2806,7 @@ impl App {
                 if method == "connection_state"
                     && params.get("state").and_then(|v| v.as_str()) == Some("closed")
                 {
-                    if let Some(event_tab) = tab_id.as_deref() {
-                        self.handle_autofix_pane_closed(event_tab, &pane_id);
-                    }
+                    self.handle_autofix_pane_closed(tab_id.as_deref(), &pane_id);
                 }
 
                 // Telemetry: emit ErrorDetected for any non-acknowledged

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -2803,6 +2803,14 @@ impl App {
                     }
                 }
 
+                if method == "connection_state"
+                    && params.get("state").and_then(|v| v.as_str()) == Some("closed")
+                {
+                    if let Some(event_tab) = tab_id.as_deref() {
+                        self.handle_autofix_pane_closed(event_tab, &pane_id);
+                    }
+                }
+
                 // Telemetry: emit ErrorDetected for any non-acknowledged
                 // critical/actionable classification. Acknowledged events are
                 // the auto-silenced "unknown"/"connected"/success cases.

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -762,13 +762,19 @@ impl App {
     /// `autofix_generation` so any chunks that arrive after this point are
     /// dropped by the stale-check in `turn_observe_chunk`.
     pub fn turn_cancel(&mut self, session_id: &str) {
-        let direct_proposal_id = self
-            .session_tab(session_id)
-            .active_direct_proposal_id
-            .clone();
         let target_tab = self.tab_for_session(session_id);
+        self.turn_cancel_for_tab(&target_tab);
+    }
+
+    /// Cancel the in-flight turn owned by a tab. Pane lifecycle cleanup uses
+    /// this before a lazily-created ACP session necessarily has an ID.
+    pub(super) fn turn_cancel_for_tab(&mut self, target_tab: &str) {
+        let direct_proposal_id = self
+            .tab_sessions
+            .get(target_tab)
+            .and_then(|tab| tab.active_direct_proposal_id.clone());
         let pane_id = {
-            let tab = self.session_tab_mut(session_id);
+            let tab = self.tab_mut(target_tab);
             tab.autofix.generation = tab.autofix.generation.wrapping_add(1);
             tab.turn
                 .prompt()
@@ -781,9 +787,9 @@ impl App {
                 .or_else(|| tab.autofix.pane_id.clone())
         };
         if pane_id.is_some() {
-            self.emit_autofix_state_cleared(&target_tab);
+            self.emit_autofix_state_cleared(target_tab);
         }
-        let tab = self.session_tab_mut(session_id);
+        let tab = self.tab_mut(target_tab);
         tab.autofix.armed_at = None;
         let canceled_marker = t!("chat.turn_canceled").into_owned();
         // Three paths into cancel:
@@ -887,7 +893,7 @@ impl App {
         // Esc on a Send card or in-flight autofix exits the chip-override
         // state; release whatever the helper had pinned. C++ falls back to
         // source-of-agent driven rendering.
-        self.recompute_chip_override(&target_tab);
+        self.recompute_chip_override(target_tab);
     }
 
     // ── Internal surface helpers (shared between eager and end-of-turn). ──

--- a/tools/wta/src/autofix_tests.rs
+++ b/tools/wta/src/autofix_tests.rs
@@ -227,6 +227,18 @@ fn closed_event(pane: &str, tab: &str) -> AppEvent {
     }
 }
 
+fn closed_event_without_tab(pane: &str) -> AppEvent {
+    AppEvent::WtEvent {
+        method: "connection_state".to_string(),
+        pane_id: pane.to_string(),
+        tab_id: None,
+        params: serde_json::json!({
+            "session_id": pane,
+            "state": "closed",
+        }),
+    }
+}
+
 #[test]
 fn closing_source_pane_clears_detected_autofix() {
     let mut app = test_app();
@@ -255,7 +267,10 @@ fn closing_source_pane_cancels_pending_autofix() {
 
     app.maybe_trigger_autofix(&failure_notification(pane, Some(tab)));
     let generation = app.tab_mut(tab).autofix.generation;
-    app.handle_event(closed_event(pane, tab));
+    // UI-initiated pane close currently races tab lookup in C++ and commonly
+    // arrives without tab_id. The pane ID is globally unique and must still
+    // resolve the owning tab's autofix state.
+    app.handle_event(closed_event_without_tab(pane));
 
     let tab = app.tab_mut(tab);
     assert!(tab.turn.is_idle());

--- a/tools/wta/src/autofix_tests.rs
+++ b/tools/wta/src/autofix_tests.rs
@@ -214,3 +214,78 @@ fn success_exit_code_does_not_arm_autofix() {
         "a successful command (exit 0) must not submit an autofix turn"
     );
 }
+
+fn closed_event(pane: &str, tab: &str) -> AppEvent {
+    AppEvent::WtEvent {
+        method: "connection_state".to_string(),
+        pane_id: pane.to_string(),
+        tab_id: Some(tab.to_string()),
+        params: serde_json::json!({
+            "session_id": pane,
+            "state": "closed",
+        }),
+    }
+}
+
+#[test]
+fn closing_source_pane_clears_detected_autofix() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.autofix_enabled = false;
+    let pane = "pane-detected";
+    let tab = "tab-detected";
+
+    app.maybe_trigger_autofix(&failure_notification(pane, Some(tab)));
+    app.handle_event(closed_event(pane, tab));
+
+    assert!(matches!(
+        app.tab_mut(tab).autofix.bar_snapshot,
+        AutofixBarSnapshot::Idle
+    ));
+    assert!(app.tab_mut(tab).autofix.trigger_echo_pane.is_none());
+}
+
+#[test]
+fn closing_source_pane_cancels_pending_autofix() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.autofix_enabled = true;
+    let pane = "pane-pending";
+    let tab = "tab-pending";
+
+    app.maybe_trigger_autofix(&failure_notification(pane, Some(tab)));
+    let generation = app.tab_mut(tab).autofix.generation;
+    app.handle_event(closed_event(pane, tab));
+
+    let tab = app.tab_mut(tab);
+    assert!(tab.turn.is_idle());
+    assert!(tab.autofix.pane_id.is_none());
+    assert!(matches!(tab.autofix.bar_snapshot, AutofixBarSnapshot::Idle));
+    assert_eq!(tab.autofix.generation, generation.wrapping_add(1));
+}
+
+#[test]
+fn closing_source_pane_clears_review_but_unrelated_close_does_not() {
+    let mut app = test_app();
+    let pane = "pane-review";
+    let tab = "tab-review";
+    {
+        let tab = app.tab_mut(tab);
+        tab.autofix.suggested_pane_id = Some(pane.to_string());
+        tab.autofix.bar_snapshot = AutofixBarSnapshot::Review {
+            pane_id: pane.to_string(),
+            hotkey_hint: "Ctrl+Alt+.".to_string(),
+        };
+    }
+
+    app.handle_event(closed_event("other-pane", tab));
+    assert!(matches!(
+        app.tab_mut(tab).autofix.bar_snapshot,
+        AutofixBarSnapshot::Review { .. }
+    ));
+
+    app.handle_event(closed_event(pane, tab));
+    let tab = app.tab_mut(tab);
+    assert!(tab.autofix.suggested_pane_id.is_none());
+    assert!(matches!(tab.autofix.bar_snapshot, AutofixBarSnapshot::Idle));
+}


### PR DESCRIPTION
## Summary
- clear Detected and Review autofix state when its source pane closes
- cancel matching in-flight autofix turns by tab so late agent output cannot restore stale state
- cover pending, detected, review, and unrelated-pane close behavior

Closes #787