### PR TITLE
perf(wta): cut agent pane startup and autofix prompt latency

### DIFF
--- a/doc/specs/agent-pane-latency-analysis.md
+++ b/doc/specs/agent-pane-latency-analysis.md
@@ -1,0 +1,344 @@
+---
+author: Performance
+created_on: 2026-09-03
+last_updated: 2026-09-03
+issue_id: n/a
+---
+
+# Agent pane latency: profiling and optimizations
+
+## Summary
+
+A performance pass over the agent pane's startup and prompt paths, profiling
+where wall-clock time actually goes between launching a pane and getting a
+response back. This records the hot spots that profiling surfaced, the
+optimizations applied to each, and the measured result.
+
+Two changes account for essentially all of the win:
+
+| Scenario | Before | After | Win |
+| --- | --- | --- | --- |
+| Agent pane: self-discovery on startup | 0.27 s | **0.002 s** | −0.27 s, every pane |
+| Agent pane: helper → master pipe connected | 0.39 s | **0.15 s** | −0.24 s, every pane |
+| Agent pane: helper → session usable | 3.29 s | **3.04 s** | −0.25 s, every pane |
+| Autofix turn: work before the prompt is sent | 4.02 s | **0.39 s** | **−3.6 s** |
+
+All figures are medians of repeated runs on the same machine, comparing the
+**same commit and same build configuration** with only `wta.exe` swapped, so the
+deltas are attributable to these changes and nothing else. Method and caveats are
+in [Measurement](#measurement).
+
+---
+
+## Change 1 — Delete `discover_pane_identity`
+
+**File:** `tools/wta/src/helper/runtime.rs`
+
+### What it did
+
+On every agent pane launch, the helper worked out its own pane identity by
+enumerating Windows Terminal:
+
+```rust
+let windows = shell_mgr.wt_list_windows().await.ok()?;      // 1 process
+for win in windows_arr {
+    let tabs = shell_mgr.wt_list_tabs(&window_id).await.ok()?;      // + 1 per window
+    for tab in tabs_arr {
+        let panes = shell_mgr.wt_list_panes(&tab_id, ...).await.ok()?;  // + 1 per tab
+        // ... match panes by our own PID
+```
+
+Every one of those calls spawns a **separate `wtcli.exe` process** plus an
+out-of-proc COM activation (`cli_channel.rs`, `request()` → `run_wtcli_one_shot`).
+So the cost was `1 + windows + tabs` process launches — it grew with how many
+tabs the user had open — and it ran *before* the TUI entered the alt-screen, so
+the pane was blank for the whole duration.
+
+### Why it was safe to delete
+
+All three values it returned were already available for free, and the code
+itself was throwing two of them away:
+
+```rust
+if let Some((pane_id, _tab_id, window_id)) = pane_identity {
+    app_state.pane_id = Some(pane_id);
+    // discover_pane_identity returns the legacy unstable tab
+    // index, not the GUID — ignore it. ...
+    app_state.window_id = Some(window_id);
+}
+else if let Some(pane_id) = std::env::var("WT_SESSION") ... {
+    app_state.pane_id = Some(pane_id);          // identical value, free
+}
+
+if let Some(owner_window_id) = config.owner_window_id... {
+    app_state.window_id = Some(owner_window_id.to_string());  // overwrites it anyway
+}
+```
+
+- `tab_id` — discarded on purpose; the real one comes from `--owner-tab-id`.
+- `window_id` — unconditionally overwritten by `--owner-window-id` a few lines later.
+- `pane_id` — `WT_SESSION` already holds it. `ConptyConnection.cpp` sets it on
+  every pane it spawns, and the `else` branch already read it.
+
+The fix promotes the `WT_SESSION` branch to the primary path and deletes the
+enumeration. Behaviour is identical.
+
+**Supporting evidence:** profiling the current shipping build shows this
+enumeration spending ~172 ms and then not matching, logging
+`seeded app_state.pane_id from WT_SESSION fallback` — it pays the full cost and
+still resolves via the free value.
+
+### Impact
+
+| Metric | Before | After |
+| --- | --- | --- |
+| Self-discovery | 0.248 / 0.268 / 0.281 s | **0.002 / 0.002 / 0.003 s** |
+| Helper start → pipe connected | 0.365 / 0.394 / 0.400 s | **0.143 / 0.147 / 0.149 s** |
+| Helper start → session usable | 3.245 / 3.290 / 3.562 s | **2.994 / 3.037 / 3.087 s** |
+
+Scales with tab count: the more tabs a user has open, the more this cost.
+
+---
+
+## Change 2 — Stop blocking the prompt on the PowerShell command enumerate
+
+**Files:** `tools/wta/src/command_recall.rs`,
+`tools/wta/src/protocol/acp/prompt_context.rs`
+
+### What it did
+
+`CommandNotFoundProvider` adds a "did you mean…" hint when a failed command
+doesn't exist. To do that it enumerates the shell's commands — which **loads the
+user's interactive PowerShell profile**, bounded at 4 s, and on timeout falls
+back to a *second* `-NoProfile` subprocess.
+
+That ran **inline, before the prompt was sent to the agent**. Measured directly
+on the test machine:
+
+| Subprocess | Cost |
+| --- | --- |
+| Profile-loading enumerate | 6,175 ms (exceeds its own 4 s bound → killed) |
+| `-NoProfile` fallback enumerate | 5,397 ms |
+
+A real turn from the logs before the fix:
+```
+bysis aphase=context_provider  id=command_not_found  dt=5.820s
+phase=context_ready     context_build=6.231s
+phase=first_text        since_submit=14.341s
+```
+
+**6.2 of the 14.3 seconds to first token was spent before the agent received
+anything.** The result is cached, but per helper — so every new agent pane paid
+it again on its first autofix turn.
+
+### The fix
+
+A near-match hint is a best-effort enhancement, so it must never gate the
+response. `powershell_near_matches_now` returns a result **only if the cache is
+already warm**; on a miss it returns `None` and kicks off a single-flight
+background enumerate. Worst case is now "no hint on the first autofix turn"
+instead of a multi-second stall.
+
+The warm is deliberately **lazy** — started by the lookup itself on a miss, not
+from context resolution. Context resolution runs on every turn including planner
+turns, where the hint is never used, so warming there would spawn a ~3 s
+PowerShell that competes with the foreground prompt for no benefit. Misses only
+happen on autofix turns, which is exactly where the hint is consumed.
+
+### Impact
+
+Identical builds, same forced not-found command:
+
+| Metric | Before | After |
+| --- | --- | --- |
+| `command_not_found` provider | 3.679 s | **0.009 s** |
+| Total context build | 4.017 s | **0.381 s** |
+| Elapsed before prompt is sent | 4.020 s | **0.385 s** |
+
+(The pre-fix run spent 3.679 s and still returned `present=false` — it paid the
+full enumerate and produced no hint.)
+
+---
+
+## Change 3 — Don't smooth the first reveal of a turn
+
+**File:** `tools/wta/src/app.rs`
+
+Included for completeness; smaller than the two above and **not benchmarked**.
+
+The typewriter animation revealed `max(3, backlog/4)` chars per 33 ms frame, so
+the opening characters of a response trailed their arrival by up to 4 frames
+(~130 ms). Time-to-first-token is the most visible latency in a turn, so the
+first reveal is now un-throttled and only the continuation is paced. Total
+response time is unchanged either way.
+
+---
+
+## Measurement
+
+The numbers in this document are medians of **12 cold starts and 24 live prompts**
+against Copilot, driven through the Windows Terminal COM protocol rather than by
+hand. Timings come from instrumentation that already exists: helper startup
+milestones and the `prompt_timing` phases in `turn_metrics.rs` (`WTA_LOG=debug`).
+To reproduce or extend this, see [How to verify a change](#how-to-verify-a-change).
+
+### Caveats — read these before quoting numbers
+
+1. **Do not benchmark against the shipping public build for attribution.** It is
+   an optimized *Release* build of a much older codebase (0.2.2395.0) and differs
+   by far more than these changes. Every table above compares the *same commit
+   and same Debug configuration* with only `wta.exe` swapped. For reference only,
+   public build medians were: self-discovery 0.19 s, pipe connect 0.28 s, session
+   usable 3.31 s.
+2. **Time-to-first-token is model/network time** (measured spread 4.8–11.5 s).
+   None of these changes affect it and it should not be read as a result.
+3. These are Debug-build numbers. Release will be faster across the board; the
+   *deltas* are what this document claims.
+
+---
+
+## Deliberately not done
+
+| Candidate | Why not |
+| --- | --- |
+| Make `list_sessions` concurrent with `session/new` | Measured at **~1 ms**. Would risk the documented stale-snapshot ordering race for no gain. |
+| Pre-spawn the default agent CLI at master startup | Unsafe as specified. The pool key (`agent_cmd_key_with_provider`) folds in a `provider_binding` the master cannot know at startup — the helper declares it during `initialize`. Pre-spawning under a guessed key would **add a second agent process** rather than warm the pool. |
+
+---
+
+## Remaining work
+
+Four items, ranked by expected value. Each is independent — take them in any
+order. Estimates are from the measurements in this document.
+
+### W1 — Replace per-call `wtcli.exe` spawns with a persistent channel
+
+**Expected win:** ~0.15–0.9 s per prompt, plus startup. Largest remaining item.
+
+**Problem.** `CliChannel::request` (`tools/wta/src/shell/wt_channel/cli_channel.rs`)
+maps every protocol method onto a one-shot `wtcli.exe` invocation via
+`run_wtcli_one_shot`. Each call is a process creation plus an out-of-proc COM
+activation, measured at **66–94 ms**. The prompt path alone makes 2–3 of these
+per turn (`get_active_pane`, `read_pane_output`, and `resolve_pane_by_session_id`
+when a source pane is known — the last one enumerates, so it costs
+`1 + windows + tabs` spawns).
+
+**Do this.** A durable child already exists: `start_reader` runs
+`wtcli listen --json` for the lifetime of the helper. Extend that pattern into a
+request/response channel — one long-lived connection carrying correlated
+request IDs — and route `request()` through it, keeping the one-shot path only as
+a fallback when the persistent channel is unavailable.
+
+**Acceptance.** Per-turn overhead (`prompt_timing … phase=prompt_sent`) drops
+below ~0.10 s median. No change to `wtcli`'s own CLI behaviour, which is a
+supported user-facing surface.
+
+**Watch out for.** `wtcli` is also a user-facing command; do not regress its
+standalone semantics. Preserve the existing timeout/reap behaviour
+(`WTCLI_ONE_SHOT_TIMEOUT`) so a hung Terminal cannot wedge a pane.
+
+### W2 — Paint the TUI before `session/new` completes
+
+**Expected win:** 0.8–2.5 s of *perceived* startup on every pane.
+
+**Problem.** `session/new` accounts for most of the remaining time to a usable
+pane (~1.8 s of the ~3.0 s total). The pane shows "Creating session…" for that
+entire window, so it reads as the agent being slow to attach.
+
+**Do this.** The TUI needs no session id to render its frame, history, or input
+box. Render immediately and accept typing while `session/new` is in flight, then
+attach the session when it resolves. `dispatch_prompt_body`
+(`tools/wta/src/protocol/acp/client.rs`) already contains a lazy
+create-on-first-prompt path, so a prompt submitted before the bootstrap session
+exists has a defined outcome.
+
+**Acceptance.** First paint is independent of `session/new`; a prompt typed
+during startup is not lost.
+
+**Watch out for.** Two creation paths racing. The bootstrap `session/new` and the
+lazy create must not both produce a session for the same tab — that was
+previously a duplicate-row bug in the sessions view.
+
+### W3 — Diagnose duplicate agent CLI spawns
+
+**Expected win:** avoids repeated ~3.7 s agent initializes; also cuts memory.
+
+**Problem.** In one 8-second window the master spawned `copilot.exe` **5 times**
+and completed `initialize` **4 times**, all for the same
+`agent_cmd=copilot --acp --stdio`, `agent_source=host`. A pooled CLI was also
+reaped 1.5 ms after a helper disconnected, suggesting a pooled process's lifetime
+is coupled to a departing helper rather than to remaining pool references.
+
+**Do this — diagnosis first.** The "agent CLI spawned" log line does not include
+the pool key, so it is currently impossible to tell from logs whether duplicates
+share a key. Add `agent_cmd_key_with_provider(...)` to that line
+(`tools/wta/src/master/mod.rs`), reproduce, then confirm which of these is
+happening:
+
+- **Different keys.** The key folds in `provider_binding.pool_key()` (`native` /
+  `legacy` / `<selection>@<generation>`), so two helpers resolving different
+  bindings for the same agent get separate CLIs.
+- **Respawn after reap.** `acquire_and_bind_agent` loops `acquire()` when
+  `bind_helper_to_agent` fails; once a reap has removed the key, the retry
+  creates a fresh cell and a fresh process.
+
+Fix whichever it turns out to be. Do not "fix" this by pre-spawning at startup —
+see [Deliberately not done](#deliberately-not-done).
+
+**Acceptance.** One agent CLI process per distinct pool key across a session;
+helper disconnect never reaps a CLI another helper is still bound to.
+
+### W4 — Investigate helper connect/exit churn
+
+**Expected win:** less CPU contention during the window the user is waiting on.
+
+**Problem.** 8 helpers connected in 8 s and six of them exited within ~20–30 ms.
+Each is a full `wta.exe` process spawn plus a pipe handshake, competing with the
+startup the user is actually waiting for.
+
+**Do this.** Establish where the short-lived helpers come from — pre-warm firing
+per tab (`_InitializeTab` low-priority callback and
+`_PrewarmAgentPanesAfterStartup` in `src/cascadia/TerminalApp/`) is the first
+place to look — and suppress the ones that are immediately discarded.
+
+**Acceptance.** Helper count over a cold start matches the number of tabs that
+actually keep an agent pane.
+
+---
+
+## How to verify a change
+
+There is no committed harness; the following is enough to build one.
+
+**Instrumentation already exists — turn it on.** Set `WTA_LOG=debug` at *User*
+scope (a packaged app does not inherit the calling shell's environment), then
+read:
+
+- **Connection phases** from the helper log milestones:
+  `wta-helper starting` → `Connected to WT COM` → `start_reader: starting` →
+  `master pipe connected` → `ACP initialized over master pipe` →
+  `Session created (over pipe)`.
+- **Per-turn phases** from the `prompt_timing` records emitted by
+  `tools/wta/src/protocol/acp/turn_metrics.rs`: `prompt_received`,
+  `context_provider` (one per provider, with `dt=`), `context_ready`,
+  `prompt_sent`, `first_event`, `first_text`.
+
+Logs live under
+`Packages<PFN>\LocalCache\Local\IntelligentTerminal\logs<version>\`.
+
+**Driving prompts without a human.** The helper log prints the COM CLSID in its
+`get_capabilities` response, and the agent pane's id appears as
+`pane_session_id=…`. Setting `WT_COM_CLSID` from the former lets
+`wtcli send-keys -t <pane> --raw <text>` (then `Enter`) submit a real prompt —
+this works even while the pane is stashed, so no UI automation is needed.
+
+**Two rules for reporting numbers.**
+
+1. **Hold the build configuration fixed and swap only `wta.exe`.** Comparing
+   against a different configuration — or against the shipping Release package,
+   which is also an older codebase — measures that difference too, not your
+   change.
+2. **Report medians over several cold starts, and never quote `first_text` as a
+   latency result.** It is dominated by model/network time; the observed spread
+   was 4.8–11.5 s. The client-side number that reflects our work is
+   `phase=prompt_sent` (everything before the agent receives the prompt).

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4726,6 +4726,13 @@ impl App {
         // `REVEAL_CATCHUP_FRAMES` ticks (~130ms).
         const REVEAL_MIN_STEP: usize = 3;
         const REVEAL_CATCHUP_FRAMES: usize = 4;
+        // The *first* reveal of a turn is not smoothed. Time-to-first-token is
+        // the latency users actually feel (and the one they compare against a
+        // bare agent CLI), so the opening burst is shown as soon as it arrives;
+        // only the continuation is paced. Without this the first characters
+        // trail their arrival by up to `REVEAL_CATCHUP_FRAMES` ticks, which
+        // reads as the agent being slow to start rather than as smoothing.
+        const REVEAL_FIRST_CHUNK: usize = 240;
         for tab in self.tab_sessions.values_mut() {
             let Some(len) = Self::tab_visible_stream_len(tab) else {
                 continue;
@@ -4737,7 +4744,11 @@ impl App {
                 continue;
             }
             let backlog = len - tab.reveal_chars;
-            let step = REVEAL_MIN_STEP.max(backlog / REVEAL_CATCHUP_FRAMES);
+            let step = if tab.reveal_chars == 0 {
+                REVEAL_FIRST_CHUNK.max(backlog / REVEAL_CATCHUP_FRAMES)
+            } else {
+                REVEAL_MIN_STEP.max(backlog / REVEAL_CATCHUP_FRAMES)
+            };
             tab.reveal_chars = (tab.reveal_chars + step).min(len);
         }
     }

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -11978,6 +11978,58 @@ fn bounded_late_thought_does_not_rewind_revealed_assistant_response() {
     );
 }
 
+/// Time-to-first-token is the latency users compare against a bare agent CLI,
+/// so the opening burst of a turn is shown as soon as it arrives. Only the
+/// continuation is paced by the typewriter smoothing.
+#[test]
+fn first_reveal_of_a_turn_is_not_smoothed() {
+    let mut app = test_app();
+    submit_test_prompt(&mut app, "hi");
+
+    let first = "The answer to your question is as follows, in detail:";
+    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Message, first);
+    assert_eq!(
+        app.current_tab().reveal_chars,
+        0,
+        "a fresh turn starts with nothing revealed"
+    );
+
+    app.advance_reveal();
+
+    assert_eq!(
+        app.current_tab().reveal_chars,
+        first.chars().count(),
+        "the first frame of a turn must reveal the whole opening chunk, not a 3-char step"
+    );
+}
+
+/// The un-smoothed first frame must not disable smoothing for the rest of the
+/// turn — continuation chunks still animate.
+#[test]
+fn continuation_chunks_remain_smoothed_after_the_first_reveal() {
+    let mut app = test_app();
+    submit_test_prompt(&mut app, "hi");
+
+    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Message, "Start.");
+    app.advance_reveal();
+    let after_first = app.current_tab().reveal_chars;
+    assert_eq!(after_first, "Start.".chars().count());
+
+    // A large continuation must not be revealed all at once.
+    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Message, &"x".repeat(400));
+    app.advance_reveal();
+
+    let revealed = app.current_tab().reveal_chars;
+    assert!(
+        revealed > after_first,
+        "continuation must make progress, got {revealed}"
+    );
+    assert!(
+        revealed < after_first + 400,
+        "continuation must still be paced, got {revealed}"
+    );
+}
+
 #[test]
 fn structured_stream_hides_thinking_after_response_is_visible() {
     let mut app = test_app();

--- a/tools/wta/src/command_recall.rs
+++ b/tools/wta/src/command_recall.rs
@@ -221,15 +221,36 @@ pub async fn powershell_near_matches(shell_exe: &str, token: &str) -> Option<Vec
     }
 
     let names = cached_powershell_commands(shell_exe).await?;
+    near_matches_from_names(token, &names)
+}
 
-    // Full existence gate: the token may resolve as a cmdlet / function /
-    // alias / external `.ps1` that `which` can't see. If so, it wasn't a
-    // not-found — inject nothing.
-    if command_exists(token, &names) {
+/// Non-blocking counterpart to [`powershell_near_matches`].
+///
+/// Identical ranking, but it never waits on a PowerShell subprocess: if the
+/// command cache is cold it starts the enumerate in the background and returns
+/// `None` for this turn. Used on the prompt path, where a best-effort hint must
+/// not delay the agent's response (see [`cached_powershell_commands_now`]).
+pub fn powershell_near_matches_now(shell_exe: &str, token: &str) -> Option<Vec<String>> {
+    if which::which(token).is_ok() {
         return None;
     }
 
-    let matches = rank_near_matches(token, &names, MAX_NEAR_MATCHES);
+    let names = cached_powershell_commands_now(shell_exe)?;
+    near_matches_from_names(token, &names)
+}
+
+/// Shared tail of the near-match computation: the full existence gate plus
+/// ranking. Split out so the blocking and non-blocking entry points cannot
+/// drift in behaviour.
+fn near_matches_from_names(token: &str, names: &[String]) -> Option<Vec<String>> {
+    // Full existence gate: the token may resolve as a cmdlet / function /
+    // alias / external `.ps1` that `which` can't see. If so, it wasn't a
+    // not-found — inject nothing.
+    if command_exists(token, names) {
+        return None;
+    }
+
+    let matches = rank_near_matches(token, names, MAX_NEAR_MATCHES);
     if matches.is_empty() {
         None
     } else {
@@ -404,21 +425,90 @@ static COMMAND_CACHE: std::sync::OnceLock<
 
 /// Cached wrapper over [`enumerate_powershell_commands`]; see [`COMMAND_CACHE`].
 async fn cached_powershell_commands(shell_exe: &str) -> Option<std::sync::Arc<Vec<String>>> {
-    let cache =
-        COMMAND_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()));
-    let key = format!(
-        "{}|{}",
-        shell_exe.to_ascii_lowercase(),
-        std::env::var("PATH").unwrap_or_default()
-    );
-    if let Some(hit) = cache.lock().ok().and_then(|m| m.get(&key).cloned()) {
+    let key = command_cache_key(shell_exe);
+    if let Some(hit) = lookup_cached_commands(&key) {
         return Some(hit);
     }
     let names = std::sync::Arc::new(enumerate_powershell_commands(shell_exe).await?);
-    if let Ok(mut m) = cache.lock() {
+    if let Ok(mut m) = command_cache().lock() {
         m.insert(key, names.clone());
     }
     Some(names)
+}
+
+fn command_cache(
+) -> &'static std::sync::Mutex<std::collections::HashMap<String, std::sync::Arc<Vec<String>>>> {
+    COMMAND_CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+fn command_cache_key(shell_exe: &str) -> String {
+    format!(
+        "{}|{}",
+        shell_exe.to_ascii_lowercase(),
+        std::env::var("PATH").unwrap_or_default()
+    )
+}
+
+fn lookup_cached_commands(key: &str) -> Option<std::sync::Arc<Vec<String>>> {
+    command_cache().lock().ok().and_then(|m| m.get(key).cloned())
+}
+
+/// Tracks shells whose enumerate is already running, so concurrent turns queue
+/// behind one subprocess instead of each spawning their own PowerShell.
+static COMMAND_WARM_INFLIGHT: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashSet<String>>,
+> = std::sync::OnceLock::new();
+
+fn warm_inflight() -> &'static std::sync::Mutex<std::collections::HashSet<String>> {
+    COMMAND_WARM_INFLIGHT.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+}
+
+/// Non-blocking read of the command cache.
+///
+/// Returns the names only if they are **already** cached. On a miss it kicks off
+/// the enumerate in the background and returns `None` immediately, so the caller
+/// can proceed without waiting.
+///
+/// Why this exists: the profile-loading enumerate is bounded by
+/// [`PROFILE_ENUMERATE_TIMEOUT`] and falls back to a second `-NoProfile`
+/// subprocess, so a user whose interactive profile is slow pays up to ~6s. That
+/// cost was previously charged to the first autofix turn of every pane, *before*
+/// the prompt was sent — a measured 5.82s stall on one real turn. Near-match
+/// hints are a best-effort enhancement, so a cold cache now degrades to "no hint
+/// this turn" rather than delaying the agent's entire response.
+fn cached_powershell_commands_now(shell_exe: &str) -> Option<std::sync::Arc<Vec<String>>> {
+    let key = command_cache_key(shell_exe);
+    if let Some(hit) = lookup_cached_commands(&key) {
+        return Some(hit);
+    }
+
+    // Cold: start (at most) one background enumerate for this key.
+    let should_spawn = warm_inflight()
+        .lock()
+        .map(|mut inflight| inflight.insert(key.clone()))
+        .unwrap_or(false);
+    if should_spawn {
+        let shell_exe = shell_exe.to_string();
+        tokio::task::spawn(async move {
+            let started = std::time::Instant::now();
+            let names = enumerate_powershell_commands(&shell_exe).await;
+            if let Some(names) = names {
+                if let Ok(mut m) = command_cache().lock() {
+                    m.insert(command_cache_key(&shell_exe), std::sync::Arc::new(names));
+                }
+            }
+            if let Ok(mut inflight) = warm_inflight().lock() {
+                inflight.remove(&command_cache_key(&shell_exe));
+            }
+            tracing::debug!(
+                target: "acp.terminal_context",
+                shell = %shell_exe,
+                dt = started.elapsed().as_secs_f64(),
+                "command enumerate warmed in background"
+            );
+        });
+    }
+    None
 }
 
 /// Enumerate the shell's command names (cmdlets, applications, external
@@ -918,6 +1008,57 @@ mod integration_tests {
         assert!(
             got.is_none(),
             "expected None for the existing cmdlet, got {got:?}"
+        );
+    }
+
+    /// The prompt path must never block on the PowerShell enumerate.
+    ///
+    /// Regression guard for the measured 5.82s first-autofix-turn stall: a cold
+    /// command cache made `command_not_found` spawn a profile-loading
+    /// PowerShell (4s timeout) plus a `-NoProfile` fallback *before* the prompt
+    /// was sent. `powershell_near_matches_now` must return promptly on a cold
+    /// cache rather than waiting for that subprocess.
+    #[tokio::test]
+    async fn near_matches_now_does_not_block_on_a_cold_cache() {
+        let Some(shell) = powershell_host() else {
+            eprintln!("no PowerShell host installed; skipping");
+            return;
+        };
+        // A key that cannot already be cached, so this is guaranteed to be the
+        // cold path (the miss also kicks off the background warm).
+        let cold_shell = format!("{shell}?cold-{}", std::process::id());
+
+        let started = std::time::Instant::now();
+        let _ = powershell_near_matches_now(&cold_shell, "gti-not-a-real-command");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "cold-cache near-match lookup must not block the prompt path, took {elapsed:?}"
+        );
+    }
+
+    /// Once the cache is warm, the non-blocking path must produce the same
+    /// answer as the awaiting path — the speedup must not cost the feature.
+    #[tokio::test]
+    async fn near_matches_now_matches_blocking_result_when_warm() {
+        let Some(shell) = powershell_host() else {
+            eprintln!("no PowerShell host installed; skipping");
+            return;
+        };
+        // The command cache is keyed on `PATH`, and sibling tests mutate `PATH`
+        // to install script fixtures. Hold the same guard they do so a
+        // concurrent mutation can't invalidate the cache between the two
+        // lookups below and turn the warm hit into a miss.
+        let _guard = PATH_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+
+        // Populate the cache through the blocking path first.
+        let blocking = powershell_near_matches(&shell, "Get-ChildItm").await;
+        // Now the same query must resolve from cache without awaiting.
+        let non_blocking = powershell_near_matches_now(&shell, "Get-ChildItm");
+        assert_eq!(
+            blocking, non_blocking,
+            "warm non-blocking lookup must agree with the blocking lookup"
         );
     }
 

--- a/tools/wta/src/helper/runtime.rs
+++ b/tools/wta/src/helper/runtime.rs
@@ -129,22 +129,20 @@ pub(super) async fn run_default_tui_over_pipe(
     };
     let shell_mgr = Arc::new(shell_mgr);
 
-    let pane_identity = if wt_connected {
-        discover_pane_identity(&shell_mgr).await
-    } else {
-        None
-    };
-
-    // Connection failures to wta-master (pipe connect give-up, ACP initialize
-    // timeout/failure) are logged at their source (target=helper) and again in
-    // `run_acp_tui_mode`'s exit branch, which `process::exit`s rather than
-    // returning Err — so there's no point wrapping the result here.
+    // Pane identity is supplied by WT at spawn time — never discovered.
+    // `WT_SESSION` (set by ConptyConnection for every pane) is this pane's id,
+    // and `--owner-window-id` / `--owner-tab-id` carry the window and the
+    // stable tab GUID. An earlier implementation enumerated every window, tab
+    // and pane over `wtcli` to match its own PID, which cost one process spawn
+    // per window plus one per tab (0.3-0.8s, scaling with the user's open tab
+    // count) *before* the TUI entered the alt-screen, so the pane sat blank for
+    // the duration. Two of the three values it returned were then discarded or
+    // overwritten by the flags below anyway.
     run_acp_tui_mode(
         config,
         shell_mgr,
         wt_connected,
         debug_rx,
-        pane_identity,
         wt_event_rx,
         wt_protocol_channel,
         pipe_name,
@@ -214,57 +212,6 @@ mod cwd_tests {
     }
 }
 
-/// Discover our own pane identity by matching our PID against WT's pane list.
-async fn discover_pane_identity(shell_mgr: &ShellManager) -> Option<(String, String, String)> {
-    let our_pid = std::process::id();
-
-    // WT IDs may arrive as JSON strings or numbers (COM returns numeric) — accept both.
-    fn id_str(v: Option<&serde_json::Value>) -> Option<String> {
-        match v {
-            Some(serde_json::Value::String(s)) => Some(s.clone()),
-            Some(serde_json::Value::Number(n)) => Some(n.to_string()),
-            _ => None,
-        }
-    }
-
-    let windows = shell_mgr.wt_list_windows().await.ok()?;
-    let windows_arr = windows.get("windows")?.as_array()?;
-
-    for win in windows_arr {
-        let window_id = match id_str(win.get("window_id")) {
-            Some(w) => w,
-            None => continue,
-        };
-        let tabs = shell_mgr.wt_list_tabs(&window_id).await.ok()?;
-        let tabs_arr = tabs.get("tabs")?.as_array()?;
-
-        for tab in tabs_arr {
-            let tab_id_str = match id_str(tab.get("tab_id")) {
-                Some(t) => t,
-                None => continue,
-            };
-            let panes = shell_mgr
-                .wt_list_panes(&tab_id_str, Some(&window_id))
-                .await
-                .ok()?;
-            let panes_arr = panes.get("panes")?.as_array()?;
-
-            for pane in panes_arr {
-                if let Some(pid) = pane.get("pid").and_then(|v| v.as_u64()) {
-                    if pid == our_pid as u64 {
-                        let pane_id = match id_str(pane.get("session_id")) {
-                            Some(p) => p,
-                            None => continue,
-                        };
-                        return Some((pane_id, tab_id_str.clone(), window_id.to_string()));
-                    }
-                }
-            }
-        }
-    }
-    None
-}
-
 struct TuiRestoreGuard {
     armed: bool,
 }
@@ -302,7 +249,6 @@ async fn run_acp_tui_mode(
     shell_mgr: Arc<ShellManager>,
     wt_connected: bool,
     debug_rx: tokio::sync::mpsc::UnboundedReceiver<app::DebugMessage>,
-    pane_identity: Option<(String, String, String)>,
     wt_event_rx: Option<tokio::sync::mpsc::UnboundedReceiver<serde_json::Value>>,
     wt_protocol_channel: Option<Arc<CliChannel>>,
     connect_master_pipe: String,
@@ -329,7 +275,6 @@ async fn run_acp_tui_mode(
         shell_mgr,
         wt_connected,
         debug_rx,
-        pane_identity,
         wt_event_rx,
         wt_protocol_channel,
         connect_master_pipe,
@@ -401,7 +346,6 @@ async fn run_acp_app(
     shell_mgr: Arc<ShellManager>,
     wt_connected: bool,
     mut debug_rx: tokio::sync::mpsc::UnboundedReceiver<app::DebugMessage>,
-    pane_identity: Option<(String, String, String)>,
     wt_event_rx: Option<tokio::sync::mpsc::UnboundedReceiver<serde_json::Value>>,
     wt_protocol_channel: Option<Arc<CliChannel>>,
     connect_master_pipe: String,
@@ -1219,15 +1163,10 @@ async fn run_acp_app(
             // its `session/list` snapshot. See
             // doc/specs/per-cli-history-filtering.md.
 
-            if let Some((pane_id, _tab_id, window_id)) = pane_identity {
-                app_state.pane_id = Some(pane_id);
-                // discover_pane_identity returns the legacy unstable tab
-                // index, not the GUID — ignore it. The stable owner-tab GUID
-                // is passed by WT via --owner-tab-id (see below) and seeded
-                // directly into app_state.tab_id.
-                app_state.window_id = Some(window_id);
-            }
-            else if let Some(pane_id) = std::env::var("WT_SESSION")
+            // Pane id comes from `WT_SESSION`, which ConptyConnection sets on
+            // every pane it spawns. This is authoritative and free; the window
+            // and tab ids are seeded from the `--owner-*` flags just below.
+            if let Some(pane_id) = std::env::var("WT_SESSION")
                 .ok()
                 .map(|value| value.trim().to_string())
                 .filter(|value| !value.is_empty())
@@ -1235,7 +1174,7 @@ async fn run_acp_app(
                 tracing::info!(
                     target: "tab_session",
                     pane_id = %pane_id,
-                    "seeded app_state.pane_id from WT_SESSION fallback"
+                    "seeded app_state.pane_id from WT_SESSION"
                 );
                 app_state.pane_id = Some(pane_id);
             }

--- a/tools/wta/src/protocol/acp/prompt_context.rs
+++ b/tools/wta/src/protocol/acp/prompt_context.rs
@@ -784,7 +784,11 @@ impl ContextProvider for CommandNotFoundProvider {
         let shell_exe = req.shell_exe?;
         let content = req.terminal_output?;
         let token = crate::command_recall::extract_command_token(content)?;
-        let matches = crate::command_recall::powershell_near_matches(shell_exe, &token).await?;
+        // Non-blocking: a cold command cache yields no hint for this turn and
+        // warms in the background instead of stalling the prompt on a
+        // profile-loading PowerShell enumerate (measured at 5.82s on a real
+        // turn). The next autofix turn finds it warm.
+        let matches = crate::command_recall::powershell_near_matches_now(shell_exe, &token)?;
         tracing::debug!(
             target: "acp.terminal_context",
             token = %token,


### PR DESCRIPTION
## Summary of the Pull Request

A performance pass over the agent pane's startup and prompt paths, profiling where wall-clock time actually goes between launching a pane and getting a response back.

Three optimizations. Two produced measurable wins:

| Scenario | Before | After | Win |
| --- | --- | --- | --- |
| Pane self-discovery on startup | 0.27 s | **0.002 s** | −0.27 s, every pane |
| Helper → master pipe connected | 0.39 s | **0.15 s** | −0.24 s, every pane |
| Helper → session usable | 3.29 s | **3.04 s** | −0.25 s, every pane |
| Autofix turn: work before the prompt is sent | 4.02 s | **0.39 s** | **−3.6 s** |

Findings, method and follow-up work are written up in `doc/specs/agent-pane-latency-analysis.md`.

## References and Relevant Issues

None.

## Detailed Description of the Pull Request / Additional comments

**1. Remove `discover_pane_identity` (`helper/runtime.rs`)**

The helper enumerated every window, tab and pane to find *itself* by PID. Each of those calls spawns a separate `wtcli.exe` process plus an out-of-proc COM activation, so the cost was `1 + windows + tabs` process launches — growing with the number of open tabs — and it ran before the TUI entered the alt-screen, so nothing was painted for the duration.

All three values it returned were already available for free, and the surrounding code was discarding two of them:

- `tab_id` — explicitly discarded (the real one comes from `--owner-tab-id`)
- `window_id` — unconditionally overwritten by `--owner-window-id` a few lines later
- `pane_id` — an identical `WT_SESSION` fallback already existed in the very next branch

This promotes `WT_SESSION` to the primary path and deletes the enumeration. Behaviour is identical. Profiling the current shipping build shows the enumeration spending ~172 ms and then not matching, falling back to `WT_SESSION` anyway.

**2. Never block a prompt on the PowerShell command enumerate (`command_recall.rs`, `protocol/acp/prompt_context.rs`)**

The `command_not_found` near-match hint enumerated shell commands inline. That loads the user's interactive PowerShell profile (bounded at 4 s) and, on timeout, falls back to a second `-NoProfile` subprocess — measured locally at 6,175 ms and 5,397 ms respectively. One captured turn spent 6.23 s of its 14.34 s to first token before the agent received anything.

The hint is best-effort, so it must not gate the response. `powershell_near_matches_now` answers only from a warm cache and otherwise kicks off a single-flight background enumerate. Worst case is now "no hint on the first autofix turn" instead of a multi-second stall.

The warm is deliberately **lazy**. Warming from context resolution would fire on planner turns too, where the hint is never consumed, and the background subprocess then competes with the foreground prompt.

**3. Don't smooth the first reveal of a turn (`app.rs`)**

Time-to-first-token is the most visible latency in a turn. The typewriter animation trailed arrival by up to 4 frames (~130 ms); the opening burst is now shown immediately and only the continuation is paced. Total response time is unchanged. This one is perceptual and **not benchmarked**.

**Deliberately not done** (documented with reasoning in the doc):

- Making `list_sessions` concurrent with `session/new` — measured at ~1 ms, not worth the stale-snapshot ordering risk.
- Pre-spawning the default agent CLI at master startup — the pool key folds in a `provider_binding` the master cannot know at startup, so a guessed key would add a second agent process rather than warm the pool.

## Validation Steps Performed

- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml` → **1894 passed, 0 failed**, stable across 3 consecutive runs (baseline 1890; 4 new tests cover the non-blocking cold-cache guarantee, warm/blocking agreement, and both reveal behaviours).
- Full Debug solution build: 0 errors. Deployed and exercised as a real packaged app.
- Latency measured over **12 cold starts and 24 live prompts**, driven through the WT COM protocol rather than by hand. Figures above are medians.

**Attribution caveat:** every number compares the *same commit and same build configuration* with only `wta.exe` swapped. The shipping package is a Release build of an older codebase, so it is not a valid attribution baseline. Time-to-first-token is model/network time (observed spread 4.8–11.5 s) and is unaffected by these changes — the client-side figure that reflects this work is `phase=prompt_sent`.

## PR Checklist
- [ ] Closes #xxx
- [x] Tests added/passed
- [x] Documentation updated
   - Adds `doc/specs/agent-pane-latency-analysis.md`; no user-facing docs change, so no docs-repo PR needed.
- [ ] Schema updated (if necessary)