### PR TITLE
Hide diagnostics glyph when idle

### DIFF
--- a/src/cascadia/TerminalApp/AgentPaneContent.h
+++ b/src/cascadia/TerminalApp/AgentPaneContent.h
@@ -10,6 +10,8 @@
 #include "TerminalPaneContent.h"
 #include "BasicPaneEvents.h"
 
+#include "AutofixState.h"
+
 namespace winrt::TerminalApp::implementation
 {
     struct AgentPaneContent : AgentPaneContentT<AgentPaneContent>, BasicPaneEvents
@@ -81,18 +83,9 @@ namespace winrt::TerminalApp::implementation
         // Driven by inbound `autofix_state_changed` events for this pane's
         // owning tab. The window-level bottom bar reads these accessors
         // when refreshing for the active tab.
-        enum class AutofixState
-        {
-            Idle,
-            Detected,
-            Pending,
-            // Analysis finished; the result (fix or explanation) is waiting
-            // in the agent pane chat. Surfaced only when the pane is closed
-            // — the helper decides via pane_open and sends Idle instead when
-            // it's already open. Replaces the old Armed/Suggested split:
-            // autofix no longer auto-executes, so both surface identically.
-            Review,
-        };
+        // Analysis results use Review while waiting in a closed agent pane.
+        // The helper sends Idle instead when the pane is already open.
+        using AutofixState = ::TerminalApp::Autofix::State;
         // Update the diagnostics state from an inbound autofix_state event
         // (single-writer for this pane's state). `pane_id` and other fields
         // come from the JSON payload; we only stash strings that the bar

--- a/src/cascadia/TerminalApp/AgentPaneContent.h
+++ b/src/cascadia/TerminalApp/AgentPaneContent.h
@@ -136,9 +136,9 @@ namespace winrt::TerminalApp::implementation
         AutofixState GetAutofixState() const noexcept { return _autofixState; }
         // True once the helper's ACP session has reached Connected (driven
         // by the `agent_status` `state` field via UpdateAgentStatus). The
-        // bottom-bar diagnostics group is gated on this: no autofix
+        // One gate for the bottom-bar diagnostics group: no autofix
         // capability exists before connect (cold start) or after a
-        // failure/disconnect, so the button must not appear at all.
+        // failure/disconnect. An actionable autofix state is also required.
         bool IsAgentConnected() const noexcept { return _agentState == L"connected"; }
         // True after the first agent_status routed to this pane. The helper
         // subscribes to WT events before it can publish that status, so this

--- a/src/cascadia/TerminalApp/AgentPaneContent.h
+++ b/src/cascadia/TerminalApp/AgentPaneContent.h
@@ -128,8 +128,8 @@ namespace winrt::TerminalApp::implementation
         // Accessors for state that the window-level bottom bar projects.
         AutofixState GetAutofixState() const noexcept { return _autofixState; }
         // True once the helper's ACP session has reached Connected (driven
-        // by the `agent_status` `state` field via UpdateAgentStatus). The
-        // One gate for the bottom-bar diagnostics group: no autofix
+        // by the `agent_status` `state` field via UpdateAgentStatus). This is
+        // one gate for the bottom-bar diagnostics group: no autofix
         // capability exists before connect (cold start) or after a
         // failure/disconnect. An actionable autofix state is also required.
         bool IsAgentConnected() const noexcept { return _agentState == L"connected"; }

--- a/src/cascadia/TerminalApp/AutofixState.h
+++ b/src/cascadia/TerminalApp/AutofixState.h
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#pragma once
+
+namespace TerminalApp::Autofix
+{
+    enum class State
+    {
+        Idle,
+        Detected,
+        Pending,
+        Review,
+    };
+
+    [[nodiscard]] constexpr bool HasDiagnostics(const State state) noexcept
+    {
+        return state == State::Detected ||
+               state == State::Pending ||
+               state == State::Review;
+    }
+}

--- a/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
+++ b/src/cascadia/TerminalApp/TerminalAppLib.vcxproj
@@ -202,6 +202,7 @@
     <ClInclude Include="AgentPaneContent.h">
       <DependentUpon>AgentPaneContent.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="AutofixState.h" />
     <ClInclude Include="AgentUsage.h" />
     <ClInclude Include="FreOverlay.h">
       <DependentUpon>FreOverlay.xaml</DependentUpon>

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3981,13 +3981,14 @@ namespace winrt::TerminalApp::implementation
 
         if (auto diagBtn = DiagnosticsButton())
         {
-            // Show gate — the diagnostics group appears only when BOTH:
+            // Show gate — the diagnostics group appears only when ALL:
             //   * error detection is enabled (detect OFF = the user opted
             //     out of shell observation: no pill, no pipeline), AND
             //   * the active tab's helper ACP session is Connected (before
             //     connect / after a failure-disconnect there's no autofix
-            //     capability).
-            // Either false → hide the whole group rather than show a dead,
+            //     capability), AND
+            //   * an error is detected, being analyzed, or ready for review.
+            // Otherwise hide the whole group rather than show a dead,
             // faded button. Event-driven, not polled: runs from the
             // AgentPaneContent::StateChanged handler (agent_status flips
             // connected/disconnected) and on settings changes. Detection is
@@ -3996,7 +3997,11 @@ namespace winrt::TerminalApp::implementation
             // via `autofix_state`.
             const bool detectionEnabled =
                 _settings && _settings.GlobalSettings().EffectiveAutoErrorDetectionEnabled();
-            const bool showGroup = detectionEnabled && agentConnected;
+            const bool hasDiagnostics =
+                autofixState == AS::Detected ||
+                autofixState == AS::Pending ||
+                autofixState == AS::Review;
+            const bool showGroup = detectionEnabled && agentConnected && hasDiagnostics;
             if (const auto group = DiagnosticsGroup())
             {
                 group.Visibility(showGroup ? Visibility::Visible : Visibility::Collapsed);
@@ -4096,17 +4101,7 @@ namespace winrt::TerminalApp::implementation
             case AS::Idle:
             default:
             {
-                diagBtn.Opacity(0.5);
                 diagBtn.IsEnabled(false);
-                ToolTipService::SetToolTip(
-                    diagBtn,
-                    box_value(RS_(L"Diagnostics_Tooltip")));
-                if (icon)
-                {
-                    icon.Foreground(
-                        winrt::Windows::UI::Xaml::Media::SolidColorBrush{
-                            winrt::Windows::UI::ColorHelper::FromArgb(255, 0xB0, 0xB0, 0xB0) });
-                }
                 if (label)
                 {
                     label.Visibility(Visibility::Collapsed);

--- a/src/cascadia/TerminalApp/TerminalPage.cpp
+++ b/src/cascadia/TerminalApp/TerminalPage.cpp
@@ -3997,10 +3997,7 @@ namespace winrt::TerminalApp::implementation
             // via `autofix_state`.
             const bool detectionEnabled =
                 _settings && _settings.GlobalSettings().EffectiveAutoErrorDetectionEnabled();
-            const bool hasDiagnostics =
-                autofixState == AS::Detected ||
-                autofixState == AS::Pending ||
-                autofixState == AS::Review;
+            const bool hasDiagnostics = ::TerminalApp::Autofix::HasDiagnostics(autofixState);
             const bool showGroup = detectionEnabled && agentConnected && hasDiagnostics;
             if (const auto group = DiagnosticsGroup())
             {

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -153,7 +153,8 @@
 
             <!-- Button 2: Diagnostics / Warning — clickable once a fix is armed.
                  Starts Collapsed: the group only appears while the active tab
-                 has a connected helper and an error to report. -->
+                 has error detection enabled, a connected helper, and an error
+                 to report. -->
             <StackPanel x:Name="DiagnosticsGroup"
                         Grid.Column="1"
                         Orientation="Horizontal"

--- a/src/cascadia/TerminalApp/TerminalPage.xaml
+++ b/src/cascadia/TerminalApp/TerminalPage.xaml
@@ -152,9 +152,8 @@
             </Button>
 
             <!-- Button 2: Diagnostics / Warning — clickable once a fix is armed.
-                 Starts Collapsed: the group only appears once the active tab's
-                 helper ACP session reaches Connected (gated in
-                 _UpdateBottomBarState off the agent_status event). -->
+                 Starts Collapsed: the group only appears while the active tab
+                 has a connected helper and an error to report. -->
             <StackPanel x:Name="DiagnosticsGroup"
                         Grid.Column="1"
                         Orientation="Horizontal"
@@ -167,7 +166,6 @@
                         Padding="6,0"
                         Background="Transparent"
                         BorderBrush="Transparent"
-                        Opacity="0.5"
                         IsEnabled="False"
                         ToolTipService.ToolTip="Diagnostics"
                         Click="_DiagnosticsButtonOnClick">

--- a/src/cascadia/ut_app/AutofixStateTests.cpp
+++ b/src/cascadia/ut_app/AutofixStateTests.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+#include "precomp.h"
+
+#include "../TerminalApp/AutofixState.h"
+
+using namespace WEX::TestExecution;
+
+namespace TerminalAppUnitTests
+{
+    class AutofixStateTests
+    {
+        TEST_CLASS(AutofixStateTests);
+
+        TEST_METHOD(IdleHasNoDiagnostics);
+        TEST_METHOD(ActionableStatesHaveDiagnostics);
+    };
+
+    void AutofixStateTests::IdleHasNoDiagnostics()
+    {
+        VERIFY_IS_FALSE(TerminalApp::Autofix::HasDiagnostics(TerminalApp::Autofix::State::Idle));
+    }
+
+    void AutofixStateTests::ActionableStatesHaveDiagnostics()
+    {
+        using State = TerminalApp::Autofix::State;
+
+        VERIFY_IS_TRUE(TerminalApp::Autofix::HasDiagnostics(State::Detected));
+        VERIFY_IS_TRUE(TerminalApp::Autofix::HasDiagnostics(State::Pending));
+        VERIFY_IS_TRUE(TerminalApp::Autofix::HasDiagnostics(State::Review));
+    }
+}

--- a/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
+++ b/src/cascadia/ut_app/TerminalApp.UnitTests.vcxproj
@@ -27,6 +27,7 @@
     <ClCompile Include="AcpModelUtilsTests.cpp" />
     <ClCompile Include="AgentSourceUtilsTests.cpp" />
     <ClCompile Include="AgentUsageTests.cpp" />
+    <ClCompile Include="AutofixStateTests.cpp" />
     <ClCompile Include="BoundedDispatchQueueTests.cpp" />
     <ClCompile Include="CustomAgentIdTests.cpp" />
     <ClCompile Include="ProtocolParsingTests.cpp" />


### PR DESCRIPTION
## Summary
- hide the diagnostics group when Autofix has nothing to report
- keep detected, analyzing, and review states visible
- remove the unused grey idle presentation
- extract and unit test the diagnostics visibility predicate

## Testing
- TerminalAppUnitTests::AutofixStateTests (2 passed)
- built TerminalApp and the Debug package
- deployed and launched the Debug package

Closes #794