### PR TITLE
Fix turn cancellation lifecycle

### DIFF
--- a/tools/wta/Cargo.lock
+++ b/tools/wta/Cargo.lock
@@ -2629,6 +2629,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/tools/wta/Cargo.toml
+++ b/tools/wta/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 [dependencies]
 agent-client-protocol = { version = "1.3.0" }
 tokio = { version = "1", features = ["full"] }
-tokio-util = { version = "0.7", features = ["compat"] }
+tokio-util = { version = "0.7", features = ["compat", "rt"] }
 async-trait = "0.1"
 anyhow = "1"
 serde_json = "1"

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -5366,13 +5366,11 @@ impl App {
     /// dispatcher before any mutation.
     fn cmd_stop(&mut self, in_flight: bool) {
         if in_flight {
-            let session_id = self.current_tab().session_id.clone();
-            if let Some(sid) = session_id.clone() {
-                let _ = self.cancel_tx.send(CancelRequest { session_id: sid });
-            }
-            if let Some(sid) = session_id {
-                self.turn_cancel(&sid);
-            }
+            let tab_id = self
+                .tab_id
+                .clone()
+                .unwrap_or_else(|| DEFAULT_TAB_ID.to_string());
+            self.request_turn_cancel_for_tab(&tab_id);
             let tab = self.current_tab_mut();
             tab.messages
                 .push(ChatMessage::success(t!("system.cancelled").into_owned()));

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -5403,6 +5403,7 @@ impl App {
     /// for clearing the input and cursor before calling this.
     fn handle_slash_command(&mut self, cmd: ParsedCommand) {
         let in_flight = self.current_tab().turn.is_in_flight();
+        let cancelling = self.current_tab().turn.is_cancelling();
         let prompt_blocked = !self.current_tab().turn.accepts_new_prompt();
         crate::telemetry::log_slash_command_invoked(cmd.spec.name);
         tracing::info!(
@@ -5418,7 +5419,7 @@ impl App {
         match cmd.kind {
             CommandKind::Help => self.cmd_help(),
             CommandKind::Clear => self.cmd_clear(),
-            CommandKind::Stop => self.cmd_stop(in_flight),
+            CommandKind::Stop => self.cmd_stop(in_flight, cancelling),
             CommandKind::New => self.cmd_new(prompt_blocked),
             CommandKind::Fix => self.cmd_fix(prompt_blocked, cmd.rest),
             CommandKind::Sessions => self.cmd_sessions(),
@@ -5446,17 +5447,19 @@ impl App {
     /// `/stop` — cancel the in-flight turn, or note that there is nothing to
     /// stop. `in_flight` is the active tab's turn state, captured by the
     /// dispatcher before any mutation.
-    fn cmd_stop(&mut self, in_flight: bool) {
-        if in_flight {
+    fn cmd_stop(&mut self, in_flight: bool, cancelling: bool) {
+        if in_flight || cancelling {
             let tab_id = self
                 .tab_id
                 .clone()
                 .unwrap_or_else(|| DEFAULT_TAB_ID.to_string());
             self.request_turn_cancel_for_tab(&tab_id);
-            let tab = self.current_tab_mut();
-            tab.messages
-                .push(ChatMessage::success(t!("system.cancelled").into_owned()));
-            tab.scroll_to_bottom();
+            if !cancelling {
+                let tab = self.current_tab_mut();
+                tab.messages
+                    .push(ChatMessage::success(t!("system.cancelled").into_owned()));
+                tab.scroll_to_bottom();
+            }
         } else {
             let tab = self.current_tab_mut();
             tab.messages.push(ChatMessage::info(

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4374,6 +4374,7 @@ impl App {
             AppEvent::AgentMessageChunk { .. } => "agent_message_chunk",
             AppEvent::UserMessageReplayChunk { .. } => "user_message_replay_chunk",
             AppEvent::AgentMessageEnd { .. } => "agent_message_end",
+            AppEvent::PromptCancellationSettled { .. } => "prompt_cancellation_settled",
             AppEvent::TimingMetric { .. } => "timing_metric",
             AppEvent::ToolCall { .. } => "tool_call",
             AppEvent::ToolCallUpdate { .. } => "tool_call_update",
@@ -5322,6 +5323,7 @@ impl App {
     /// for clearing the input and cursor before calling this.
     fn handle_slash_command(&mut self, cmd: ParsedCommand) {
         let in_flight = self.current_tab().turn.is_in_flight();
+        let prompt_blocked = !self.current_tab().turn.accepts_new_prompt();
         crate::telemetry::log_slash_command_invoked(cmd.spec.name);
         tracing::info!(
             target: "slash_cmd",
@@ -5337,8 +5339,8 @@ impl App {
             CommandKind::Help => self.cmd_help(),
             CommandKind::Clear => self.cmd_clear(),
             CommandKind::Stop => self.cmd_stop(in_flight),
-            CommandKind::New => self.cmd_new(in_flight),
-            CommandKind::Fix => self.cmd_fix(in_flight, cmd.rest),
+            CommandKind::New => self.cmd_new(prompt_blocked),
+            CommandKind::Fix => self.cmd_fix(prompt_blocked, cmd.rest),
             CommandKind::Sessions => self.cmd_sessions(),
             CommandKind::Restart => self.cmd_restart(),
             CommandKind::Agent => self.cmd_agent(cmd.rest),
@@ -5386,8 +5388,8 @@ impl App {
 
     /// `/new` — start a fresh session on the active tab. Refuses while a turn
     /// is in flight (the user should `/stop` first).
-    fn cmd_new(&mut self, in_flight: bool) {
-        if in_flight {
+    fn cmd_new(&mut self, prompt_blocked: bool) {
+        if prompt_blocked {
             let tab = self.current_tab_mut();
             tab.messages.push(ChatMessage::warning(
                 t!("system.busy_use_stop").into_owned(),

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -17,7 +17,6 @@ struct DeferredAcpParams {
     agent_source: crate::agent_source::AgentSource,
     source_cwd: Option<String>,
     prompt_rx: Option<mpsc::UnboundedReceiver<crate::protocol::acp::client::PromptSubmission>>,
-    cancel_rx: Option<mpsc::UnboundedReceiver<crate::protocol::acp::client::CancelRequest>>,
     new_session_rx: Option<mpsc::UnboundedReceiver<crate::protocol::acp::client::NewSessionForTab>>,
     load_session_rx:
         Option<mpsc::UnboundedReceiver<crate::protocol::acp::client::LoadSessionForTab>>,
@@ -136,8 +135,8 @@ use crate::coordinator::{recommended_choice_index, RecommendationChoice, Recomme
 use crate::pane_context::PaneContext;
 
 use crate::protocol::acp::client::{
-    AgentLifecycleRequest, AgentReconnectRequest, CancelRequest, DropSessionRequest,
-    LoadSessionForTab, NewSessionForTab, PromptSubmission, RenameSessionRequest,
+    AgentLifecycleRequest, AgentReconnectRequest, DropSessionRequest, LoadSessionForTab,
+    NewSessionForTab, PromptSubmission, RenameSessionRequest,
 };
 use crate::protocol::acp::turn_metrics::prompt_timing_log;
 use crate::ui;
@@ -1008,6 +1007,11 @@ pub struct App {
     /// had already closed. The replacement-master readiness event must start
     /// a fresh pipe client because no transport disconnect remains to do so.
     restart_without_acp_pending: bool,
+    /// Unexpected transport loss resets App state immediately, but a
+    /// replacement client must not start until the old client confirms that
+    /// its transport, prompt tasks, and queued submissions are retired.
+    reconnect_after_transport_retired: bool,
+    agent_transport_retirement_pending: bool,
     /// Agent ID selected by user (FRE/preflight) — sent to C++ once connected.
     pending_agent_selection: Option<String>,
     /// Show first-run welcome hint until user sends first message.
@@ -1068,7 +1072,6 @@ pub struct App {
     prompt_tx: mpsc::UnboundedSender<PromptSubmission>,
     recommendation_tx: mpsc::UnboundedSender<crate::coordinator::ChoiceExecution>,
     permission_tx: mpsc::UnboundedSender<String>,
-    cancel_tx: mpsc::UnboundedSender<CancelRequest>,
     new_session_tx: mpsc::UnboundedSender<NewSessionForTab>,
     load_session_tx: mpsc::UnboundedSender<LoadSessionForTab>,
     drop_session_tx: mpsc::UnboundedSender<DropSessionRequest>,
@@ -1345,7 +1348,6 @@ impl App {
         prompt_tx: mpsc::UnboundedSender<PromptSubmission>,
         recommendation_tx: mpsc::UnboundedSender<crate::coordinator::ChoiceExecution>,
         permission_tx: mpsc::UnboundedSender<String>,
-        cancel_tx: mpsc::UnboundedSender<CancelRequest>,
         new_session_tx: mpsc::UnboundedSender<NewSessionForTab>,
         load_session_tx: mpsc::UnboundedSender<LoadSessionForTab>,
         drop_session_tx: mpsc::UnboundedSender<DropSessionRequest>,
@@ -1370,6 +1372,8 @@ impl App {
             auth_recovery_generation: 0,
             auth_recovery_state: AuthRecoveryState::Idle,
             restart_without_acp_pending: false,
+            reconnect_after_transport_retired: false,
+            agent_transport_retirement_pending: false,
             pending_agent_selection: None,
             show_welcome_hint: false,
             deferred_acp: None,
@@ -1404,7 +1408,6 @@ impl App {
             prompt_tx,
             recommendation_tx,
             permission_tx,
-            cancel_tx,
             new_session_tx,
             load_session_tx,
             drop_session_tx,
@@ -1519,7 +1522,6 @@ impl App {
             agent_source,
             source_cwd,
             prompt_rx: None,
-            cancel_rx: None,
             new_session_rx: None,
             load_session_rx: None,
             drop_session_rx: None,
@@ -1531,6 +1533,7 @@ impl App {
             master_pipe_name: Some(pipe_name),
             owner_tab_id,
         });
+        self.agent_transport_retirement_pending = true;
     }
 
     /// Try to start the ACP client if login just completed.
@@ -1577,7 +1580,6 @@ impl App {
             // Also update all sender fields on self so the App routes to the new ACP client.
             if params.prompt_rx.is_none() {
                 let (ptx, prx) = mpsc::unbounded_channel();
-                let (ctx, crx) = mpsc::unbounded_channel();
                 let (ntx, nrx) = mpsc::unbounded_channel();
                 let (ltx, lrx) = mpsc::unbounded_channel();
                 let (dtx, drx) = mpsc::unbounded_channel();
@@ -1585,7 +1587,6 @@ impl App {
                 let (rtx, rrx) = mpsc::unbounded_channel();
                 let (mtx, mrx) = mpsc::unbounded_channel();
                 self.prompt_tx = ptx;
-                self.cancel_tx = ctx;
                 self.new_session_tx = ntx;
                 self.load_session_tx = ltx;
                 self.drop_session_tx = dtx;
@@ -1593,7 +1594,6 @@ impl App {
                 self.restart_tx = rtx;
                 self.master_request_tx = mtx;
                 params.prompt_rx = Some(prx);
-                params.cancel_rx = Some(crx);
                 params.new_session_rx = Some(nrx);
                 params.load_session_rx = Some(lrx);
                 params.drop_session_rx = Some(drx);
@@ -1604,7 +1604,6 @@ impl App {
 
             if let (
                 Some(prompt_rx),
-                Some(cancel_rx),
                 Some(new_session_rx),
                 Some(load_session_rx),
                 Some(drop_session_rx),
@@ -1613,7 +1612,6 @@ impl App {
                 Some(master_ext_rx),
             ) = (
                 params.prompt_rx.take(),
-                params.cancel_rx.take(),
                 params.new_session_rx.take(),
                 params.load_session_rx.take(),
                 params.drop_session_rx.take(),
@@ -1667,6 +1665,7 @@ impl App {
                     let pending_load_sid = pending_load.as_ref().map(|p| p.session_id.clone());
                     let event_tx_for_pipe = event_tx.clone();
                     let proposal_channels = Arc::clone(&self.proposal_channels);
+                    self.agent_transport_retirement_pending = true;
                     tokio::task::spawn_local(async move {
                         match crate::protocol::acp::client::run_acp_client_over_pipe(
                             pipe_name,
@@ -1687,7 +1686,6 @@ impl App {
                             yolo_state,
                             event_tx_for_pipe.clone(),
                             prompt_rx,
-                            cancel_rx,
                             new_session_rx,
                             load_session_rx,
                             drop_session_rx,
@@ -1778,8 +1776,12 @@ impl App {
                             session_id = %request.session_id,
                             "re-issuing pending session load onto the reconnected client"
                         );
-                        let _ = self.load_session_tx.send(request);
-                        self.pending_session_load = None;
+                        if self.load_session_tx.send(request).is_err() {
+                            tracing::warn!(
+                                target: "acp_load_session",
+                                "reconnected client rejected pending session load; retaining it for the next reconnect"
+                            );
+                        }
                     }
                 } else {
                     // Unreachable in the shipped product: wta only runs as a
@@ -3571,11 +3573,13 @@ impl App {
         self.acp_model.clone_from(&request.acp_model);
         self.custom_model_selection
             .clone_from(&request.custom_model_selection);
+        self.pending_session_load = None;
         self.reset_agent_scoped_state();
     }
 
     fn reset_agent_scoped_state(&mut self) {
         self.pending_acp_start = false;
+        self.reconnect_after_transport_retired = false;
         self.pending_agent_selection = None;
         self.suppress_next_failed_client_error = false;
         self.needs_post_login_authenticate = false;
@@ -3606,6 +3610,7 @@ impl App {
         let active_tab_id = self.active_tab_key().to_string();
         for tab in self.tab_sessions.values_mut() {
             tab.clear_chat_history();
+            tab.invalidate_active_prompt_attachment();
             tab.usage = None;
             tab.usage_staleness = crate::usage::UsageStaleness::default();
             tab.clear_completed_turns();
@@ -3647,12 +3652,34 @@ impl App {
         self.publish_agent_status();
     }
 
+    fn pending_session_load_for_reconnect(&self) -> Option<(LoadSessionForTab, Option<bool>)> {
+        let pending = self.pending_session_load.as_ref()?;
+        let tab = self.tab_sessions.get(&pending.tab_id)?;
+        (tab.loading_session
+            && tab.loading_target_session_id.as_deref() == Some(pending.session_id.as_str()))
+        .then(|| (pending.clone(), tab.meaningful_conversation_before_load))
+    }
+
+    fn restore_pending_session_load(
+        &mut self,
+        pending: LoadSessionForTab,
+        prior_meaningful: Option<bool>,
+    ) {
+        self.pending_session_load = Some(pending.clone());
+        let tab = self.tab_mut(&pending.tab_id);
+        tab.loading_session = true;
+        tab.loading_target_session_id = Some(pending.session_id);
+        tab.has_meaningful_conversation = true;
+        tab.meaningful_conversation_before_load = prior_meaningful;
+    }
+
     fn begin_pending_agent_reconnect_preflight(&mut self) -> Option<AgentReconnectRequest> {
         let AgentReconnectState::Disconnecting(latest) =
             std::mem::take(&mut self.agent_reconnect_state)
         else {
             return None;
         };
+        self.pending_session_load = None;
         self.reset_agent_scoped_state();
         self.agent_reconnect_state = AgentReconnectState::Preflighting(latest.clone());
         if let Some(tx) = self.event_tx.clone() {
@@ -4150,6 +4177,57 @@ impl App {
         })
     }
 
+    fn current_tab_for_session(&self, session_id: &str) -> Option<String> {
+        self.tab_sessions
+            .iter()
+            .find_map(|(tab_id, tab)| {
+                (tab.loading_session
+                    && tab.loading_target_session_id.as_deref() == Some(session_id))
+                .then(|| tab_id.clone())
+            })
+            .or_else(|| {
+                self.bound_tab_for_session(session_id).filter(|tab_id| {
+                    self.tab_sessions.get(tab_id).is_some_and(|tab| {
+                        !tab.loading_session && tab.session_id.as_deref() == Some(session_id)
+                    })
+                })
+            })
+    }
+
+    fn session_tab_mut_if_current(&mut self, session_id: &str) -> Option<&mut TabSession> {
+        let tab_id = self.current_tab_for_session(session_id)?;
+        self.tab_sessions.get_mut(&tab_id)
+    }
+
+    /// Resolve a terminal prompt event without falling back to the active tab.
+    /// A retired session may still release its exact cancellation barrier, but
+    /// it is no longer allowed to mutate the replacement session on that tab.
+    fn terminal_event_tab_for_session(&self, session_id: &str) -> Option<(String, bool)> {
+        if let Some(tab_id) = self.bound_tab_for_session(session_id) {
+            let is_current = self
+                .tab_sessions
+                .get(&tab_id)
+                .is_some_and(|tab| tab.session_id.as_deref() == Some(session_id));
+            if is_current {
+                return Some((tab_id, true));
+            }
+        }
+
+        self.tab_sessions.iter().find_map(|(tab_id, tab)| {
+            let prompt_id = match &tab.turn {
+                TurnState::Cancelling { prompt_id } => *prompt_id,
+                _ => return None,
+            };
+            tab.active_prompt_cancellation
+                .as_ref()
+                .is_some_and(|active| {
+                    active.prompt_id == prompt_id
+                        && active.session_id.as_deref() == Some(session_id)
+                })
+                .then(|| (tab_id.clone(), false))
+        })
+    }
+
     /// Mutable view of the tab that owns the given session id. Lazily
     /// creates the `TabSession` if missing.
     pub fn session_tab_mut(&mut self, session_id: &str) -> &mut TabSession {
@@ -4359,6 +4437,7 @@ impl App {
             AppEvent::SessionConfigSetCompleted { .. } => "session_config_set_completed",
             AppEvent::SessionConfigSetFailed { .. } => "session_config_set_failed",
             AppEvent::TabError { .. } => "tab_error",
+            AppEvent::PromptError { .. } => "prompt_error",
             AppEvent::TabSystemMessage { .. } => "tab_system_message",
             AppEvent::AgentPasteTextReady { .. } => "agent_paste_text_ready",
             AppEvent::AgentPasteTextFailed { .. } => "agent_paste_text_failed",
@@ -4366,6 +4445,7 @@ impl App {
             AppEvent::PromptTargetResolved { .. } => "prompt_target_resolved",
             AppEvent::AgentError { .. } => "agent_error",
             AppEvent::MasterDisconnected => "master_disconnected",
+            AppEvent::AgentTransportRetired => "agent_transport_retired",
             AppEvent::AgentSoftStop { .. } => "agent_soft_stop",
             AppEvent::AgentBusy { .. } => "agent_busy",
             AppEvent::TabRenamed { .. } => "tab_renamed",
@@ -5401,6 +5481,13 @@ impl App {
             .tab_id
             .clone()
             .unwrap_or_else(|| DEFAULT_TAB_ID.to_string());
+        if self
+            .pending_session_load
+            .as_ref()
+            .is_some_and(|pending| pending.tab_id == tab_id)
+        {
+            self.pending_session_load = None;
+        }
         let request = NewSessionForTab {
             tab_id: tab_id.clone(),
             cwd: self.source_cwd.clone(),
@@ -5517,7 +5604,11 @@ impl App {
             has_hint = !hint.is_empty(),
             "dispatching /fix",
         );
-        self.turn_submit_prompt_for_tab(&target_tab_id, submitted);
+        self.turn_submit_prompt_for_tab_with_cancellation(
+            &target_tab_id,
+            submitted,
+            prompt.cancellation_token(),
+        );
         let _ = self.prompt_tx.send(prompt);
     }
 
@@ -5738,6 +5829,7 @@ impl App {
     /// over the stable master pipe with clean ACP sessions.
     fn cmd_restart(&mut self) {
         self.state = ConnectionState::Connecting("Restarting agent...".to_string());
+        self.pending_session_load = None;
         self.session_to_tab.clear();
         self.session_model_configs.clear();
         self.session_config_options.clear();
@@ -5745,6 +5837,7 @@ impl App {
         self.session_id.clear();
         for (_, tab) in self.tab_sessions.iter_mut() {
             tab.clear_chat_history();
+            tab.invalidate_active_prompt_attachment();
             tab.usage = None;
             tab.usage_staleness = crate::usage::UsageStaleness::default();
             tab.clear_completed_turns();
@@ -5930,7 +6023,19 @@ impl App {
             );
             return;
         }
+        if let Some(tab) = self.tab_sessions.get(closed_tab_id) {
+            if let Some(prompt_id) = tab.turn.prompt_id() {
+                tab.cancel_active_prompt(prompt_id);
+            }
+        }
         let removed = self.tab_sessions.remove(closed_tab_id);
+        if self
+            .pending_session_load
+            .as_ref()
+            .is_some_and(|pending| pending.tab_id == closed_tab_id)
+        {
+            self.pending_session_load = None;
+        }
         self.pending_yolo_session_tabs.remove(closed_tab_id);
         if let Some(session_id) = removed.as_ref().and_then(|tab| tab.session_id.as_ref()) {
             self.session_model_configs.remove(session_id);
@@ -6047,6 +6152,11 @@ impl App {
         // source window, new id is in target), drops the event, and the
         // title bar / bottom bar never picks up the helper's state.
         let owner_matched = self.owner_tab_id.as_deref() == Some(old_tab_id);
+        if let Some(params) = self.deferred_acp.as_mut() {
+            if params.owner_tab_id.as_deref() == Some(old_tab_id) {
+                params.owner_tab_id = Some(new_tab_id.to_string());
+            }
+        }
         if owner_matched {
             self.owner_tab_id = Some(new_tab_id.to_string());
             // This helper owns the dragged tab. The conpty/TermControl
@@ -6064,6 +6174,11 @@ impl App {
                     new_window_id = wid,
                     "tab_renamed: updated self.window_id (dragged helper)"
                 );
+            }
+        }
+        if let Some(pending) = self.pending_session_load.as_mut() {
+            if pending.tab_id == old_tab_id {
+                pending.tab_id = new_tab_id.to_string();
             }
         }
 
@@ -6144,11 +6259,13 @@ impl App {
     /// alive. Called when WT sends `reset_tab_session` (the Ctrl+C×2 hide
     /// path): the WT tab itself isn't going anywhere, but the user asked
     /// for a clean slate on this tab. After this:
-    ///   - Conversation history, completed turns, in-flight state are gone.
+    ///   - Conversation history and completed turns are gone.
+    ///   - An active turn remains `Cancelling` until its prompt producer
+    ///     reaches a terminal boundary.
     ///   - `session_to_tab` entries pointing at this tab are pruned so any
     ///     late ACP events for the old SessionId can't route back in.
-    ///   - The ACP client task drops the binding in `tab_to_session` and
-    ///     cancels any in-flight prompt for the old SessionId. The master
+    ///   - The ACP client task drops the binding in `tab_to_session`. The
+    ///     prompt task observes the token cancellation, and the master
     ///     consumes the same process-wide WT event and owns the physical
     ///     close; the next prompt lazily creates a fresh ACP session.
     /// Unlike `drop_tab_session`, this preserves the HashMap key — the
@@ -6156,6 +6273,13 @@ impl App {
     /// `TabSession` and just renders an empty chat.
     fn reset_tab_session_for(&mut self, tab_id: &str) {
         self.pending_yolo_session_tabs.remove(tab_id);
+        if self
+            .pending_session_load
+            .as_ref()
+            .is_some_and(|pending| pending.tab_id == tab_id)
+        {
+            self.pending_session_load = None;
+        }
         let mut removed_session_id = None;
         // Same wipe as the `/clear` slash command: clear in-flight chat state
         // via `clear_chat_history` AND the completed-turn history that
@@ -6166,6 +6290,7 @@ impl App {
             tab.config_pending_id = None;
             tab.native_yolo_config_pending = false;
             tab.clear_chat_history();
+            tab.invalidate_active_prompt_attachment();
             tab.usage = None;
             tab.usage_staleness = crate::usage::UsageStaleness::default();
             tab.clear_completed_turns();

--- a/tools/wta/src/app/autofix.rs
+++ b/tools/wta/src/app/autofix.rs
@@ -289,7 +289,11 @@ impl App {
         // lookup so a tab with no ACP session yet still gets the prompt
         // queued correctly (the ACP layer creates the session lazily when
         // it processes the prompt).
-        self.turn_submit_prompt_for_tab(&target_tab_id, submitted);
+        self.turn_submit_prompt_for_tab_with_cancellation(
+            &target_tab_id,
+            submitted,
+            prompt.cancellation_token(),
+        );
         tracing::info!(target: "autofix", pane_id = %notification.pane_id, tab_id = %target_tab_id, generation = new_gen, "sending auto-fix prompt");
         let _ = self.prompt_tx.send(prompt);
 

--- a/tools/wta/src/app/autofix.rs
+++ b/tools/wta/src/app/autofix.rs
@@ -529,7 +529,7 @@ impl App {
         let (turn_matches, state_matches) = autofix_pane_matches(tab, pane_id);
 
         if turn_matches {
-            self.turn_cancel_for_tab(&target_tab_id);
+            self.request_turn_cancel_for_tab(&target_tab_id);
         } else if state_matches {
             let tab = self.tab_mut(&target_tab_id);
             tab.autofix.generation = tab.autofix.generation.wrapping_add(1);

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -241,6 +241,13 @@ pub struct UserInputState {
         Option<tokio::sync::oneshot::Sender<crate::agent_tools::user_input::UserInputResponse>>,
 }
 
+pub(crate) struct ActivePromptCancellation {
+    pub prompt_id: u64,
+    pub token: tokio_util::sync::CancellationToken,
+    pub session_id: Option<String>,
+    pub attachment_valid: bool,
+}
+
 impl UserInputState {
     pub fn selection_count(&self) -> usize {
         self.request.choices.len() + usize::from(self.request.allow_freeform)
@@ -585,6 +592,7 @@ pub struct TabSession {
     // Explicit per-turn lifecycle. Source of truth in the new state machine
     // (see `doc/specs/turn-state-refactor.md`).
     pub turn: TurnState,
+    pub(crate) active_prompt_cancellation: Option<ActivePromptCancellation>,
     pub activity_frame: usize,
     /// Ephemeral ACP thought text shown only until visible assistant output
     /// or another structured activity begins. It never enters `messages` or
@@ -682,6 +690,74 @@ impl TabSession {
                 .as_deref()
                 .or(self.session_id.as_deref()),
         )?
+    }
+
+    pub(crate) fn set_prompt_cancellation(
+        &mut self,
+        prompt_id: u64,
+        token: tokio_util::sync::CancellationToken,
+    ) {
+        self.active_prompt_cancellation = Some(ActivePromptCancellation {
+            prompt_id,
+            token,
+            session_id: self.session_id.clone(),
+            attachment_valid: true,
+        });
+    }
+
+    pub(crate) fn can_attach_prompt_session(&self, prompt_id: u64, session_id: &str) -> bool {
+        self.active_prompt_cancellation
+            .as_ref()
+            .is_some_and(|active| {
+                active.prompt_id == prompt_id
+                    && active.attachment_valid
+                    && active
+                        .session_id
+                        .as_deref()
+                        .is_none_or(|known| known == session_id)
+            })
+    }
+
+    pub(crate) fn bind_active_prompt_session(&mut self, prompt_id: u64, session_id: &str) {
+        if let Some(active) = self.active_prompt_cancellation.as_mut().filter(|active| {
+            active.prompt_id == prompt_id && active.attachment_valid && active.session_id.is_none()
+        }) {
+            active.session_id = Some(session_id.to_string());
+        }
+    }
+
+    pub(crate) fn invalidate_active_prompt_attachment(&mut self) {
+        if let Some(active) = self.active_prompt_cancellation.as_mut() {
+            active.attachment_valid = false;
+        }
+    }
+
+    pub(crate) fn cancel_active_prompt(&self, prompt_id: u64) {
+        if let Some(active) = self
+            .active_prompt_cancellation
+            .as_ref()
+            .filter(|active| active.prompt_id == prompt_id)
+        {
+            active.token.cancel();
+        }
+    }
+
+    pub(crate) fn active_prompt_matches_session(&self, prompt_id: u64, session_id: &str) -> bool {
+        self.active_prompt_cancellation
+            .as_ref()
+            .is_some_and(|active| {
+                active.prompt_id == prompt_id && active.session_id.as_deref() == Some(session_id)
+            })
+    }
+
+    pub(crate) fn finish_active_prompt(&mut self, prompt_id: u64) {
+        if self
+            .active_prompt_cancellation
+            .as_ref()
+            .is_some_and(|active| active.prompt_id == prompt_id)
+        {
+            self.active_prompt_cancellation = None;
+        }
     }
 
     pub(crate) fn cached_completed_turn_height(
@@ -935,6 +1011,25 @@ impl TabSession {
     }
 
     pub fn clear_chat_history(&mut self) {
+        let cancellation_barrier = match &self.turn {
+            TurnState::Submitted(prompt)
+            | TurnState::Streaming { prompt }
+            | TurnState::Surfaced {
+                prompt,
+                end_pending: true,
+                ..
+            } => Some(prompt.id),
+            TurnState::Cancelling { prompt_id } => Some(*prompt_id),
+            TurnState::Idle
+            | TurnState::Surfaced {
+                end_pending: false, ..
+            } => None,
+        };
+        if let Some(prompt_id) = cancellation_barrier {
+            self.cancel_active_prompt(prompt_id);
+        } else {
+            self.active_prompt_cancellation = None;
+        }
         self.messages.clear();
         self.clear_streaming_thought();
         self.permission.clear();
@@ -947,7 +1042,9 @@ impl TabSession {
         self.timing_note = None;
         self.selection_visible_pending = false;
         self.clear_completed_turn_selection();
-        self.turn = TurnState::Idle;
+        self.turn = cancellation_barrier
+            .map(|prompt_id| TurnState::Cancelling { prompt_id })
+            .unwrap_or(TurnState::Idle);
         self.clear_recommendations();
         self.attachments
             .remove_tokens_from_input(&mut self.input, &mut self.cursor_pos);

--- a/tools/wta/src/app/turn_state.rs
+++ b/tools/wta/src/app/turn_state.rs
@@ -133,6 +133,16 @@ impl TurnState {
         matches!(self, TurnState::Cancelling { .. })
     }
 
+    pub fn prompt_id(&self) -> Option<u64> {
+        match self {
+            TurnState::Idle => None,
+            TurnState::Submitted(prompt)
+            | TurnState::Streaming { prompt }
+            | TurnState::Surfaced { prompt, .. } => Some(prompt.id),
+            TurnState::Cancelling { prompt_id } => Some(*prompt_id),
+        }
+    }
+
     /// True while an Agent request can still be attributed to this turn.
     ///
     /// A surfaced turn may have released its UI busy gate before a follow-up

--- a/tools/wta/src/app/turn_state.rs
+++ b/tools/wta/src/app/turn_state.rs
@@ -31,8 +31,9 @@ pub enum TurnState {
     },
     /// The user requested cancellation, but the ACP prompt has not reached
     /// its terminal boundary yet. New prompts remain blocked and all
-    /// turn-scoped updates are discarded until `AgentMessageEnd` arrives.
-    Cancelling,
+    /// turn-scoped updates are discarded until the correlated cancellation
+    /// settlement arrives.
+    Cancelling { prompt_id: u64 },
 }
 
 impl Default for TurnState {
@@ -104,7 +105,9 @@ impl TurnState {
         match self {
             TurnState::Idle => true,
             TurnState::Surfaced { end_pending, .. } => !*end_pending,
-            TurnState::Submitted(_) | TurnState::Streaming { .. } | TurnState::Cancelling => false,
+            TurnState::Submitted(_)
+            | TurnState::Streaming { .. }
+            | TurnState::Cancelling { .. } => false,
         }
     }
 
@@ -122,12 +125,12 @@ impl TurnState {
             | TurnState::Surfaced {
                 end_pending: false, ..
             }
-            | TurnState::Cancelling => false,
+            | TurnState::Cancelling { .. } => false,
         }
     }
 
     pub fn is_cancelling(&self) -> bool {
-        matches!(self, TurnState::Cancelling)
+        matches!(self, TurnState::Cancelling { .. })
     }
 
     /// True while an Agent request can still be attributed to this turn.
@@ -137,7 +140,7 @@ impl TurnState {
     /// request itself proves the Agent is still waiting; only `Idle` means
     /// there is no turn left to service.
     pub fn can_service_agent_request(&self) -> bool {
-        !matches!(self, TurnState::Idle | TurnState::Cancelling)
+        !matches!(self, TurnState::Idle | TurnState::Cancelling { .. })
     }
 
     /// The surfaced recommendation set, if the outcome is a card.
@@ -154,7 +157,7 @@ impl TurnState {
     /// Prompt info for the in-flight or just-surfaced turn.
     pub fn prompt(&self) -> Option<&SubmittedPrompt> {
         match self {
-            TurnState::Idle | TurnState::Cancelling => None,
+            TurnState::Idle | TurnState::Cancelling { .. } => None,
             TurnState::Submitted(p) => Some(p),
             TurnState::Streaming { prompt } => Some(prompt),
             TurnState::Surfaced { prompt, .. } => Some(prompt),
@@ -166,7 +169,7 @@ impl TurnState {
     /// `App::apply_prompt_target_resolved`).
     pub fn prompt_mut(&mut self) -> Option<&mut SubmittedPrompt> {
         match self {
-            TurnState::Idle | TurnState::Cancelling => None,
+            TurnState::Idle | TurnState::Cancelling { .. } => None,
             TurnState::Submitted(p) => Some(p),
             TurnState::Streaming { prompt } => Some(prompt),
             TurnState::Surfaced { prompt, .. } => Some(prompt),
@@ -305,7 +308,7 @@ mod tests {
 
     #[test]
     fn cancelling_blocks_new_prompts_and_drops_turn_updates() {
-        let s = TurnState::Cancelling;
+        let s = TurnState::Cancelling { prompt_id: 1 };
         assert!(!s.is_idle());
         assert!(!s.accepts_new_prompt());
         assert!(!s.is_in_flight());

--- a/tools/wta/src/app/turn_state.rs
+++ b/tools/wta/src/app/turn_state.rs
@@ -29,6 +29,10 @@ pub enum TurnState {
         outcome: TurnOutcome,
         end_pending: bool,
     },
+    /// The user requested cancellation, but the ACP prompt has not reached
+    /// its terminal boundary yet. New prompts remain blocked and all
+    /// turn-scoped updates are discarded until `AgentMessageEnd` arrives.
+    Cancelling,
 }
 
 impl Default for TurnState {
@@ -100,7 +104,7 @@ impl TurnState {
         match self {
             TurnState::Idle => true,
             TurnState::Surfaced { end_pending, .. } => !*end_pending,
-            _ => false,
+            TurnState::Submitted(_) | TurnState::Streaming { .. } | TurnState::Cancelling => false,
         }
     }
 
@@ -114,8 +118,16 @@ impl TurnState {
             TurnState::Surfaced {
                 end_pending: true, ..
             } => true,
-            _ => false,
+            TurnState::Idle
+            | TurnState::Surfaced {
+                end_pending: false, ..
+            }
+            | TurnState::Cancelling => false,
         }
+    }
+
+    pub fn is_cancelling(&self) -> bool {
+        matches!(self, TurnState::Cancelling)
     }
 
     /// True while an Agent request can still be attributed to this turn.
@@ -125,7 +137,7 @@ impl TurnState {
     /// request itself proves the Agent is still waiting; only `Idle` means
     /// there is no turn left to service.
     pub fn can_service_agent_request(&self) -> bool {
-        !matches!(self, TurnState::Idle)
+        !matches!(self, TurnState::Idle | TurnState::Cancelling)
     }
 
     /// The surfaced recommendation set, if the outcome is a card.
@@ -142,7 +154,7 @@ impl TurnState {
     /// Prompt info for the in-flight or just-surfaced turn.
     pub fn prompt(&self) -> Option<&SubmittedPrompt> {
         match self {
-            TurnState::Idle => None,
+            TurnState::Idle | TurnState::Cancelling => None,
             TurnState::Submitted(p) => Some(p),
             TurnState::Streaming { prompt } => Some(prompt),
             TurnState::Surfaced { prompt, .. } => Some(prompt),
@@ -154,7 +166,7 @@ impl TurnState {
     /// `App::apply_prompt_target_resolved`).
     pub fn prompt_mut(&mut self) -> Option<&mut SubmittedPrompt> {
         match self {
-            TurnState::Idle => None,
+            TurnState::Idle | TurnState::Cancelling => None,
             TurnState::Submitted(p) => Some(p),
             TurnState::Streaming { prompt } => Some(prompt),
             TurnState::Surfaced { prompt, .. } => Some(prompt),
@@ -289,6 +301,17 @@ mod tests {
             end_pending: true,
         };
         assert!(s.recommendations().is_some());
+    }
+
+    #[test]
+    fn cancelling_blocks_new_prompts_and_drops_turn_updates() {
+        let s = TurnState::Cancelling;
+        assert!(!s.is_idle());
+        assert!(!s.accepts_new_prompt());
+        assert!(!s.is_in_flight());
+        assert!(s.is_cancelling());
+        assert!(!s.can_service_agent_request());
+        assert!(s.prompt().is_none());
     }
 
     #[test]

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -36,6 +36,10 @@ pub enum AppEvent {
     SessionAttached {
         tab_id: String,
         session_id: String,
+        /// Present only for a session lazily created by this exact prompt.
+        /// Lifecycle-created sessions (`/new`, `session/load`, startup
+        /// fallback) are not prompt-owned.
+        prompt_id: Option<u64>,
         available_models: Vec<AcpModelInfo>,
         current_model_id: Option<String>,
     },
@@ -92,6 +96,11 @@ pub enum AppEvent {
         tab_id: String,
         message: String,
     },
+    PromptError {
+        tab_id: String,
+        prompt_id: u64,
+        message: String,
+    },
     TabSystemMessage {
         tab_id: String,
         message: String,
@@ -122,6 +131,11 @@ pub enum AppEvent {
     /// The helper's pipe to wta-master closed. A retained helper reconnects
     /// its existing immutable binding over the stable pipe.
     MasterDisconnected,
+    /// The ACP client has conclusively retired its transport and no prompt
+    /// or lifecycle task owned by that client can produce more events.
+    /// Releases cancellation barriers for both dispatched and still-queued
+    /// prompts.
+    AgentTransportRetired,
     AgentSoftStop {
         session_id: String,
         reason: crate::protocol::acp::soft_stop::SoftStopReason,
@@ -152,9 +166,8 @@ pub enum AppEvent {
         session_id: String,
     },
     PromptCancellationSettled {
-        tab_id: String,
         prompt_id: u64,
-        session_id: Option<String>,
+        started: bool,
     },
     TimingMetric {
         session_id: String,

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -151,6 +151,11 @@ pub enum AppEvent {
     AgentMessageEnd {
         session_id: String,
     },
+    PromptCancellationSettled {
+        tab_id: String,
+        prompt_id: u64,
+        session_id: Option<String>,
+    },
     TimingMetric {
         session_id: String,
         note: String,

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -1450,6 +1450,13 @@ impl App {
                 self.turn_close(&session_id);
                 self.session_tab_mut(&session_id).scroll_to_bottom();
             }
+            AppEvent::PromptCancellationSettled {
+                tab_id,
+                prompt_id,
+                session_id,
+            } => {
+                self.settle_prompt_cancellation(&tab_id, prompt_id, session_id.as_deref());
+            }
             AppEvent::TimingMetric { session_id, note } => {
                 self.session_tab_mut(&session_id).timing_note = Some(note);
             }

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -176,7 +176,14 @@ impl App {
                 .send(AgentLifecycleRequest::RebindAgent(request))
                 .is_err()
         {
-            let _ = self.begin_pending_agent_reconnect_preflight();
+            if self.agent_transport_retirement_pending {
+                tracing::info!(
+                    target: "agent_rebind",
+                    "ACP lifecycle receiver is closed; waiting for transport retirement"
+                );
+            } else {
+                let _ = self.begin_pending_agent_reconnect_preflight();
+            }
         }
     }
 
@@ -607,15 +614,9 @@ impl App {
                 );
             }
             AppEvent::AgentClientFailed => {
-                if let Some(latest) = self.begin_pending_agent_reconnect_preflight() {
+                if !matches!(&self.agent_reconnect_state, AgentReconnectState::Idle) {
                     self.suppress_next_failed_client_error = true;
-                    tracing::info!(
-                        target: "agent_rebind",
-                        operation_id = %latest.operation_id,
-                        generation = latest.generation,
-                        agent_id = %latest.agent_id,
-                        "outgoing ACP client failed during startup; preflighting latest target"
-                    );
+                    tracing::info!(target: "agent_rebind", "outgoing ACP client failed during startup; suppressing its terminal error");
                 }
             }
             AppEvent::AgentConnected {
@@ -709,9 +710,26 @@ impl App {
             AppEvent::SessionAttached {
                 tab_id,
                 session_id,
+                prompt_id,
                 available_models,
                 current_model_id,
             } => {
+                if let Some(prompt_id) = prompt_id {
+                    let attachment_is_current = self
+                        .tab_sessions
+                        .get(&tab_id)
+                        .is_some_and(|tab| tab.can_attach_prompt_session(prompt_id, &session_id));
+                    if !attachment_is_current {
+                        tracing::debug!(
+                            target: "acp",
+                            tab = %tab_id,
+                            session_id,
+                            prompt_id,
+                            "ignoring stale prompt-owned SessionAttached"
+                        );
+                        return;
+                    }
+                }
                 let waiting_for_different_load_target =
                     self.tab_sessions.get(&tab_id).is_some_and(|tab| {
                         tab.loading_session
@@ -755,6 +773,9 @@ impl App {
                     tab.native_yolo_config_pending = false;
                 }
                 tab.session_id = Some(session_id.clone());
+                if let Some(prompt_id) = prompt_id {
+                    tab.bind_active_prompt_session(prompt_id, &session_id);
+                }
                 // Close the session/load replay window only when this
                 // attach is for the session we asked to load. An
                 // unrelated `SessionAttached` (e.g. the bootstrap
@@ -777,6 +798,7 @@ impl App {
                     tab.loading_target_session_id = None;
                     tab.meaningful_conversation_before_load = None;
                     tab.scroll_to_bottom();
+                    self.pending_session_load = None;
                 }
                 // Per-session model lists could differ — surface the new
                 // tab's models when the agent_status event publishes for
@@ -820,7 +842,9 @@ impl App {
                 session_id,
                 snapshot,
             } => {
-                let target_tab = self.tab_for_session(&session_id);
+                let Some(target_tab) = self.current_tab_for_session(&session_id) else {
+                    return;
+                };
                 let tab = self.tab_mut(&target_tab);
                 tab.usage_staleness.mark_reported(&snapshot);
                 if let Some(current) = tab.usage.as_mut() {
@@ -831,7 +855,9 @@ impl App {
                 self.project_tab_state(&target_tab);
             }
             AppEvent::UsageCleared { session_id } => {
-                let target_tab = self.tab_for_session(&session_id);
+                let Some(target_tab) = self.current_tab_for_session(&session_id) else {
+                    return;
+                };
                 let tab = self.tab_mut(&target_tab);
                 tab.usage = None;
                 tab.usage_staleness = crate::usage::UsageStaleness::default();
@@ -902,7 +928,7 @@ impl App {
                 model,
                 pane_override,
             } => {
-                let target_tab = self.bound_tab_for_session(&session_id);
+                let target_tab = self.current_tab_for_session(&session_id);
                 let Some(target_tab) = target_tab else {
                     return;
                 };
@@ -931,7 +957,7 @@ impl App {
                 pane_override,
                 message,
             } => {
-                let target_tab = self.bound_tab_for_session(&session_id);
+                let target_tab = self.current_tab_for_session(&session_id);
                 let Some(target_tab) = target_tab else {
                     return;
                 };
@@ -953,9 +979,9 @@ impl App {
                 session_id,
                 options,
             } => {
+                let target_tab = self.current_tab_for_session(&session_id);
                 self.session_config_options
                     .insert(session_id.clone(), options);
-                let target_tab = self.bound_tab_for_session(&session_id);
                 let Some(target_tab) = target_tab else {
                     return;
                 };
@@ -984,6 +1010,10 @@ impl App {
                 value,
                 model_compat,
             } => {
+                let target_tab = self.current_tab_for_session(&session_id);
+                let Some(target_tab) = target_tab else {
+                    return;
+                };
                 let (option_name, value_name) = self
                     .session_config_options
                     .get_mut(&session_id)
@@ -993,10 +1023,6 @@ impl App {
                         (option.name.clone(), option.current_value_name().to_string())
                     })
                     .unwrap_or_else(|| (config_id.clone(), value.clone()));
-                let target_tab = self.bound_tab_for_session(&session_id);
-                let Some(target_tab) = target_tab else {
-                    return;
-                };
                 {
                     let tab = self.tab_mut(&target_tab);
                     if tab.config_pending_id.as_deref() == Some(config_id.as_str()) {
@@ -1031,16 +1057,16 @@ impl App {
                 message,
                 restart_required,
             } => {
+                let target_tab = self.current_tab_for_session(&session_id);
+                let Some(target_tab) = target_tab else {
+                    return;
+                };
                 let option_name = self
                     .session_config_options
                     .get(&session_id)
                     .and_then(|options| options.iter().find(|option| option.id == config_id))
                     .map(|option| option.name.clone())
                     .unwrap_or(config_id.clone());
-                let target_tab = self.bound_tab_for_session(&session_id);
-                let Some(target_tab) = target_tab else {
-                    return;
-                };
                 {
                     let tab = self.tab_mut(&target_tab);
                     if !restart_required
@@ -1062,6 +1088,13 @@ impl App {
             }
             AppEvent::TabError { tab_id, message } => {
                 self.pending_yolo_session_tabs.remove(&tab_id);
+                if self
+                    .pending_session_load
+                    .as_ref()
+                    .is_some_and(|pending| pending.tab_id == tab_id)
+                {
+                    self.pending_session_load = None;
+                }
                 // Scoped error for a specific tab. Bypasses the global
                 // auth-fallback / ConnectionState::Failed flip in
                 // AgentError because the error is local to one tab's
@@ -1077,8 +1110,33 @@ impl App {
                     .take()
                     .unwrap_or(false);
                 tab.timing_note = None;
-                tab.turn = TurnState::Idle;
+                if !tab.turn.is_cancelling() {
+                    if let Some(prompt_id) = tab.turn.prompt_id() {
+                        tab.finish_active_prompt(prompt_id);
+                    }
+                    tab.turn = TurnState::Idle;
+                }
                 tab.active_direct_proposal_id = None;
+                tab.messages.push(ChatMessage::Error(message));
+                tab.scroll_to_bottom();
+                self.project_tab_state(&tab_id);
+            }
+            AppEvent::PromptError {
+                tab_id,
+                prompt_id,
+                message,
+            } => {
+                let prompt_is_current = self
+                    .tab_sessions
+                    .get(&tab_id)
+                    .is_some_and(|tab| tab.turn.prompt_id() == Some(prompt_id));
+                if !prompt_is_current {
+                    return;
+                }
+                let tab = self.tab_mut(&tab_id);
+                tab.finish_active_prompt(prompt_id);
+                tab.turn = TurnState::Idle;
+                tab.timing_note = None;
                 tab.messages.push(ChatMessage::Error(message));
                 tab.scroll_to_bottom();
                 self.project_tab_state(&tab_id);
@@ -1133,10 +1191,69 @@ impl App {
                     "agent failure"
                 );
 
+                let terminal_target = match session_id.as_deref() {
+                    Some(session_id) => match self.terminal_event_tab_for_session(session_id) {
+                        Some(target) => Some(target),
+                        None => {
+                            tracing::debug!(
+                                target: "failure",
+                                session_id,
+                                "ignoring agent failure for an unbound session"
+                            );
+                            return;
+                        }
+                    },
+                    None => None,
+                };
+                if let Some((target_tab, false)) = terminal_target.as_ref() {
+                    let prompt_id =
+                        self.tab_sessions
+                            .get(target_tab)
+                            .and_then(|tab| match &tab.turn {
+                                TurnState::Cancelling { prompt_id } => Some(*prompt_id),
+                                _ => None,
+                            });
+                    if let Some(prompt_id) = prompt_id {
+                        let tab = self.tab_mut(target_tab);
+                        tab.finish_active_prompt(prompt_id);
+                        tab.turn = TurnState::Idle;
+                        self.project_tab_state(target_tab);
+                    }
+                    return;
+                }
+
                 // A user-initiated cancel surfaced as an error is not a
-                // failure — the turn already ended via the cancel path, so
-                // show nothing and leave the state untouched.
+                // failure. If visible activity already proved this prompt
+                // started, the current session's error may release its exact
+                // barrier; otherwise PromptCancellationSettled (or conclusive
+                // transport retirement) remains the authority.
                 if failure.is_cancelled() {
+                    if let Some((target_tab, true)) = terminal_target.as_ref() {
+                        let prompt_id =
+                            self.tab_sessions
+                                .get(target_tab)
+                                .and_then(|tab| match &tab.turn {
+                                    TurnState::Cancelling { prompt_id }
+                                        if tab.has_meaningful_conversation
+                                            && session_id.as_deref().is_some_and(
+                                                |session_id| {
+                                                    tab.active_prompt_matches_session(
+                                                        *prompt_id, session_id,
+                                                    )
+                                                },
+                                            ) =>
+                                    {
+                                        Some(*prompt_id)
+                                    }
+                                    _ => None,
+                                });
+                        if let Some(prompt_id) = prompt_id {
+                            let tab = self.tab_mut(target_tab);
+                            tab.finish_active_prompt(prompt_id);
+                            tab.turn = TurnState::Idle;
+                            self.project_tab_state(target_tab);
+                        }
+                    }
                     return;
                 }
 
@@ -1206,13 +1323,25 @@ impl App {
                         self.state = ConnectionState::Failed(message.clone());
                         self.publish_agent_status();
                     }
-                    let tab = match session_id.as_deref() {
-                        Some(sid) => self.session_tab_mut(sid),
+                    let target_tab = terminal_target.as_ref().map(|(tab_id, _)| tab_id.clone());
+                    let tab = match target_tab.as_deref() {
+                        Some(tab_id) => self.tab_mut(tab_id),
                         None => self.current_tab_mut(),
                     };
                     tab.activity_frame = 0;
                     tab.timing_note = None;
-                    tab.turn = TurnState::Idle;
+                    let should_finish_turn = match (&tab.turn, session_id.as_deref()) {
+                        (TurnState::Cancelling { prompt_id }, Some(session_id)) => {
+                            tab.active_prompt_matches_session(*prompt_id, session_id)
+                        }
+                        _ => true,
+                    };
+                    if should_finish_turn {
+                        if let Some(prompt_id) = tab.turn.prompt_id() {
+                            tab.finish_active_prompt(prompt_id);
+                        }
+                        tab.turn = TurnState::Idle;
+                    }
                     // Suppress only an identical consecutive error so repeated
                     // provider failures do not stack duplicate messages.
                     let is_duplicate = matches!(
@@ -1222,10 +1351,19 @@ impl App {
                     if !is_duplicate {
                         tab.messages.push(ChatMessage::Error(message));
                     }
+                    if let Some(target_tab) = target_tab {
+                        self.project_tab_state(&target_tab);
+                    }
                 }
             }
             AppEvent::MasterDisconnected => {
-                self.agent_reconnect_state = AgentReconnectState::Idle;
+                let agent_rebind_pending = matches!(
+                    &self.agent_reconnect_state,
+                    AgentReconnectState::Disconnecting(_)
+                );
+                if !agent_rebind_pending {
+                    self.agent_reconnect_state = AgentReconnectState::Idle;
+                }
                 if self.deferred_acp.is_some() {
                     if !matches!(&self.auth_recovery_state, AuthRecoveryState::Idle) {
                         tracing::warn!(
@@ -1240,14 +1378,38 @@ impl App {
                         source = %self.current_agent_source,
                         "master disconnected; reconnecting retained helper over stable pipe"
                     );
+                    let pending_load = self.pending_session_load_for_reconnect();
+                    if pending_load.is_none() {
+                        self.pending_session_load = None;
+                    }
                     self.reset_agent_scoped_state();
-                    self.pending_acp_start = true;
+                    if let Some((pending, prior_meaningful)) = pending_load {
+                        self.restore_pending_session_load(pending, prior_meaningful);
+                    }
+                    self.reconnect_after_transport_retired = !agent_rebind_pending;
                 } else {
                     tracing::warn!(
                         target: "helper",
                         "master disconnected without deferred binding; terminating helper"
                     );
                     self.should_quit = true;
+                }
+            }
+            AppEvent::AgentTransportRetired => {
+                self.agent_transport_retirement_pending = false;
+                self.settle_retired_transport_prompts();
+                if let Some(latest) = self.begin_pending_agent_reconnect_preflight() {
+                    tracing::info!(
+                        target: "agent_rebind",
+                        operation_id = %latest.operation_id,
+                        generation = latest.generation,
+                        agent_id = %latest.agent_id,
+                        "old ACP transport retired; preflighting latest pending target"
+                    );
+                    return;
+                }
+                if std::mem::take(&mut self.reconnect_after_transport_retired) {
+                    self.pending_acp_start = true;
                 }
             }
             AppEvent::PostLoginAuthRecovery {
@@ -1375,7 +1537,9 @@ impl App {
                     SoftStopReason::MaxTurnRequests => t!("system.stopped_max_turn_requests"),
                     SoftStopReason::Refusal => t!("system.stopped_refusal"),
                 };
-                let tab = self.session_tab_mut(&session_id);
+                let Some(tab) = self.session_tab_mut_if_current(&session_id) else {
+                    return;
+                };
                 tab.messages.push(ChatMessage::warning(msg.into_owned()));
                 tab.scroll_to_bottom();
             }
@@ -1389,7 +1553,9 @@ impl App {
                 self.turn_observe_chunk(&session_id, ChunkKind::Thought, &text);
             }
             AppEvent::AgentMessageChunk { session_id, text } => {
-                let tab = self.session_tab_mut(&session_id);
+                let Some(tab) = self.session_tab_mut_if_current(&session_id) else {
+                    return;
+                };
                 // Late chunks after cancel / completion are dropped by
                 // `turn_observe_chunk` (state isn't Submitted/Streaming).
                 // During session/load replay no Submitted state exists,
@@ -1423,7 +1589,9 @@ impl App {
                 // dropped otherwise. A new user_message_chunk after a
                 // buffered agent response marks the turn boundary —
                 // flush the previous agent message first.
-                let tab = self.session_tab_mut(&session_id);
+                let Some(tab) = self.session_tab_mut_if_current(&session_id) else {
+                    return;
+                };
                 if !tab.loading_session {
                     return;
                 }
@@ -1444,21 +1612,15 @@ impl App {
                 tab.replay_user_buffer.push_str(&text);
             }
             AppEvent::AgentMessageEnd { session_id } => {
-                if let Some(summary) = self.session_completion_latency_summary(&session_id) {
-                    self.push_execution_info(summary);
-                }
-                self.turn_close(&session_id);
-                self.session_tab_mut(&session_id).scroll_to_bottom();
+                self.turn_close_terminal_event(&session_id);
             }
-            AppEvent::PromptCancellationSettled {
-                tab_id,
-                prompt_id,
-                session_id,
-            } => {
-                self.settle_prompt_cancellation(&tab_id, prompt_id, session_id.as_deref());
+            AppEvent::PromptCancellationSettled { prompt_id, started } => {
+                self.settle_prompt_cancellation(prompt_id, started);
             }
             AppEvent::TimingMetric { session_id, note } => {
-                self.session_tab_mut(&session_id).timing_note = Some(note);
+                if let Some(tab) = self.session_tab_mut_if_current(&session_id) {
+                    tab.timing_note = Some(note);
+                }
             }
             AppEvent::ToolCall {
                 session_id,
@@ -1474,14 +1636,20 @@ impl App {
                 content,
                 locations,
             } => {
-                let loading_session = self.session_tab(&session_id).loading_session;
-                if !self.session_tab(&session_id).turn.is_in_flight() && !loading_session {
+                let Some(target_tab) = self.current_tab_for_session(&session_id) else {
+                    return;
+                };
+                let loading_session = self.tab_sessions[&target_tab].loading_session;
+                if !self.tab_sessions[&target_tab].turn.is_in_flight() && !loading_session {
                     return;
                 }
                 if !loading_session {
                     self.turn_observe_chunk(&session_id, ChunkKind::Thought, "");
                 }
-                let tab = self.session_tab_mut(&session_id);
+                let tab = self
+                    .tab_sessions
+                    .get_mut(&target_tab)
+                    .expect("current session tab exists");
                 // Commit streamed prose before the tool so the transcript
                 // follows ACP event order instead of drawing the streaming
                 // buffer after every eagerly inserted tool card.
@@ -1521,7 +1689,9 @@ impl App {
                 cwd,
                 exit_code,
             } => {
-                let tab = self.session_tab_mut(&session_id);
+                let Some(tab) = self.session_tab_mut_if_current(&session_id) else {
+                    return;
+                };
                 if !tab.turn.is_in_flight() && !tab.loading_session {
                     return;
                 }
@@ -1584,7 +1754,9 @@ impl App {
                 output,
                 exit_code,
             } => {
-                let tab = self.session_tab_mut(&session_id);
+                let Some(tab) = self.session_tab_mut_if_current(&session_id) else {
+                    return;
+                };
                 let update_content = |message: &mut ChatMessage| -> bool {
                     let ChatMessage::ToolCall {
                         output: card_output,
@@ -1638,7 +1810,9 @@ impl App {
                 }
             }
             AppEvent::HideToolCall { session_id, id } => {
-                let tab = self.session_tab_mut(&session_id);
+                let Some(tab) = self.session_tab_mut_if_current(&session_id) else {
+                    return;
+                };
                 // Copilot currently omits ACP messageId during session/load,
                 // but recommendation-only turns still replay their hidden
                 // proposal tool call. Use that as the turn boundary without
@@ -1654,14 +1828,20 @@ impl App {
                 session_id,
                 entries,
             } => {
-                let loading_session = self.session_tab(&session_id).loading_session;
-                if !self.session_tab(&session_id).turn.is_in_flight() && !loading_session {
+                let Some(target_tab) = self.current_tab_for_session(&session_id) else {
+                    return;
+                };
+                let loading_session = self.tab_sessions[&target_tab].loading_session;
+                if !self.tab_sessions[&target_tab].turn.is_in_flight() && !loading_session {
                     return;
                 }
                 if !loading_session {
                     self.turn_observe_chunk(&session_id, ChunkKind::Thought, "");
                 }
-                let tab = self.session_tab_mut(&session_id);
+                let tab = self
+                    .tab_sessions
+                    .get_mut(&target_tab)
+                    .expect("current session tab exists");
                 if tab.loading_session {
                     tab.flush_replay_user_buffer();
                     if !tab.replay_agent_buffer.is_empty() {
@@ -1683,7 +1863,9 @@ impl App {
                 options,
                 responder,
             } => {
-                let tab = self.session_tab_mut(&session_id);
+                let Some(tab) = self.session_tab_mut_if_current(&session_id) else {
+                    return;
+                };
                 if !tab.turn.can_service_agent_request() && !tab.loading_session {
                     // Auto-deny only when no turn remains to own the request.
                     // A surfaced turn may have released its UI busy gate while
@@ -1712,7 +1894,9 @@ impl App {
                 request,
                 responder,
             } => {
-                let tab = self.session_tab_mut(&session_id);
+                let Some(tab) = self.session_tab_mut_if_current(&session_id) else {
+                    return;
+                };
                 if !tab.turn.can_service_agent_request() && !tab.loading_session {
                     return;
                 }
@@ -1729,7 +1913,9 @@ impl App {
                 request_id,
                 session_id,
             } => {
-                let tab = self.session_tab_mut(&session_id);
+                let Some(tab) = self.session_tab_mut_if_current(&session_id) else {
+                    return;
+                };
                 if let Some(index) = tab
                     .user_input
                     .iter()
@@ -2177,8 +2363,20 @@ impl App {
                             AUTH_RECOVERY_CONNECTION_TIMEOUT,
                         );
                     }
+                    let wait_for_transport_retirement = self.agent_transport_retirement_pending;
+                    let pending_load = self.pending_session_load_for_reconnect();
+                    if pending_load.is_none() {
+                        self.pending_session_load = None;
+                    }
                     self.reset_agent_scoped_state();
-                    self.pending_acp_start = true;
+                    if let Some((pending, prior_meaningful)) = pending_load {
+                        self.restore_pending_session_load(pending, prior_meaningful);
+                    }
+                    if wait_for_transport_retirement {
+                        self.reconnect_after_transport_retired = true;
+                    } else {
+                        self.pending_acp_start = true;
+                    }
                     return;
                 }
 
@@ -2546,6 +2744,7 @@ impl App {
                         let tab = self.tab_mut(tab_id);
                         tab.current_view = View::Chat;
                         tab.clear_chat_history();
+                        tab.invalidate_active_prompt_attachment();
                         tab.usage = None;
                         tab.usage_staleness = crate::usage::UsageStaleness::default();
                         tab.clear_completed_turns();
@@ -3043,26 +3242,7 @@ impl App {
                                 // `autofix.pane_id` as a fallback), and
                                 // resets `tab.turn` to Idle. Avoid duplicating
                                 // its work.
-                                let session_id = self
-                                    .tab_sessions
-                                    .get(&target_tab)
-                                    .and_then(|t| t.session_id.clone());
-                                if let Some(sid) = session_id {
-                                    self.turn_cancel(&sid);
-                                } else {
-                                    // No ACP session bound — replicate the
-                                    // minimum cleanup turn_cancel would do.
-                                    let pane_to_clear = {
-                                        let tab = self.tab_mut(&target_tab);
-                                        tab.autofix.generation =
-                                            tab.autofix.generation.wrapping_add(1);
-                                        tab.clear_recommendations();
-                                        tab.autofix.pane_id.take()
-                                    };
-                                    if pane_to_clear.is_some() {
-                                        self.emit_autofix_state_cleared(&target_tab);
-                                    }
-                                }
+                                self.request_turn_cancel_for_tab(&target_tab);
                             }
                             // Suggested: dismiss on prompt activity (exit-zero
                             // or a fresh prompt-start) in the event's tab.
@@ -3258,7 +3438,6 @@ impl App {
                             agent_source: self.current_agent_source.clone(),
                             source_cwd: self.source_cwd.clone(),
                             prompt_rx: None, // try_start_acp will create fresh channels
-                            cancel_rx: None,
                             new_session_rx: None,
                             load_session_rx: None,
                             drop_session_rx: None,

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -15,6 +15,46 @@ fn modifiers_allow_text_input(modifiers: KeyModifiers) -> bool {
 }
 
 impl App {
+    fn handle_global_ctrl_c(&mut self) {
+        let tab = self.current_tab();
+        let cancelling = tab.turn.is_cancelling();
+        let has_active_request =
+            tab.turn.is_in_flight() || !tab.user_input.is_empty() || !tab.permission.is_empty();
+        if has_active_request || cancelling {
+            let tab_id = self.active_tab_key().to_string();
+            self.request_turn_cancel_for_tab(&tab_id);
+            if !cancelling {
+                let tab = self.current_tab_mut();
+                tab.messages
+                    .push(ChatMessage::success(t!("system.cancelled").into_owned()));
+                tab.scroll_to_bottom();
+            }
+            self.close_pane_armed_at = None;
+        } else if !self.current_tab().input.is_empty() || !self.current_tab().attachments.is_empty()
+        {
+            let tab = self.current_tab_mut();
+            tab.clear_input();
+            self.close_pane_armed_at = None;
+        } else {
+            let now = std::time::Instant::now();
+            let armed = self
+                .close_pane_armed_at
+                .map(|t| now.duration_since(t) < CLOSE_PANE_ARM_WINDOW)
+                .unwrap_or(false);
+            if armed {
+                self.close_pane_armed_at = None;
+                self.transient_hint = None;
+                self.request_close_agent_pane();
+            } else {
+                self.close_pane_armed_at = Some(now);
+                self.transient_hint = Some((
+                    t!("system.close_pane_hint").into_owned(),
+                    now + CLOSE_PANE_ARM_WINDOW,
+                ));
+            }
+        }
+    }
+
     pub(super) fn handle_key(&mut self, key: KeyEvent) {
         // Per-keystroke and carries the raw `KeyCode` (the typed character for
         // `Char` keys) — the user's prompt can be reconstructed from this
@@ -42,6 +82,10 @@ impl App {
             // Don't clear `transient_hint` here — it has its own deadline and
             // ui::render checks expiry on each draw. Clearing on every key
             // would steal too much of the hint's visible lifetime.
+        }
+        if is_ctrl_c && self.mode == AppMode::Chat {
+            self.handle_global_ctrl_c();
+            return;
         }
 
         // The source picker is also reachable from Setup when the configured
@@ -690,56 +734,6 @@ impl App {
                 self.debug_scroll = self.debug_scroll.saturating_sub(10);
                 return;
             }
-            KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                // In-flight: state is Submitted/Streaming or Surfaced{end_pending}.
-                let in_flight = self.current_tab().turn.is_in_flight();
-                if in_flight {
-                    // Send a session/cancel to the ACP client. The client
-                    // keeps this turn active until the matching prompt reaches
-                    // its terminal boundary, preventing late output from
-                    // leaking into the next turn.
-                    let tab_id = self
-                        .tab_id
-                        .clone()
-                        .unwrap_or_else(|| DEFAULT_TAB_ID.to_string());
-                    self.request_turn_cancel_for_tab(&tab_id);
-                    let tab = self.current_tab_mut();
-                    tab.messages
-                        .push(ChatMessage::success(t!("system.cancelled").into_owned()));
-                    tab.scroll_to_bottom();
-                    self.close_pane_armed_at = None;
-                } else if !self.current_tab().input.is_empty()
-                    || !self.current_tab().attachments.is_empty()
-                {
-                    // Mirror bash readline: Ctrl+C clears the whole draft,
-                    // including any queued image attachments.
-                    let tab = self.current_tab_mut();
-                    tab.clear_input();
-                    self.close_pane_armed_at = None;
-                } else {
-                    // Idle + empty input. First press arms; second press
-                    // within CLOSE_PANE_ARM_WINDOW asks WT to close the
-                    // pane. We never set should_quit ourselves — the pane
-                    // teardown will kill our ConPty, which is the only
-                    // path that should terminate wta.
-                    let now = std::time::Instant::now();
-                    let armed = self
-                        .close_pane_armed_at
-                        .map(|t| now.duration_since(t) < CLOSE_PANE_ARM_WINDOW)
-                        .unwrap_or(false);
-                    if armed {
-                        self.close_pane_armed_at = None;
-                        self.transient_hint = None;
-                        self.request_close_agent_pane();
-                    } else {
-                        self.close_pane_armed_at = Some(now);
-                        self.transient_hint = Some((
-                            t!("system.close_pane_hint").into_owned(),
-                            now + CLOSE_PANE_ARM_WINDOW,
-                        ));
-                    }
-                }
-            }
             KeyCode::Esc if self.help_overlay_visible => {
                 self.help_overlay_visible = false;
             }
@@ -754,23 +748,8 @@ impl App {
                 // Dismiss armed fix card or cancel in-flight autofix request.
                 // `turn_cancel` bumps generation, emits autofix_state_cleared,
                 // and resets the state machine to Idle.
-                let session_id = self.current_tab().session_id.clone();
-                if let Some(sid) = session_id {
-                    self.turn_cancel(&sid);
-                } else {
-                    // No session attached yet — fall back to manual cleanup
-                    // (no chunks can be in flight in that case).
-                    let pane_to_clear = {
-                        let tab = self.current_tab_mut();
-                        tab.autofix.generation = tab.autofix.generation.wrapping_add(1);
-                        tab.autofix.armed_at = None;
-                        tab.autofix.pane_id.take()
-                    };
-                    if pane_to_clear.is_some() {
-                        let active = self.active_tab_key().to_string();
-                        self.emit_autofix_state_cleared(&active);
-                    }
-                }
+                let tab_id = self.active_tab_key().to_string();
+                self.request_turn_cancel_for_tab(&tab_id);
             }
             // Dismiss the bottom-bar Suggested indicator (autofix produced an
             // explanation, not an executable fix). Reachable only when the user
@@ -961,7 +940,11 @@ impl App {
                         context: TurnContext::default(),
                         autofix: None,
                     };
-                    self.turn_submit_prompt(&session_id, submitted);
+                    self.turn_submit_prompt_with_cancellation(
+                        &session_id,
+                        submitted,
+                        prompt.cancellation_token(),
+                    );
                     let _ = self.prompt_tx.send(prompt);
                 }
             }

--- a/tools/wta/src/app_keys.rs
+++ b/tools/wta/src/app_keys.rs
@@ -692,26 +692,17 @@ impl App {
             }
             KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 // In-flight: state is Submitted/Streaming or Surfaced{end_pending}.
-                let in_flight = !self.current_tab().turn.is_idle()
-                    && !matches!(
-                        self.current_tab().turn,
-                        TurnState::Surfaced {
-                            end_pending: false,
-                            ..
-                        }
-                    );
+                let in_flight = self.current_tab().turn.is_in_flight();
                 if in_flight {
                     // Send a session/cancel to the ACP client. The client
-                    // will fire the protocol notification and signal the
-                    // per-prompt oneshot so the spawned task drops out of
-                    // conn.prompt() immediately.
-                    let session_id = self.current_tab().session_id.clone();
-                    if let Some(sid) = session_id.clone() {
-                        let _ = self.cancel_tx.send(CancelRequest { session_id: sid });
-                    }
-                    if let Some(sid) = session_id {
-                        self.turn_cancel(&sid);
-                    }
+                    // keeps this turn active until the matching prompt reaches
+                    // its terminal boundary, preventing late output from
+                    // leaking into the next turn.
+                    let tab_id = self
+                        .tab_id
+                        .clone()
+                        .unwrap_or_else(|| DEFAULT_TAB_ID.to_string());
+                    self.request_turn_cancel_for_tab(&tab_id);
                     let tab = self.current_tab_mut();
                     tab.messages
                         .push(ChatMessage::success(t!("system.cancelled").into_owned()));
@@ -896,10 +887,16 @@ impl App {
                     // turn isn't accepting one. The ACP transport rejects
                     // too, but bouncing here keeps the user's input intact.
                     if !self.current_tab().turn.accepts_new_prompt() {
-                        let tab = self.current_tab_mut();
-                        tab.messages
-                            .push(ChatMessage::warning(t!("system.agent_busy").into_owned()));
-                        tab.scroll_to_bottom();
+                        // Cancellation has already produced its own status
+                        // line. Keep the draft intact and wait for the real
+                        // terminal boundary instead of claiming the agent is
+                        // busy or accidentally submitting into the old turn.
+                        if !self.current_tab().turn.is_cancelling() {
+                            let tab = self.current_tab_mut();
+                            tab.messages
+                                .push(ChatMessage::warning(t!("system.agent_busy").into_owned()));
+                            tab.scroll_to_bottom();
+                        }
                         return;
                     }
                     if self.prompt_reconfiguration_pending_for_tab(self.active_tab_key()) {

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -13716,6 +13716,7 @@ fn turn_cancel_requests_correlated_cancellation_and_enters_cancelling() {
         .insert(session_id.into(), DEFAULT_TAB_ID.into());
     app.tab_mut(DEFAULT_TAB_ID).session_id = Some(session_id.into());
     submit_test_prompt(&mut app, "stop this");
+    app.current_tab_mut().input = "keep this draft".into();
 
     app.turn_cancel(session_id);
 
@@ -13726,6 +13727,7 @@ fn turn_cancel_requests_correlated_cancellation_and_enters_cancelling() {
     assert_eq!(request.prompt_id, 42);
     assert_eq!(request.session_id.as_deref(), Some(session_id));
     assert!(app.current_tab().turn.is_cancelling());
+    assert_eq!(app.current_tab().input, "keep this draft");
 }
 
 #[test]

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -13691,7 +13691,7 @@ fn stale_autofix_at_close_resets_to_idle() {
 }
 
 #[test]
-fn cancel_bumps_generation_and_returns_to_idle() {
+fn cancel_bumps_generation_and_waits_for_terminal_boundary() {
     let mut app = test_app();
     submit_autofix_prompt(&mut app, "pane-1");
     let gen_before = app.tab_mut(DEFAULT_TAB_ID).autofix.generation;
@@ -13700,8 +13700,10 @@ fn cancel_bumps_generation_and_returns_to_idle() {
         app.tab_mut(DEFAULT_TAB_ID).autofix.generation,
         gen_before.wrapping_add(1)
     );
-    assert!(app.current_tab().turn.is_idle());
+    assert!(app.current_tab().turn.is_cancelling());
     assert!(app.tab_mut(DEFAULT_TAB_ID).autofix.pane_id.is_none());
+    app.turn_close(DEFAULT_TAB_ID);
+    assert!(app.current_tab().turn.is_idle());
 }
 
 #[test]
@@ -13714,7 +13716,7 @@ fn cancel_mid_stream_preserves_visible_prose_with_canceled_marker() {
     app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Message, "\n\nOnce upon a time");
     app.turn_cancel(DEFAULT_TAB_ID);
     let tab = app.current_tab();
-    assert!(tab.turn.is_idle(), "got {:?}", tab.turn);
+    assert!(tab.turn.is_cancelling(), "got {:?}", tab.turn);
     assert_eq!(tab.completed_turns.len(), 1);
     let committed = &tab.completed_turns[0];
     assert_eq!(committed.prompt, "tell me a story");
@@ -13736,6 +13738,18 @@ fn cancel_mid_stream_preserves_visible_prose_with_canceled_marker() {
     );
     assert!(tab.messages.is_empty(), "messages cleared on cancel");
 
+    app.turn_observe_chunk(
+        DEFAULT_TAB_ID,
+        ChunkKind::Message,
+        " stale text after cancel",
+    );
+    assert_eq!(
+        app.current_tab().completed_turns.len(),
+        1,
+        "late cancelled-turn chunks must be discarded"
+    );
+    app.turn_close(DEFAULT_TAB_ID);
+    assert!(app.current_tab().turn.is_idle());
     app.turn_cancel(DEFAULT_TAB_ID);
     assert_eq!(
         app.current_tab().completed_turns.len(),
@@ -13752,7 +13766,7 @@ fn cancel_mid_stream_preserves_raw_json_with_canceled_marker() {
     app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Message, json);
     app.turn_cancel(DEFAULT_TAB_ID);
     let tab = app.current_tab();
-    assert!(tab.turn.is_idle());
+    assert!(tab.turn.is_cancelling());
     assert_eq!(tab.completed_turns.len(), 1);
     let committed = &tab.completed_turns[0];
     assert_eq!(committed.prompt, "kill pid 1234");
@@ -13772,6 +13786,8 @@ fn cancel_mid_stream_preserves_raw_json_with_canceled_marker() {
         committed.trailing_marker
     );
     assert!(tab.messages.is_empty());
+    app.turn_close(DEFAULT_TAB_ID);
+    assert!(app.current_tab().turn.is_idle());
 }
 
 #[test]
@@ -14035,6 +14051,10 @@ fn direct_proposal_cancel_before_commit_does_not_surface() {
     });
     assert!(!commit_rx.blocking_recv().unwrap());
 
+    assert!(app.session_tab(session_id).turn.is_cancelling());
+    app.handle_event(AppEvent::AgentMessageEnd {
+        session_id: session_id.into(),
+    });
     assert!(app.session_tab(session_id).turn.is_idle());
     assert_eq!(
         final_rx.blocking_recv().unwrap(),

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -13702,7 +13702,11 @@ fn cancel_bumps_generation_and_waits_for_terminal_boundary() {
     );
     assert!(app.current_tab().turn.is_cancelling());
     assert!(app.tab_mut(DEFAULT_TAB_ID).autofix.pane_id.is_none());
-    app.turn_close(DEFAULT_TAB_ID);
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: DEFAULT_TAB_ID.into(),
+        prompt_id: 99,
+        session_id: None,
+    });
     assert!(app.current_tab().turn.is_idle());
 }
 
@@ -13726,8 +13730,230 @@ fn turn_cancel_requests_correlated_cancellation_and_enters_cancelling() {
     assert_eq!(request.tab_id, DEFAULT_TAB_ID);
     assert_eq!(request.prompt_id, 42);
     assert_eq!(request.session_id.as_deref(), Some(session_id));
-    assert!(app.current_tab().turn.is_cancelling());
+    assert_eq!(
+        app.current_tab().turn,
+        TurnState::Cancelling { prompt_id: 42 }
+    );
     assert_eq!(app.current_tab().input, "keep this draft");
+
+    app.turn_close(session_id);
+    assert!(
+        app.current_tab().turn.is_idle(),
+        "normal prompt completion racing cancellation is still a terminal boundary"
+    );
+}
+
+#[test]
+fn manual_fix_does_not_replace_a_cancelling_turn() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let mut app = test_app();
+    submit_test_prompt(&mut app, "stop this");
+    app.turn_cancel(DEFAULT_TAB_ID);
+    let cancelling = app.current_tab().turn.clone();
+    let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+    app.prompt_tx = prompt_tx;
+    app.current_tab_mut().input = "/fix".into();
+    app.current_tab_mut().cursor_pos = "/fix".len();
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert_eq!(app.current_tab().turn, cancelling);
+    assert!(
+        prompt_rx.try_recv().is_err(),
+        "/fix must not enqueue a prompt while cancellation is settling"
+    );
+}
+
+#[test]
+fn slash_new_does_not_replace_a_cancelling_turn() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let (mut app, mut new_session_rx) = test_app_with_new_session_rx();
+    submit_test_prompt(&mut app, "stop this");
+    app.turn_cancel(DEFAULT_TAB_ID);
+    let cancelling = app.current_tab().turn.clone();
+    app.current_tab_mut().input = "/new".into();
+    app.current_tab_mut().cursor_pos = "/new".len();
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    assert_eq!(app.current_tab().turn, cancelling);
+    assert!(
+        new_session_rx.try_recv().is_err(),
+        "/new must not request a replacement session while cancellation is settling"
+    );
+}
+
+#[test]
+fn cancellation_settlement_requires_exact_tab_and_prompt() {
+    let mut app = test_app();
+    submit_test_prompt(&mut app, "stop this");
+    app.turn_cancel(DEFAULT_TAB_ID);
+    app.tab_sessions
+        .insert("wrong-tab".into(), TabSession::default());
+
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: "wrong-tab".into(),
+        prompt_id: 42,
+        session_id: None,
+    });
+    assert_eq!(
+        app.current_tab().turn,
+        TurnState::Cancelling { prompt_id: 42 }
+    );
+    assert!(app.tab_sessions["wrong-tab"].turn.is_idle());
+
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: DEFAULT_TAB_ID.into(),
+        prompt_id: 41,
+        session_id: None,
+    });
+    assert_eq!(
+        app.current_tab().turn,
+        TurnState::Cancelling { prompt_id: 42 }
+    );
+
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: DEFAULT_TAB_ID.into(),
+        prompt_id: 42,
+        session_id: None,
+    });
+    assert!(app.current_tab().turn.is_idle());
+}
+
+#[test]
+fn cancellation_settlement_does_not_scan_for_an_unknown_session() {
+    let mut app = test_app();
+    submit_test_prompt(&mut app, "stop this");
+    app.turn_cancel(DEFAULT_TAB_ID);
+
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: "wrong-tab".into(),
+        prompt_id: 42,
+        session_id: Some("unknown-session".into()),
+    });
+
+    assert_eq!(
+        app.current_tab().turn,
+        TurnState::Cancelling { prompt_id: 42 }
+    );
+    assert!(!app.tab_sessions.contains_key("wrong-tab"));
+}
+
+#[test]
+fn old_tab_cancellation_settlement_finds_renamed_exact_prompt() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("old-session".into());
+    app.session_to_tab
+        .insert("old-session".into(), DEFAULT_TAB_ID.into());
+    submit_test_prompt(&mut app, "stop this");
+    app.turn_cancel(DEFAULT_TAB_ID);
+    app.handle_event(AppEvent::TabRenamed {
+        old_tab_id: DEFAULT_TAB_ID.into(),
+        new_tab_id: "renamed-tab".into(),
+        new_window_id: None,
+    });
+
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: DEFAULT_TAB_ID.into(),
+        prompt_id: 42,
+        session_id: Some("old-session".into()),
+    });
+
+    assert!(app.tab_sessions["renamed-tab"].turn.is_idle());
+    assert!(!app.tab_sessions.contains_key(DEFAULT_TAB_ID));
+}
+
+#[test]
+fn old_tab_cancellation_settlement_does_not_settle_different_prompt() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("old-session".into());
+    app.session_to_tab
+        .insert("old-session".into(), DEFAULT_TAB_ID.into());
+    submit_test_prompt(&mut app, "stop this");
+    app.turn_cancel(DEFAULT_TAB_ID);
+    app.handle_event(AppEvent::TabRenamed {
+        old_tab_id: DEFAULT_TAB_ID.into(),
+        new_tab_id: "renamed-tab".into(),
+        new_window_id: None,
+    });
+
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: DEFAULT_TAB_ID.into(),
+        prompt_id: 41,
+        session_id: Some("old-session".into()),
+    });
+
+    assert_eq!(
+        app.tab_sessions["renamed-tab"].turn,
+        TurnState::Cancelling { prompt_id: 42 }
+    );
+}
+
+#[test]
+fn cancellation_settlement_does_not_recreate_dropped_tab() {
+    let mut app = test_app();
+    app.tab_sessions.remove(DEFAULT_TAB_ID);
+
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: DEFAULT_TAB_ID.into(),
+        prompt_id: 99,
+        session_id: None,
+    });
+
+    assert!(!app.tab_sessions.contains_key(DEFAULT_TAB_ID));
+}
+
+#[test]
+fn cancellation_settlement_finds_renamed_turn_when_old_tab_key_was_recreated() {
+    let mut app = test_app();
+    app.current_tab_mut().session_id = Some("old-session".into());
+    app.session_to_tab
+        .insert("old-session".into(), DEFAULT_TAB_ID.into());
+    submit_test_prompt(&mut app, "old prompt");
+    app.turn_cancel(DEFAULT_TAB_ID);
+    app.handle_event(AppEvent::TabRenamed {
+        old_tab_id: DEFAULT_TAB_ID.into(),
+        new_tab_id: "renamed-tab".into(),
+        new_window_id: None,
+    });
+    app.tab_sessions
+        .insert(DEFAULT_TAB_ID.into(), Default::default());
+
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: DEFAULT_TAB_ID.into(),
+        prompt_id: 42,
+        session_id: Some("old-session".into()),
+    });
+
+    assert!(app.tab_sessions["renamed-tab"].turn.is_idle());
+    assert!(app.tab_sessions[DEFAULT_TAB_ID].turn.is_idle());
+}
+
+#[test]
+fn stale_cancellation_settlement_does_not_close_newer_turn() {
+    let mut app = test_app();
+    submit_test_prompt(&mut app, "old prompt");
+    app.turn_cancel(DEFAULT_TAB_ID);
+    app.current_tab_mut().turn = TurnState::Submitted(SubmittedPrompt {
+        id: 43,
+        text: "new prompt".into(),
+        submitted_at_unix_s: 0.0,
+        context: TurnContext::default(),
+        autofix: None,
+    });
+
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: DEFAULT_TAB_ID.into(),
+        prompt_id: 42,
+        session_id: None,
+    });
+
+    assert!(matches!(
+        app.current_tab().turn,
+        TurnState::Submitted(SubmittedPrompt { id: 43, .. })
+    ));
 }
 
 #[test]
@@ -13772,7 +13998,11 @@ fn cancel_mid_stream_preserves_visible_prose_with_canceled_marker() {
         1,
         "late cancelled-turn chunks must be discarded"
     );
-    app.turn_close(DEFAULT_TAB_ID);
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: DEFAULT_TAB_ID.into(),
+        prompt_id: 42,
+        session_id: None,
+    });
     assert!(app.current_tab().turn.is_idle());
     app.turn_cancel(DEFAULT_TAB_ID);
     assert_eq!(
@@ -13810,7 +14040,11 @@ fn cancel_mid_stream_preserves_raw_json_with_canceled_marker() {
         committed.trailing_marker
     );
     assert!(tab.messages.is_empty());
-    app.turn_close(DEFAULT_TAB_ID);
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: DEFAULT_TAB_ID.into(),
+        prompt_id: 42,
+        session_id: None,
+    });
     assert!(app.current_tab().turn.is_idle());
 }
 
@@ -14034,8 +14268,10 @@ fn cancel_after_direct_proposal_commits_trailing_transcript_once() {
     });
 
     app.turn_cancel(session_id);
-    app.handle_event(AppEvent::AgentMessageEnd {
-        session_id: session_id.into(),
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: DEFAULT_TAB_ID.into(),
+        prompt_id: 99,
+        session_id: Some(session_id.into()),
     });
     app.turn_cancel(session_id);
 
@@ -14076,8 +14312,10 @@ fn direct_proposal_cancel_before_commit_does_not_surface() {
     assert!(!commit_rx.blocking_recv().unwrap());
 
     assert!(app.session_tab(session_id).turn.is_cancelling());
-    app.handle_event(AppEvent::AgentMessageEnd {
-        session_id: session_id.into(),
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        tab_id: DEFAULT_TAB_ID.into(),
+        prompt_id: 99,
+        session_id: Some(session_id.into()),
     });
     assert!(app.session_tab(session_id).turn.is_idle());
     assert_eq!(

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -53,7 +53,6 @@ pub(super) fn test_app() -> App {
     let (prompt_tx, _prompt_rx) = tokio::sync::mpsc::unbounded_channel();
     let (recommendation_tx, _recommendation_rx) = tokio::sync::mpsc::unbounded_channel();
     let (permission_tx, _permission_rx) = tokio::sync::mpsc::unbounded_channel();
-    let (cancel_tx, _cancel_rx) = tokio::sync::mpsc::unbounded_channel();
     let (new_session_tx, _new_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (load_session_tx, _load_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (drop_session_tx, _drop_session_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -65,7 +64,6 @@ pub(super) fn test_app() -> App {
         prompt_tx,
         recommendation_tx,
         permission_tx,
-        cancel_tx,
         new_session_tx,
         load_session_tx,
         drop_session_tx,
@@ -99,7 +97,6 @@ fn test_app_with_restart_rx() -> (
     let (prompt_tx, _prompt_rx) = tokio::sync::mpsc::unbounded_channel();
     let (recommendation_tx, _recommendation_rx) = tokio::sync::mpsc::unbounded_channel();
     let (permission_tx, _permission_rx) = tokio::sync::mpsc::unbounded_channel();
-    let (cancel_tx, _cancel_rx) = tokio::sync::mpsc::unbounded_channel();
     let (new_session_tx, _new_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (load_session_tx, _load_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (drop_session_tx, _drop_session_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -111,7 +108,6 @@ fn test_app_with_restart_rx() -> (
             prompt_tx,
             recommendation_tx,
             permission_tx,
-            cancel_tx,
             new_session_tx,
             load_session_tx,
             drop_session_tx,
@@ -137,7 +133,6 @@ fn test_app_with_drop_session_rx() -> (
     let (prompt_tx, _prompt_rx) = tokio::sync::mpsc::unbounded_channel();
     let (recommendation_tx, _recommendation_rx) = tokio::sync::mpsc::unbounded_channel();
     let (permission_tx, _permission_rx) = tokio::sync::mpsc::unbounded_channel();
-    let (cancel_tx, _cancel_rx) = tokio::sync::mpsc::unbounded_channel();
     let (new_session_tx, _new_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (load_session_tx, _load_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (drop_session_tx, drop_session_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -149,7 +144,6 @@ fn test_app_with_drop_session_rx() -> (
             prompt_tx,
             recommendation_tx,
             permission_tx,
-            cancel_tx,
             new_session_tx,
             load_session_tx,
             drop_session_tx,
@@ -308,6 +302,7 @@ fn replacement_session_clears_old_native_config_prompt_gate() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: "replacement-session".into(),
+        prompt_id: None,
         available_models: Vec::new(),
         current_model_id: None,
     });
@@ -1446,7 +1441,6 @@ pub(super) fn test_app_with_master_rx() -> (
     let (prompt_tx, _prompt_rx) = tokio::sync::mpsc::unbounded_channel();
     let (recommendation_tx, _recommendation_rx) = tokio::sync::mpsc::unbounded_channel();
     let (permission_tx, _permission_rx) = tokio::sync::mpsc::unbounded_channel();
-    let (cancel_tx, _cancel_rx) = tokio::sync::mpsc::unbounded_channel();
     let (new_session_tx, _new_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (load_session_tx, _load_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (drop_session_tx, _drop_session_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1458,7 +1452,6 @@ pub(super) fn test_app_with_master_rx() -> (
         prompt_tx,
         recommendation_tx,
         permission_tx,
-        cancel_tx,
         new_session_tx,
         load_session_tx,
         drop_session_tx,
@@ -1681,7 +1674,6 @@ fn tab_renamed_sends_rename_session_request_to_acp_client() {
     let (prompt_tx, _prompt_rx) = tokio::sync::mpsc::unbounded_channel();
     let (recommendation_tx, _recommendation_rx) = tokio::sync::mpsc::unbounded_channel();
     let (permission_tx, _permission_rx) = tokio::sync::mpsc::unbounded_channel();
-    let (cancel_tx, _cancel_rx) = tokio::sync::mpsc::unbounded_channel();
     let (new_session_tx, _new_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (load_session_tx, _load_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (drop_session_tx, _drop_session_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1693,7 +1685,6 @@ fn tab_renamed_sends_rename_session_request_to_acp_client() {
         prompt_tx,
         recommendation_tx,
         permission_tx,
-        cancel_tx,
         new_session_tx,
         load_session_tx,
         drop_session_tx,
@@ -1742,7 +1733,6 @@ fn tab_renamed_noop_does_not_send_rename_session_request() {
     let (prompt_tx, _prompt_rx) = tokio::sync::mpsc::unbounded_channel();
     let (recommendation_tx, _recommendation_rx) = tokio::sync::mpsc::unbounded_channel();
     let (permission_tx, _permission_rx) = tokio::sync::mpsc::unbounded_channel();
-    let (cancel_tx, _cancel_rx) = tokio::sync::mpsc::unbounded_channel();
     let (new_session_tx, _new_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (load_session_tx, _load_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (drop_session_tx, _drop_session_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1754,7 +1744,6 @@ fn tab_renamed_noop_does_not_send_rename_session_request() {
         prompt_tx,
         recommendation_tx,
         permission_tx,
-        cancel_tx,
         new_session_tx,
         load_session_tx,
         drop_session_tx,
@@ -1835,7 +1824,6 @@ fn make_app_with_load_session_channel() -> (
     let (prompt_tx, _prompt_rx) = tokio::sync::mpsc::unbounded_channel();
     let (recommendation_tx, _recommendation_rx) = tokio::sync::mpsc::unbounded_channel();
     let (permission_tx, _permission_rx) = tokio::sync::mpsc::unbounded_channel();
-    let (cancel_tx, _cancel_rx) = tokio::sync::mpsc::unbounded_channel();
     let (new_session_tx, _new_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (load_session_tx, load_session_rx) = tokio::sync::mpsc::unbounded_channel();
     let (drop_session_tx, _drop_session_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -1847,7 +1835,6 @@ fn make_app_with_load_session_channel() -> (
         prompt_tx,
         recommendation_tx,
         permission_tx,
-        cancel_tx,
         new_session_tx,
         load_session_tx,
         drop_session_tx,
@@ -2075,6 +2062,7 @@ fn session_attached_for_bootstrap_does_not_close_load_replay_window() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: "OWNER-TAB".to_string(),
         session_id: "sess-bootstrap".to_string(),
+        prompt_id: None,
         available_models: vec![],
         current_model_id: None,
     });
@@ -2120,6 +2108,7 @@ fn unrelated_session_attached_keeps_load_target_yolo_gate() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: "OWNER-TAB".to_string(),
         session_id: "sess-unrelated".to_string(),
+        prompt_id: None,
         available_models: vec![],
         current_model_id: None,
     });
@@ -2148,6 +2137,7 @@ fn session_attached_reconciles_stale_client_yolo_target() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: session_id.into(),
+        prompt_id: None,
         available_models: Vec::new(),
         current_model_id: None,
     });
@@ -2181,6 +2171,7 @@ fn load_failure_then_fallback_attach_binds_the_fresh_session() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: tab_id.clone(),
         session_id: "fallback-session".into(),
+        prompt_id: None,
         available_models: Vec::new(),
         current_model_id: None,
     });
@@ -2287,6 +2278,7 @@ fn session_attached_for_load_target_closes_replay_window() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: "OWNER-TAB".to_string(),
         session_id: "sess-target".to_string(),
+        prompt_id: None,
         available_models: vec![],
         current_model_id: None,
     });
@@ -2345,6 +2337,7 @@ fn a_resume_keeps_the_status_row_after_the_connection_completes() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: "OWNER-TAB".to_string(),
         session_id: "sess-target".to_string(),
+        prompt_id: None,
         available_models: vec![],
         current_model_id: None,
     });
@@ -2668,6 +2661,7 @@ fn session_attached_for_load_target_packs_replayed_history() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: "OWNER-TAB".to_string(),
         session_id: "sess-target".to_string(),
+        prompt_id: None,
         available_models: vec![],
         current_model_id: None,
     });
@@ -2721,6 +2715,7 @@ fn replay_message_ids_preserve_user_only_recommendation_turns() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: "OWNER-TAB".to_string(),
         session_id: "sess-target".to_string(),
+        prompt_id: None,
         available_models: vec![],
         current_model_id: None,
     });
@@ -2779,6 +2774,7 @@ fn hidden_proposal_tool_calls_delimit_replayed_user_messages_without_ids() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: "OWNER-TAB".to_string(),
         session_id: "sess-target".to_string(),
+        prompt_id: None,
         available_models: vec![],
         current_model_id: None,
     });
@@ -3316,6 +3312,7 @@ fn model_config_update_before_session_attach_is_applied_on_attach() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: "sid-later".into(),
+        prompt_id: None,
         available_models: vec![model_info("claude-sonnet-5")],
         current_model_id: Some("claude-sonnet-5".into()),
     });
@@ -3341,6 +3338,7 @@ fn session_attach_prunes_replaced_session_model_config() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: "sid-new".into(),
+        prompt_id: None,
         available_models: vec![model_info("gpt-5.6-sol")],
         current_model_id: Some("gpt-5.6-sol".into()),
     });
@@ -3360,6 +3358,7 @@ fn background_session_attach_waits_for_tab_switch_to_update_picker() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: "background".into(),
         session_id: "sid-background".into(),
+        prompt_id: None,
         available_models: vec![model_info("gpt-5.6-sol")],
         current_model_id: Some("gpt-5.6-sol".into()),
     });
@@ -3560,6 +3559,7 @@ fn fresh_session_model_replaces_stale_agent_default() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: "sid-fresh".into(),
+        prompt_id: None,
         available_models: vec![model_info("stale"), model_info("fresh")],
         current_model_id: Some("fresh".into()),
     });
@@ -3726,6 +3726,7 @@ fn global_on_session_attach_gates_prompt_until_native_yolo_enable_acknowledges()
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: "global-on-session".into(),
+        prompt_id: None,
         available_models: Vec::new(),
         current_model_id: None,
     });
@@ -3788,6 +3789,7 @@ fn known_global_on_failure_releases_yolo_prompt_gate_for_interactive_fallback() 
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: "unsupported-global-on".into(),
+        prompt_id: None,
         available_models: Vec::new(),
         current_model_id: None,
     });
@@ -4044,6 +4046,7 @@ fn initial_load_placeholder_agent_connected_skips_yolo_reconcile() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: "loaded-session".into(),
+        prompt_id: None,
         available_models: Vec::new(),
         current_model_id: None,
     });
@@ -4207,6 +4210,7 @@ fn agent_reset_clears_reconcile_state_before_reused_id_attaches() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: session_id.into(),
+        prompt_id: None,
         available_models: Vec::new(),
         current_model_id: None,
     });
@@ -4231,6 +4235,7 @@ fn fresh_session_model_does_not_replace_global_override() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: "sid-fresh".into(),
+        prompt_id: None,
         available_models: vec![model_info("agent-default"), model_info("global")],
         current_model_id: Some("agent-default".into()),
     });
@@ -4264,6 +4269,7 @@ fn fresh_session_model_does_not_replace_pane_override_on_new() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: "sid-new".into(),
+        prompt_id: None,
         available_models: vec![model_info("agent-default"), model_info("pane-picked")],
         current_model_id: Some("agent-default".into()),
     });
@@ -4307,6 +4313,7 @@ fn fresh_session_model_does_not_replace_custom_selection() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: "sid-fresh".into(),
+        prompt_id: None,
         available_models: vec![model_info("agent-default")],
         current_model_id: Some("agent-default".into()),
     });
@@ -4493,13 +4500,18 @@ fn settings_agent_rebind_targets_owner_and_resets_only_agent_state() {
     assert!(!app.pending_acp_start);
     assert!(matches!(
         &app.agent_reconnect_state,
-        AgentReconnectState::Preflighting(_)
+        AgentReconnectState::Disconnecting(_)
     ));
     assert!(
         app.current_tab().messages.is_empty(),
         "the outgoing client's startup error must not leak into the new agent chat"
     );
 
+    app.handle_event(AppEvent::AgentTransportRetired);
+    assert!(matches!(
+        &app.agent_reconnect_state,
+        AgentReconnectState::Preflighting(_)
+    ));
     app.handle_event(AppEvent::AgentReconnectPreflightComplete {
         operation_id: "op-1".into(),
         generation: 1,
@@ -6958,6 +6970,9 @@ fn post_login_auth_recovery_shows_reconnecting_then_signin_fallback() {
         tab_id: None,
         params: json!({ "operation_id": restart_request_id }),
     });
+    assert!(!app.pending_acp_start);
+    assert!(app.reconnect_after_transport_retired);
+    app.handle_event(AppEvent::AgentTransportRetired);
     assert!(app.pending_acp_start);
     assert!(matches!(
         &app.auth_recovery_state,
@@ -7040,6 +7055,9 @@ fn auth_recovery_accepts_master_readiness_after_connection_timeout_window() {
         params: json!({ "operation_id": request_id }),
     });
 
+    assert!(!app.pending_acp_start);
+    assert!(app.reconnect_after_transport_retired);
+    app.handle_event(AppEvent::AgentTransportRetired);
     assert!(app.pending_acp_start);
     assert!(matches!(
         app.auth_recovery_state,
@@ -7131,9 +7149,12 @@ fn master_disconnect_reconnects_retained_custom_wsl_helper() {
 
     assert!(!app.should_quit);
     assert!(
-        app.pending_acp_start,
-        "master disconnect must reconnect the existing immutable binding"
+        !app.pending_acp_start,
+        "replacement client must wait until the old transport is retired"
     );
+    assert!(app.reconnect_after_transport_retired);
+    app.handle_event(AppEvent::AgentTransportRetired);
+    assert!(app.pending_acp_start);
     assert!(matches!(
         &app.agent_reconnect_state,
         AgentReconnectState::Idle
@@ -7157,12 +7178,161 @@ fn master_disconnect_reconnects_retained_custom_wsl_helper() {
 }
 
 #[test]
+fn master_disconnect_preserves_in_flight_session_load_for_reconnect() {
+    let mut app = test_app();
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some(DEFAULT_TAB_ID.into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+    let pending = LoadSessionForTab {
+        tab_id: DEFAULT_TAB_ID.into(),
+        session_id: "historical-session".into(),
+        cwd: Some("C:\\work".into()),
+    };
+    app.pending_session_load = Some(pending.clone());
+    app.current_tab_mut().loading_session = true;
+    app.current_tab_mut().loading_target_session_id = Some(pending.session_id.clone());
+
+    app.handle_event(AppEvent::MasterDisconnected);
+
+    assert_eq!(
+        app.pending_session_load
+            .as_ref()
+            .map(|request| request.session_id.as_str()),
+        Some("historical-session")
+    );
+    assert!(app.current_tab().loading_session);
+    assert_eq!(
+        app.current_tab().loading_target_session_id.as_deref(),
+        Some("historical-session")
+    );
+    assert!(app.reconnect_after_transport_retired);
+}
+
+#[test]
+fn master_disconnect_does_not_resurrect_abandoned_session_load() {
+    let mut app = test_app();
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some(DEFAULT_TAB_ID.into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+    app.pending_session_load = Some(LoadSessionForTab {
+        tab_id: DEFAULT_TAB_ID.into(),
+        session_id: "abandoned-session".into(),
+        cwd: None,
+    });
+
+    app.handle_event(AppEvent::MasterDisconnected);
+
+    assert!(app.pending_session_load.is_none());
+    assert!(!app.current_tab().loading_session);
+    assert!(app.current_tab().loading_target_session_id.is_none());
+}
+
+#[test]
+fn prompt_error_settles_only_the_matching_background_tab() {
+    let mut app = test_app();
+    app.tab_sessions
+        .insert("background-tab".into(), TabSession::default());
+    let prompt = PromptSubmission::new("background autofix".into(), None);
+    let prompt_id = prompt.id;
+    let cancellation = prompt.cancellation_token();
+    app.turn_submit_prompt_for_tab_with_cancellation(
+        "background-tab",
+        SubmittedPrompt {
+            id: prompt_id,
+            text: prompt.text,
+            submitted_at_unix_s: prompt.submitted_at_unix_s,
+            context: TurnContext::default(),
+            autofix: Some(AutofixContext { generation: 0 }),
+        },
+        cancellation,
+    );
+
+    app.handle_event(AppEvent::PromptError {
+        tab_id: "background-tab".into(),
+        prompt_id,
+        message: "lazy session failed".into(),
+    });
+
+    assert!(app.tab_sessions["background-tab"].turn.is_idle());
+    assert!(app.tab_sessions["background-tab"]
+        .active_prompt_cancellation
+        .is_none());
+    assert!(matches!(
+        app.tab_sessions["background-tab"].messages.last(),
+        Some(ChatMessage::Error(message)) if message == "lazy session failed"
+    ));
+    assert!(app.current_tab().messages.is_empty());
+}
+
+#[test]
 fn master_disconnect_without_binding_terminates_helper() {
     let mut app = test_app();
 
     app.handle_event(AppEvent::MasterDisconnected);
 
     assert!(app.should_quit);
+}
+
+#[test]
+fn tab_rename_updates_all_persisted_reconnect_identity() {
+    let mut app = test_app();
+    app.tab_id = Some(DEFAULT_TAB_ID.into());
+    app.owner_tab_id = Some(DEFAULT_TAB_ID.into());
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some(DEFAULT_TAB_ID.into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+    app.pending_session_load = Some(LoadSessionForTab {
+        tab_id: DEFAULT_TAB_ID.into(),
+        session_id: "historical-session".into(),
+        cwd: None,
+    });
+
+    app.handle_event(AppEvent::TabRenamed {
+        old_tab_id: DEFAULT_TAB_ID.into(),
+        new_tab_id: "renamed-tab".into(),
+        new_window_id: None,
+    });
+
+    assert_eq!(app.owner_tab_id.as_deref(), Some("renamed-tab"));
+    assert_eq!(
+        app.deferred_acp
+            .as_ref()
+            .and_then(|params| params.owner_tab_id.as_deref()),
+        Some("renamed-tab")
+    );
+    assert_eq!(
+        app.pending_session_load
+            .as_ref()
+            .map(|request| request.tab_id.as_str()),
+        Some("renamed-tab")
+    );
 }
 
 #[test]
@@ -7190,6 +7360,9 @@ fn replacement_master_recovers_helper_failed_during_session_retirement() {
         params: json!({ "operation_id": "normal-restart" }),
     });
 
+    assert!(!app.pending_acp_start);
+    assert!(app.reconnect_after_transport_retired);
+    app.handle_event(AppEvent::AgentTransportRetired);
     assert!(app.pending_acp_start);
     assert!(matches!(app.state, ConnectionState::Connecting(_)));
     assert!(matches!(&app.auth_recovery_state, AuthRecoveryState::Idle));
@@ -7228,6 +7401,9 @@ fn replacement_master_does_not_duplicate_connected_helper() {
 fn protocol_error_ends_turn_without_failing_connection() {
     let mut app = test_app();
     app.state = ConnectionState::Connected;
+    app.current_tab_mut().session_id = Some("live-session".into());
+    app.session_to_tab
+        .insert("live-session".into(), DEFAULT_TAB_ID.into());
 
     app.handle_event(AppEvent::AgentError {
         session_id: Some("live-session".to_string()),
@@ -7250,6 +7426,9 @@ fn protocol_error_ends_turn_without_failing_connection() {
 fn superseded_lazy_prompt_error_keeps_committed_user_bubble_visible() {
     let mut app = test_app();
     app.state = ConnectionState::Connected;
+    app.current_tab_mut().session_id = Some(DEFAULT_TAB_ID.to_string());
+    app.session_to_tab
+        .insert(DEFAULT_TAB_ID.to_string(), DEFAULT_TAB_ID.to_string());
     submit_test_prompt(&mut app, "keep this prompt visible");
 
     app.handle_event(AppEvent::AgentError {
@@ -7358,6 +7537,7 @@ fn soft_stop_appends_system_line_without_changing_state() {
     use crate::protocol::acp::soft_stop::SoftStopReason;
     let mut app = test_app();
     app.state = ConnectionState::Connected;
+    bind_test_session(&mut app, DEFAULT_TAB_ID);
 
     app.handle_event(AppEvent::AgentSoftStop {
         session_id: "0".to_string(),
@@ -7407,6 +7587,7 @@ fn soft_stop_reasons_map_to_distinct_localized_lines() {
         (SoftStopReason::Refusal, "system.stopped_refusal"),
     ] {
         let mut app = test_app();
+        bind_test_session(&mut app, DEFAULT_TAB_ID);
         app.handle_event(AppEvent::AgentSoftStop {
             session_id: "0".to_string(),
             reason,
@@ -7959,12 +8140,25 @@ fn osc133_prompt_start_in_agent_pane_origin_is_ignored() {
 // ─── turn-state integration tests ──────────────────────────────────────
 //
 // Drive `App` directly through the turn-state transitions in
-// `doc/specs/turn-state-refactor.md`'s table. We use the active tab's
-// `DEFAULT_TAB_ID` as the session key — `session_tab_mut` falls back to
-// the active tab when the id is unknown, which keeps these tests free
-// of ACP wiring.
+// `doc/specs/turn-state-refactor.md`'s table. Most tests bind the active tab
+// to `DEFAULT_TAB_ID`, matching production's exact SessionId routing while
+// keeping the setup terse.
+
+fn bind_test_session(app: &mut App, session_id: &str) {
+    let tab_id = app.active_tab_key().to_string();
+    app.current_tab_mut().session_id = Some(session_id.to_string());
+    app.session_to_tab.insert(session_id.to_string(), tab_id);
+}
 
 fn submit_test_prompt(app: &mut App, text: &str) {
+    let tab_id = app.active_tab_key().to_string();
+    let session_id = app
+        .current_tab()
+        .session_id
+        .clone()
+        .unwrap_or_else(|| DEFAULT_TAB_ID.to_string());
+    app.current_tab_mut().session_id = Some(session_id.clone());
+    app.session_to_tab.insert(session_id.clone(), tab_id);
     let prompt = SubmittedPrompt {
         id: 42,
         text: text.into(),
@@ -7972,7 +8166,7 @@ fn submit_test_prompt(app: &mut App, text: &str) {
         context: TurnContext::default(),
         autofix: None,
     };
-    app.turn_submit_prompt(DEFAULT_TAB_ID, prompt);
+    app.turn_submit_prompt(&session_id, prompt);
 }
 
 /// Form A end-to-end (mock-acp-agent spec, "option 2"): the mock + real
@@ -8003,6 +8197,7 @@ async fn mock_agent_reply_streams_into_app_chat() {
                 .new_session(acp::schema::v1::NewSessionRequest::new("/test"))
                 .await
                 .expect("new_session failed");
+            let session_id = session.session_id.to_string();
             conn.prompt(acp::schema::v1::PromptRequest::new(
                 session.session_id.clone(),
                 vec!["hello".into()],
@@ -8013,6 +8208,7 @@ async fn mock_agent_reply_streams_into_app_chat() {
             // Real App with an in-flight turn so streamed chunks are accepted
             // (the AgentMessageChunk handler drops chunks on an idle turn).
             let mut app = test_app();
+            bind_test_session(&mut app, &session_id);
             submit_test_prompt(&mut app, "hello");
 
             // Pump the AppEvents the real WtaClient produced into the real
@@ -8070,6 +8266,7 @@ async fn run_permission_scenario(expected_keys: &[KeyCode], want: &str) {
         .new_session(acp::schema::v1::NewSessionRequest::new("/test"))
         .await
         .expect("new_session failed");
+    let session_id = session.session_id.to_string();
     conn.prompt(acp::schema::v1::PromptRequest::new(
         session.session_id.clone(),
         vec!["do it".into()],
@@ -8079,6 +8276,7 @@ async fn run_permission_scenario(expected_keys: &[KeyCode], want: &str) {
 
     // Real App with an in-flight turn so the permission request is accepted.
     let mut app = test_app();
+    bind_test_session(&mut app, &session_id);
     submit_test_prompt(&mut app, "do it");
 
     // Pump events until the PermissionRequest is applied to the App.
@@ -8260,6 +8458,7 @@ fn perm_option_kind_matching_is_case_insensitive() {
 #[test]
 fn permission_request_replaces_thinking_until_dismissed() {
     let mut app = test_app();
+    bind_test_session(&mut app, DEFAULT_TAB_ID);
     let prompt = SubmittedPrompt {
         id: 1,
         text: "test".into(),
@@ -8312,6 +8511,7 @@ fn permission_request_replaces_thinking_until_dismissed() {
 #[test]
 fn surfaced_autofix_turn_accepts_follow_up_permission_request() {
     let mut app = test_app();
+    bind_test_session(&mut app, DEFAULT_TAB_ID);
     let prompt = SubmittedPrompt {
         id: 1,
         text: "autofix".into(),
@@ -8353,6 +8553,7 @@ fn surfaced_autofix_turn_accepts_follow_up_permission_request() {
 #[test]
 fn yolo_enabled_permission_request_remains_pending_until_user_input() {
     let mut app = test_app();
+    bind_test_session(&mut app, DEFAULT_TAB_ID);
     app.yolo_state.lock().unwrap().update_runtime(true, false);
     assert!(
         app.yolo_state.lock().unwrap().effective(DEFAULT_TAB_ID),
@@ -8405,6 +8606,7 @@ fn yolo_enabled_permission_request_remains_pending_until_user_input() {
 }
 
 fn begin_user_input_test(app: &mut App) {
+    bind_test_session(app, DEFAULT_TAB_ID);
     app.tab_mut(DEFAULT_TAB_ID).turn = TurnState::Submitted(SubmittedPrompt {
         id: 1,
         text: "test".into(),
@@ -8415,9 +8617,82 @@ fn begin_user_input_test(app: &mut App) {
 }
 
 #[test]
+fn ctrl_c_cancels_prompt_while_mcp_clarification_is_visible() {
+    let mut app = test_app();
+    submit_test_prompt(&mut app, "needs clarification");
+    app.current_tab_mut().input = "preserve this draft".into();
+    let cancellation = app
+        .current_tab()
+        .active_prompt_cancellation
+        .as_ref()
+        .expect("prompt token")
+        .token
+        .clone();
+    let (input_tx, mut input_rx) = tokio::sync::oneshot::channel();
+    let (permission_tx, mut permission_rx) = tokio::sync::oneshot::channel();
+    app.handle_event(AppEvent::UserInputRequest {
+        request_id: "clarification".into(),
+        session_id: DEFAULT_TAB_ID.into(),
+        request: crate::agent_tools::user_input::UserInputRequest {
+            question: "Which target?".into(),
+            choices: vec!["A".into()],
+            allow_freeform: true,
+        },
+        responder: input_tx,
+    });
+    let mut permission = perm_with("Allow follow-up?");
+    permission.responder = Some(permission_tx);
+    app.current_tab_mut().permission.push_back(permission);
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+
+    assert!(cancellation.is_cancelled());
+    assert!(app.current_tab().turn.is_cancelling());
+    assert!(app.current_tab().user_input.is_empty());
+    assert!(app.current_tab().permission.is_empty());
+    assert_eq!(app.current_tab().input, "preserve this draft");
+    assert!(matches!(
+        input_rx.try_recv(),
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed)
+    ));
+    assert!(matches!(
+        permission_rx.try_recv(),
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed)
+    ));
+}
+
+#[test]
+fn ctrl_c_cancels_prompt_while_permission_is_visible() {
+    let mut app = test_app();
+    submit_test_prompt(&mut app, "needs permission");
+    let cancellation = app
+        .current_tab()
+        .active_prompt_cancellation
+        .as_ref()
+        .expect("prompt token")
+        .token
+        .clone();
+    let (permission_tx, mut permission_rx) = tokio::sync::oneshot::channel();
+    let mut permission = perm_with("Allow tool?");
+    permission.responder = Some(permission_tx);
+    app.current_tab_mut().permission.push_back(permission);
+
+    app.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+
+    assert!(cancellation.is_cancelled());
+    assert!(app.current_tab().turn.is_cancelling());
+    assert!(app.current_tab().permission.is_empty());
+    assert!(matches!(
+        permission_rx.try_recv(),
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed)
+    ));
+}
+
+#[test]
 fn session_load_preserves_user_input_request() {
     let mut app = test_app();
     app.current_tab_mut().loading_session = true;
+    app.current_tab_mut().loading_target_session_id = Some(DEFAULT_TAB_ID.into());
     let (responder, mut response) = tokio::sync::oneshot::channel();
 
     app.handle_event(AppEvent::UserInputRequest {
@@ -8805,6 +9080,7 @@ async fn tool_call_surfaces_card_in_chat() {
                 .new_session(acp::schema::v1::NewSessionRequest::new("/test"))
                 .await
                 .expect("new_session failed");
+            let session_id = session.session_id.to_string();
             conn.prompt(acp::schema::v1::PromptRequest::new(
                 session.session_id.clone(),
                 vec!["run it".into()],
@@ -8813,6 +9089,7 @@ async fn tool_call_surfaces_card_in_chat() {
             .expect("prompt failed");
 
             let mut app = test_app();
+            bind_test_session(&mut app, &session_id);
             submit_test_prompt(&mut app, "run it");
 
             let pumped = tokio::time::timeout(std::time::Duration::from_secs(5), async {
@@ -8874,7 +9151,7 @@ async fn pump_until(
 /// leaving an in-flight turn whose streamed notifications the caller pumps
 /// into a real `App`. Returns `()` — it only drives ACP traffic; the caller
 /// owns the `App`.
-async fn app_after_prompt(conn: &crate::protocol::acp::conn::ClientLink) {
+async fn app_after_prompt(conn: &crate::protocol::acp::conn::ClientLink) -> String {
     use agent_client_protocol as acp;
 
     conn.initialize(acp::schema::v1::InitializeRequest::new(
@@ -8892,6 +9169,7 @@ async fn app_after_prompt(conn: &crate::protocol::acp::conn::ClientLink) {
     ))
     .await
     .expect("prompt failed");
+    session.session_id.to_string()
 }
 
 /// Streaming: a reply split across two `AgentMessageChunk`s must coalesce
@@ -8904,9 +9182,10 @@ async fn streaming_two_chunks_coalesce_in_app_chat() {
     local
         .run_until(async {
             let (conn, mut event_rx) = connect_mock_agent_streaming_two_chunks();
-            app_after_prompt(&conn).await;
+            let session_id = app_after_prompt(&conn).await;
 
             let mut app = test_app();
+            bind_test_session(&mut app, &session_id);
             submit_test_prompt(&mut app, "go");
 
             // Two chunks arrive; pump each.
@@ -8938,9 +9217,10 @@ async fn tool_call_completion_updates_card_status() {
     local
         .run_until(async {
             let (conn, mut event_rx) = connect_mock_agent_completing_tool();
-            app_after_prompt(&conn).await;
+            let session_id = app_after_prompt(&conn).await;
 
             let mut app = test_app();
+            bind_test_session(&mut app, &session_id);
             submit_test_prompt(&mut app, "go");
 
             pump_until(&mut app, &mut event_rx, |ev| {
@@ -9070,9 +9350,10 @@ async fn plan_surfaces_card_in_chat() {
     local
         .run_until(async {
             let (conn, mut event_rx) = connect_mock_agent_proposing_plan();
-            app_after_prompt(&conn).await;
+            let session_id = app_after_prompt(&conn).await;
 
             let mut app = test_app();
+            bind_test_session(&mut app, &session_id);
             submit_test_prompt(&mut app, "go");
 
             pump_until(&mut app, &mut event_rx, |ev| {
@@ -12520,6 +12801,7 @@ fn completed_turn_toggle_render_is_stable_after_first_frame() {
 fn completed_tool_output_update_invalidates_cached_turn_height() {
     let mut app = test_app();
     app.state = ConnectionState::Connected;
+    bind_test_session(&mut app, DEFAULT_TAB_ID);
     app.current_tab_mut().completed_turns.push(CompletedTurn {
         prompt: "TERMINAL_CACHE_PROMPT".into(),
         details: vec![ChatMessage::ToolCall {
@@ -12667,6 +12949,14 @@ fn render_recommendation_compact_keeps_summary_and_actions_visible() {
 }
 
 fn submit_autofix_prompt(app: &mut App, pane: &str) {
+    let tab_id = app.active_tab_key().to_string();
+    let session_id = app
+        .current_tab()
+        .session_id
+        .clone()
+        .unwrap_or_else(|| DEFAULT_TAB_ID.to_string());
+    app.current_tab_mut().session_id = Some(session_id.clone());
+    app.session_to_tab.insert(session_id.clone(), tab_id);
     let gen = {
         let tab = app.tab_mut(DEFAULT_TAB_ID);
         tab.autofix.generation = tab.autofix.generation.wrapping_add(1);
@@ -12680,7 +12970,7 @@ fn submit_autofix_prompt(app: &mut App, pane: &str) {
         context: TurnContext::with_target_pane(pane),
         autofix: Some(AutofixContext { generation: gen }),
     };
-    app.turn_submit_prompt(DEFAULT_TAB_ID, prompt);
+    app.turn_submit_prompt(&session_id, prompt);
 }
 
 /// Submit a manual-`/fix`-style autofix turn: an autofix context whose
@@ -13598,7 +13888,7 @@ fn end_with_no_eager_chat_fallback_commits_completed_turn() {
         ChunkKind::Message,
         "Light scatters in the atmosphere.",
     );
-    app.turn_close(DEFAULT_TAB_ID);
+    app.turn_close("fresh-session");
     let tab = app.current_tab();
     assert!(
         matches!(
@@ -13703,43 +13993,320 @@ fn cancel_bumps_generation_and_waits_for_terminal_boundary() {
     assert!(app.current_tab().turn.is_cancelling());
     assert!(app.tab_mut(DEFAULT_TAB_ID).autofix.pane_id.is_none());
     app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 99,
-        session_id: None,
+        started: false,
     });
     assert!(app.current_tab().turn.is_idle());
+    assert!(!app.current_tab().has_meaningful_conversation);
 }
 
 #[test]
-fn turn_cancel_requests_correlated_cancellation_and_enters_cancelling() {
+fn turn_cancel_signals_prompt_token_and_normal_completion_releases_ui() {
     let mut app = test_app();
-    let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::unbounded_channel();
-    app.cancel_tx = cancel_tx;
     let session_id = "session-1";
     app.session_to_tab
         .insert(session_id.into(), DEFAULT_TAB_ID.into());
     app.tab_mut(DEFAULT_TAB_ID).session_id = Some(session_id.into());
     submit_test_prompt(&mut app, "stop this");
+    let cancellation = app
+        .current_tab()
+        .active_prompt_cancellation
+        .as_ref()
+        .expect("prompt token")
+        .token
+        .clone();
     app.current_tab_mut().input = "keep this draft".into();
 
     app.turn_cancel(session_id);
 
-    let request = cancel_rx
-        .try_recv()
-        .expect("turn_cancel must request ACP cancellation");
-    assert_eq!(request.tab_id, DEFAULT_TAB_ID);
-    assert_eq!(request.prompt_id, 42);
-    assert_eq!(request.session_id.as_deref(), Some(session_id));
+    assert!(cancellation.is_cancelled());
     assert_eq!(
         app.current_tab().turn,
         TurnState::Cancelling { prompt_id: 42 }
     );
     assert_eq!(app.current_tab().input, "keep this draft");
 
-    app.turn_close(session_id);
+    app.handle_event(AppEvent::AgentMessageEnd {
+        session_id: session_id.into(),
+    });
     assert!(
         app.current_tab().turn.is_idle(),
         "normal prompt completion racing cancellation is still a terminal boundary"
+    );
+    assert!(app.current_tab().has_meaningful_conversation);
+}
+
+#[test]
+fn cancelling_lazy_prompt_binds_its_tagged_session_and_becomes_resumable() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    let prompt = PromptSubmission::new("lazy prompt".into(), None);
+    let prompt_id = prompt.id;
+    let cancellation = prompt.cancellation_token();
+    app.turn_submit_prompt_for_tab_with_cancellation(
+        DEFAULT_TAB_ID,
+        SubmittedPrompt {
+            id: prompt_id,
+            text: prompt.text,
+            submitted_at_unix_s: prompt.submitted_at_unix_s,
+            context: TurnContext::default(),
+            autofix: None,
+        },
+        cancellation,
+    );
+    app.request_turn_cancel_for_tab(DEFAULT_TAB_ID);
+
+    app.handle_event(AppEvent::SessionAttached {
+        tab_id: DEFAULT_TAB_ID.into(),
+        session_id: "lazy-session".into(),
+        prompt_id: Some(prompt_id),
+        available_models: Vec::new(),
+        current_model_id: None,
+    });
+
+    assert_eq!(
+        app.current_tab()
+            .active_prompt_cancellation
+            .as_ref()
+            .and_then(|active| active.session_id.as_deref()),
+        Some("lazy-session")
+    );
+    assert!(app.current_tab().turn.is_cancelling());
+
+    app.handle_event(AppEvent::AgentMessageEnd {
+        session_id: "lazy-session".into(),
+    });
+
+    assert!(app.current_tab().turn.is_idle());
+    assert_eq!(
+        app.current_tab().resumable_session_id(),
+        Some("lazy-session")
+    );
+}
+
+#[test]
+fn reset_invalidates_late_prompt_attachment_and_completion_only_releases_barrier() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    let prompt = PromptSubmission::new("lazy prompt".into(), None);
+    let prompt_id = prompt.id;
+    let cancellation = prompt.cancellation_token();
+    app.turn_submit_prompt_for_tab_with_cancellation(
+        DEFAULT_TAB_ID,
+        SubmittedPrompt {
+            id: prompt_id,
+            text: prompt.text,
+            submitted_at_unix_s: prompt.submitted_at_unix_s,
+            context: TurnContext::default(),
+            autofix: None,
+        },
+        cancellation,
+    );
+
+    app.reset_tab_session_for(DEFAULT_TAB_ID);
+    app.handle_event(AppEvent::SessionAttached {
+        tab_id: DEFAULT_TAB_ID.into(),
+        session_id: "retired-lazy-session".into(),
+        prompt_id: Some(prompt_id),
+        available_models: Vec::new(),
+        current_model_id: None,
+    });
+
+    assert!(app.current_tab().session_id.is_none());
+    assert!(!app.session_to_tab.contains_key("retired-lazy-session"));
+    assert!(app.current_tab().turn.is_cancelling());
+
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        prompt_id,
+        started: true,
+    });
+
+    assert!(app.current_tab().turn.is_idle());
+    assert!(!app.current_tab().has_meaningful_conversation);
+    assert_eq!(app.current_tab().resumable_session_id(), None);
+}
+
+#[test]
+fn late_nonterminal_events_from_retired_session_cannot_mutate_replacement() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().session_id = Some("replacement-session".into());
+    app.session_to_tab
+        .insert("replacement-session".into(), DEFAULT_TAB_ID.into());
+
+    app.handle_event(AppEvent::AgentThoughtChunk {
+        session_id: "retired-session".into(),
+        text: "stale thought".into(),
+    });
+    app.handle_event(AppEvent::AgentMessageChunk {
+        session_id: "retired-session".into(),
+        text: "stale message".into(),
+    });
+    app.handle_event(AppEvent::Plan {
+        session_id: "retired-session".into(),
+        entries: Vec::new(),
+    });
+    app.handle_event(AppEvent::TimingMetric {
+        session_id: "retired-session".into(),
+        note: "stale timing".into(),
+    });
+
+    assert!(!app.current_tab().has_meaningful_conversation);
+    assert!(app.current_tab().messages.is_empty());
+    assert!(app.current_tab().timing_note.is_none());
+}
+
+#[test]
+fn queued_prompt_cancel_survives_tab_rename_without_rekeying() {
+    let mut app = test_app();
+    let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+    app.prompt_tx = prompt_tx;
+    let prompt = PromptSubmission::new("queued".into(), None);
+    let prompt_id = prompt.id;
+    let cancellation = prompt.cancellation_token();
+    app.turn_submit_prompt_for_tab_with_cancellation(
+        DEFAULT_TAB_ID,
+        SubmittedPrompt {
+            id: prompt_id,
+            text: prompt.text.clone(),
+            submitted_at_unix_s: prompt.submitted_at_unix_s,
+            context: TurnContext::default(),
+            autofix: None,
+        },
+        cancellation.clone(),
+    );
+    app.prompt_tx.send(prompt).unwrap();
+
+    app.request_turn_cancel_for_tab(DEFAULT_TAB_ID);
+    app.handle_event(AppEvent::TabRenamed {
+        old_tab_id: DEFAULT_TAB_ID.into(),
+        new_tab_id: "renamed-tab".into(),
+        new_window_id: None,
+    });
+
+    let queued = prompt_rx.try_recv().expect("prompt remains queued");
+    assert!(queued.cancellation_token().is_cancelled());
+    assert!(cancellation.is_cancelled());
+    assert!(matches!(
+        app.tab_sessions["renamed-tab"].turn,
+        TurnState::Cancelling {
+            prompt_id: cancelling_id
+        } if cancelling_id == prompt_id
+    ));
+
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        prompt_id,
+        started: false,
+    });
+    assert!(app.tab_sessions["renamed-tab"].turn.is_idle());
+}
+
+#[test]
+fn reset_keeps_cancellation_barrier_and_preserves_next_draft() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+    app.prompt_tx = prompt_tx;
+    let prompt = PromptSubmission::new("old".into(), None);
+    let prompt_id = prompt.id;
+    let cancellation = prompt.cancellation_token();
+    app.turn_submit_prompt_for_tab_with_cancellation(
+        DEFAULT_TAB_ID,
+        SubmittedPrompt {
+            id: prompt_id,
+            text: prompt.text.clone(),
+            submitted_at_unix_s: prompt.submitted_at_unix_s,
+            context: TurnContext::default(),
+            autofix: None,
+        },
+        cancellation.clone(),
+    );
+    app.prompt_tx.send(prompt).unwrap();
+    app.current_tab_mut().input = "keep next draft".into();
+    app.current_tab_mut().cursor_pos = "keep next draft".len();
+
+    app.reset_tab_session_for(DEFAULT_TAB_ID);
+    assert!(cancellation.is_cancelled());
+    assert!(matches!(
+        app.current_tab().turn,
+        TurnState::Cancelling {
+            prompt_id: cancelling_id
+        } if cancelling_id == prompt_id
+    ));
+    assert_eq!(app.current_tab().input, "keep next draft");
+
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    assert_eq!(app.current_tab().input, "keep next draft");
+    assert_eq!(
+        prompt_rx.try_recv().expect("old prompt remains queued").id,
+        prompt_id
+    );
+    assert!(
+        prompt_rx.try_recv().is_err(),
+        "reset must not consume a new draft into a phantom Submitted turn"
+    );
+
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        prompt_id,
+        started: false,
+    });
+    app.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+    assert_ne!(
+        prompt_rx
+            .try_recv()
+            .expect("new prompt dispatches after settlement")
+            .id,
+        prompt_id
+    );
+}
+
+#[test]
+fn queued_prompt_lost_to_rebind_is_released_only_after_transport_retirement() {
+    let (mut app, mut restart_rx) = test_app_with_restart_rx();
+    app.owner_tab_id = Some(DEFAULT_TAB_ID.into());
+    app.window_id = Some("window-1".into());
+    app.current_agent_id = "copilot".into();
+    let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+    app.prompt_tx = prompt_tx;
+    let prompt = PromptSubmission::new("queued on old transport".into(), None);
+    let prompt_id = prompt.id;
+    let cancellation = prompt.cancellation_token();
+    app.turn_submit_prompt_for_tab_with_cancellation(
+        DEFAULT_TAB_ID,
+        SubmittedPrompt {
+            id: prompt_id,
+            text: prompt.text.clone(),
+            submitted_at_unix_s: prompt.submitted_at_unix_s,
+            context: TurnContext::default(),
+            autofix: None,
+        },
+        cancellation.clone(),
+    );
+    app.prompt_tx.send(prompt).unwrap();
+    app.current_tab_mut().input = "preserve this draft".into();
+
+    app.handle_event(agent_rebind_event(DEFAULT_TAB_ID, 1, "claude"));
+    assert!(matches!(
+        restart_rx.try_recv(),
+        Ok(AgentLifecycleRequest::RebindAgent(_))
+    ));
+    assert!(cancellation.is_cancelled());
+    assert!(app.current_tab().turn.is_cancelling());
+    assert_eq!(app.current_tab().input, "preserve this draft");
+
+    app.handle_event(AppEvent::AgentTransportRetired);
+
+    assert!(app.current_tab().turn.is_idle());
+    assert!(app.current_tab().active_prompt_cancellation.is_none());
+    assert_eq!(app.current_tab().input, "preserve this draft");
+    assert_eq!(
+        prompt_rx
+            .try_recv()
+            .expect("submission was still queued on old client")
+            .id,
+        prompt_id
     );
 }
 
@@ -13786,27 +14353,13 @@ fn slash_new_does_not_replace_a_cancelling_turn() {
 }
 
 #[test]
-fn cancellation_settlement_requires_exact_tab_and_prompt() {
+fn cancellation_settlement_requires_exact_prompt() {
     let mut app = test_app();
     submit_test_prompt(&mut app, "stop this");
     app.turn_cancel(DEFAULT_TAB_ID);
-    app.tab_sessions
-        .insert("wrong-tab".into(), TabSession::default());
-
     app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: "wrong-tab".into(),
-        prompt_id: 42,
-        session_id: None,
-    });
-    assert!(app.current_tab().turn.is_idle());
-    assert!(app.tab_sessions["wrong-tab"].turn.is_idle());
-
-    submit_test_prompt(&mut app, "stop another");
-    app.turn_cancel(DEFAULT_TAB_ID);
-    app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 41,
-        session_id: None,
+        started: false,
     });
     assert_eq!(
         app.current_tab().turn,
@@ -13814,30 +14367,308 @@ fn cancellation_settlement_requires_exact_tab_and_prompt() {
     );
 
     app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 42,
-        session_id: None,
+        started: false,
     });
     assert!(app.current_tab().turn.is_idle());
 }
 
 #[test]
-fn cancellation_settlement_does_not_scan_for_an_unknown_session() {
+fn started_cancellation_settlement_marks_session_meaningful() {
     let mut app = test_app();
+    app.current_tab_mut().session_id = Some("session-1".into());
     submit_test_prompt(&mut app, "stop this");
     app.turn_cancel(DEFAULT_TAB_ID);
 
     app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: "wrong-tab".into(),
         prompt_id: 42,
-        session_id: Some("unknown-session".into()),
+        started: true,
     });
 
-    assert_eq!(
-        app.current_tab().turn,
-        TurnState::Cancelling { prompt_id: 42 }
+    assert!(app.current_tab().turn.is_idle());
+    assert!(app.current_tab().has_meaningful_conversation);
+    let projection = super::app_status_projection::build_agent_state_changed_event(
+        DEFAULT_TAB_ID,
+        app.current_tab(),
     );
-    assert!(!app.tab_sessions.contains_key("wrong-tab"));
+    assert_eq!(
+        projection["params"]["agent_session_id"],
+        serde_json::json!("session-1"),
+        "started no-output cancellation must immediately project a resumable session"
+    );
+}
+
+#[test]
+fn transport_retirement_releases_submitted_and_cancelling_turns() {
+    let mut app = test_app();
+    app.tab_id = Some("submitted-tab".into());
+    app.tab_mut("submitted-tab").session_id = Some("submitted-session".into());
+    app.session_to_tab
+        .insert("submitted-session".into(), "submitted-tab".into());
+    app.turn_submit_prompt(
+        "submitted-session",
+        SubmittedPrompt {
+            id: 60,
+            text: "queued".into(),
+            submitted_at_unix_s: 0.0,
+            context: TurnContext::default(),
+            autofix: None,
+        },
+    );
+    let submitted_token = app.tab_sessions["submitted-tab"]
+        .active_prompt_cancellation
+        .as_ref()
+        .expect("submitted token")
+        .token
+        .clone();
+
+    app.tab_mut("cancelling-tab").session_id = Some("cancelling-session".into());
+    app.session_to_tab
+        .insert("cancelling-session".into(), "cancelling-tab".into());
+    app.turn_submit_prompt(
+        "cancelling-session",
+        SubmittedPrompt {
+            id: 61,
+            text: "running".into(),
+            submitted_at_unix_s: 0.0,
+            context: TurnContext::default(),
+            autofix: None,
+        },
+    );
+    app.turn_cancel("cancelling-session");
+
+    app.handle_event(AppEvent::AgentTransportRetired);
+
+    assert!(submitted_token.is_cancelled());
+    assert!(app.tab_sessions["submitted-tab"].turn.is_idle());
+    assert!(app.tab_sessions["cancelling-tab"].turn.is_idle());
+    assert!(app.tab_sessions["submitted-tab"]
+        .active_prompt_cancellation
+        .is_none());
+    assert!(app.tab_sessions["cancelling-tab"]
+        .active_prompt_cancellation
+        .is_none());
+}
+
+#[test]
+fn unexpected_transport_exit_releases_reset_cancellation_barrier() {
+    let mut app = test_app();
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some(DEFAULT_TAB_ID.into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+    app.current_tab_mut().session_id = Some("old-session".into());
+    app.session_to_tab
+        .insert("old-session".into(), DEFAULT_TAB_ID.into());
+    app.turn_submit_prompt(
+        "old-session",
+        SubmittedPrompt {
+            id: 62,
+            text: "running".into(),
+            submitted_at_unix_s: 0.0,
+            context: TurnContext::default(),
+            autofix: None,
+        },
+    );
+
+    app.handle_event(AppEvent::MasterDisconnected);
+    assert!(app.current_tab().turn.is_cancelling());
+    app.handle_event(AppEvent::AgentTransportRetired);
+
+    assert!(app.current_tab().turn.is_idle());
+    assert!(app.current_tab().active_prompt_cancellation.is_none());
+    assert!(app.pending_acp_start);
+}
+
+#[test]
+fn rebind_after_master_disconnect_uses_closed_receiver_fallback() {
+    let (mut app, mut restart_rx) = test_app_with_restart_rx();
+    app.owner_tab_id = Some(DEFAULT_TAB_ID.into());
+    app.window_id = Some("window-1".into());
+    app.current_agent_id = "copilot".into();
+    app.set_master_pipe_acp_params(
+        "master-pipe".into(),
+        "copilot --acp".into(),
+        Some("copilot".into()),
+        None,
+        None,
+        crate::agent_source::AgentSource::Host,
+        None,
+        Some(DEFAULT_TAB_ID.into()),
+        Arc::clone(&app.shell_mgr),
+        true,
+    );
+
+    restart_rx.close();
+    app.handle_event(AppEvent::MasterDisconnected);
+    app.handle_event(agent_rebind_event(DEFAULT_TAB_ID, 1, "claude"));
+
+    assert!(matches!(
+        &app.agent_reconnect_state,
+        AgentReconnectState::Disconnecting(request)
+            if request.agent_id == "claude" && request.generation == 1
+    ));
+    assert!(!app.reconnect_after_transport_retired);
+
+    app.handle_event(AppEvent::AgentTransportRetired);
+    assert!(matches!(
+        &app.agent_reconnect_state,
+        AgentReconnectState::Preflighting(request)
+            if request.agent_id == "claude" && request.generation == 1
+    ));
+
+    app.handle_event(AppEvent::AgentReconnectPreflightComplete {
+        operation_id: "op-1".into(),
+        generation: 1,
+        result: passed_preflight("claude", "Claude"),
+    });
+    assert!(app.pending_acp_start);
+}
+
+fn prepare_retired_cancellation(
+    app: &mut App,
+    tab_id: &str,
+    old_session_id: &str,
+    new_session_id: &str,
+    prompt_id: u64,
+) {
+    app.tab_mut(tab_id).session_id = Some(old_session_id.into());
+    app.session_to_tab
+        .insert(old_session_id.into(), tab_id.into());
+    app.turn_submit_prompt(
+        old_session_id,
+        SubmittedPrompt {
+            id: prompt_id,
+            text: "old prompt".into(),
+            submitted_at_unix_s: 0.0,
+            context: TurnContext::default(),
+            autofix: None,
+        },
+    );
+    app.turn_cancel(old_session_id);
+    app.reset_tab_session_for(tab_id);
+    app.handle_event(AppEvent::SessionAttached {
+        tab_id: tab_id.into(),
+        session_id: new_session_id.into(),
+        prompt_id: None,
+        available_models: Vec::new(),
+        current_model_id: None,
+    });
+}
+
+#[test]
+fn late_old_terminal_events_release_exact_barriers_without_blessing_new_sessions() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.tab_id = Some("active-tab".into());
+    app.tab_mut("active-tab").session_id = Some("active-session".into());
+    app.session_to_tab
+        .insert("active-session".into(), "active-tab".into());
+    app.tab_mut("active-tab")
+        .messages
+        .push(ChatMessage::info("keep me"));
+
+    prepare_retired_cancellation(
+        &mut app,
+        "ended-tab",
+        "old-ended-session",
+        "new-ended-session",
+        70,
+    );
+    prepare_retired_cancellation(
+        &mut app,
+        "error-tab",
+        "old-error-session",
+        "new-error-session",
+        71,
+    );
+    prepare_retired_cancellation(
+        &mut app,
+        "settled-tab",
+        "old-settled-session",
+        "new-settled-session",
+        72,
+    );
+
+    app.handle_event(AppEvent::AgentMessageEnd {
+        session_id: "new-ended-session".into(),
+    });
+    assert!(app.tab_sessions["ended-tab"].turn.is_cancelling());
+    assert!(!app.tab_sessions["ended-tab"].has_meaningful_conversation);
+
+    app.handle_event(AppEvent::AgentMessageEnd {
+        session_id: "old-ended-session".into(),
+    });
+    app.handle_event(AppEvent::AgentError {
+        session_id: Some("old-error-session".into()),
+        failure: crate::protocol::acp::failure::AgentFailure::Protocol {
+            code: -32000,
+            message: "late failure".into(),
+        },
+        message: "late failure".into(),
+    });
+    app.handle_event(AppEvent::PromptCancellationSettled {
+        prompt_id: 72,
+        started: true,
+    });
+
+    for tab_id in ["ended-tab", "error-tab", "settled-tab"] {
+        let tab = &app.tab_sessions[tab_id];
+        assert!(tab.turn.is_idle());
+        assert!(!tab.has_meaningful_conversation);
+        assert_eq!(tab.resumable_session_id(), None);
+        assert!(tab.messages.is_empty());
+    }
+    assert_eq!(
+        app.tab_sessions["ended-tab"].session_id.as_deref(),
+        Some("new-ended-session")
+    );
+    assert_eq!(
+        app.tab_sessions["error-tab"].session_id.as_deref(),
+        Some("new-error-session")
+    );
+    assert_eq!(
+        app.tab_sessions["settled-tab"].session_id.as_deref(),
+        Some("new-settled-session")
+    );
+    assert_eq!(app.tab_sessions["active-tab"].messages.len(), 1);
+    assert!(matches!(app.state, ConnectionState::Connected));
+}
+
+#[test]
+fn unknown_old_terminal_events_do_not_mutate_the_active_tab() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    app.current_tab_mut().session_id = Some("active-session".into());
+    app.session_to_tab
+        .insert("active-session".into(), DEFAULT_TAB_ID.into());
+    submit_test_prompt(&mut app, "still running");
+    let turn_before = app.current_tab().turn.clone();
+    let messages_before = app.current_tab().messages.clone();
+
+    app.handle_event(AppEvent::AgentMessageEnd {
+        session_id: "unknown-old-session".into(),
+    });
+    app.handle_event(AppEvent::AgentError {
+        session_id: Some("unknown-old-session".into()),
+        failure: crate::protocol::acp::failure::AgentFailure::Protocol {
+            code: -32000,
+            message: "stale".into(),
+        },
+        message: "stale".into(),
+    });
+
+    assert_eq!(app.current_tab().turn, turn_before);
+    assert_eq!(app.current_tab().messages, messages_before);
+    assert!(matches!(app.state, ConnectionState::Connected));
 }
 
 #[test]
@@ -13855,9 +14686,8 @@ fn old_tab_cancellation_settlement_finds_renamed_exact_prompt() {
     });
 
     app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 42,
-        session_id: None,
+        started: false,
     });
 
     assert!(app.tab_sessions["renamed-tab"].turn.is_idle());
@@ -13879,9 +14709,8 @@ fn old_tab_cancellation_settlement_does_not_settle_different_prompt() {
     });
 
     app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 41,
-        session_id: Some("old-session".into()),
+        started: true,
     });
 
     assert_eq!(
@@ -13896,9 +14725,8 @@ fn cancellation_settlement_does_not_recreate_dropped_tab() {
     app.tab_sessions.remove(DEFAULT_TAB_ID);
 
     app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 99,
-        session_id: None,
+        started: false,
     });
 
     assert!(!app.tab_sessions.contains_key(DEFAULT_TAB_ID));
@@ -13921,9 +14749,8 @@ fn cancellation_settlement_finds_renamed_turn_when_old_tab_key_was_recreated() {
         .insert(DEFAULT_TAB_ID.into(), Default::default());
 
     app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 42,
-        session_id: Some("old-session".into()),
+        started: false,
     });
 
     assert!(app.tab_sessions["renamed-tab"].turn.is_idle());
@@ -13944,9 +14771,8 @@ fn stale_cancellation_settlement_does_not_close_newer_turn() {
     });
 
     app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 42,
-        session_id: None,
+        started: false,
     });
 
     assert!(matches!(
@@ -13998,9 +14824,8 @@ fn cancel_mid_stream_preserves_visible_prose_with_canceled_marker() {
         "late cancelled-turn chunks must be discarded"
     );
     app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 42,
-        session_id: None,
+        started: true,
     });
     assert!(app.current_tab().turn.is_idle());
     app.turn_cancel(DEFAULT_TAB_ID);
@@ -14040,9 +14865,8 @@ fn cancel_mid_stream_preserves_raw_json_with_canceled_marker() {
     );
     assert!(tab.messages.is_empty());
     app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 42,
-        session_id: None,
+        started: true,
     });
     assert!(app.current_tab().turn.is_idle());
 }
@@ -14077,6 +14901,7 @@ fn raw_json_assistant_text_commits_as_chat_turn() {
 fn stage_proposal_session(app: &mut App, session_id: &str) {
     app.session_to_tab
         .insert(session_id.to_string(), DEFAULT_TAB_ID.to_string());
+    app.tab_mut(DEFAULT_TAB_ID).session_id = Some(session_id.to_string());
 }
 
 fn submit_proposal_prompt(app: &mut App, session_id: &str) {
@@ -14268,9 +15093,8 @@ fn cancel_after_direct_proposal_commits_trailing_transcript_once() {
 
     app.turn_cancel(session_id);
     app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 99,
-        session_id: Some(session_id.into()),
+        started: true,
     });
     app.turn_cancel(session_id);
 
@@ -14312,9 +15136,8 @@ fn direct_proposal_cancel_before_commit_does_not_surface() {
 
     assert!(app.session_tab(session_id).turn.is_cancelling());
     app.handle_event(AppEvent::PromptCancellationSettled {
-        tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 99,
-        session_id: Some(session_id.into()),
+        started: true,
     });
     assert!(app.session_tab(session_id).turn.is_idle());
     assert_eq!(
@@ -15512,6 +16335,7 @@ fn usage_reported_updates_only_the_session_owner_tab() {
         .insert("ACTIVE-TAB".to_string(), TabSession::default());
     app.tab_sessions
         .insert("OWNER-TAB".to_string(), TabSession::default());
+    app.tab_sessions.get_mut("OWNER-TAB").unwrap().session_id = Some("usage-session".to_string());
     app.session_to_tab
         .insert("usage-session".to_string(), "OWNER-TAB".to_string());
     let snapshot = usage_snapshot();
@@ -15528,6 +16352,7 @@ fn usage_reported_updates_only_the_session_owner_tab() {
 #[test]
 fn usage_reported_merges_independent_metrics_for_the_same_session() {
     let mut app = test_app();
+    app.current_tab_mut().session_id = Some("usage-session".to_string());
     app.session_to_tab
         .insert("usage-session".to_string(), DEFAULT_TAB_ID.to_string());
     app.handle_event(AppEvent::UsageReported {
@@ -15568,6 +16393,7 @@ fn usage_cleared_removes_only_owner_snapshot_without_changing_chat() {
         TabSession {
             messages: vec![ChatMessage::System("keep this message".to_string())],
             usage: Some(snapshot.clone()),
+            session_id: Some("usage-session".to_string()),
             ..Default::default()
         },
     );
@@ -15806,7 +16632,7 @@ fn a_submitted_prompt_is_not_resumable_until_the_agent_answers() {
         "a prompt the agent has not answered yet must not be persisted as resumable"
     );
 
-    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Message, "hi");
+    app.turn_observe_chunk("fresh-session", ChunkKind::Message, "hi");
     assert_eq!(
         app.tab_mut(DEFAULT_TAB_ID).resumable_session_id(),
         Some("fresh-session")

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -13798,12 +13798,11 @@ fn cancellation_settlement_requires_exact_tab_and_prompt() {
         prompt_id: 42,
         session_id: None,
     });
-    assert_eq!(
-        app.current_tab().turn,
-        TurnState::Cancelling { prompt_id: 42 }
-    );
+    assert!(app.current_tab().turn.is_idle());
     assert!(app.tab_sessions["wrong-tab"].turn.is_idle());
 
+    submit_test_prompt(&mut app, "stop another");
+    app.turn_cancel(DEFAULT_TAB_ID);
     app.handle_event(AppEvent::PromptCancellationSettled {
         tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 41,
@@ -13858,7 +13857,7 @@ fn old_tab_cancellation_settlement_finds_renamed_exact_prompt() {
     app.handle_event(AppEvent::PromptCancellationSettled {
         tab_id: DEFAULT_TAB_ID.into(),
         prompt_id: 42,
-        session_id: Some("old-session".into()),
+        session_id: None,
     });
 
     assert!(app.tab_sessions["renamed-tab"].turn.is_idle());

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -13707,6 +13707,28 @@ fn cancel_bumps_generation_and_waits_for_terminal_boundary() {
 }
 
 #[test]
+fn turn_cancel_requests_correlated_cancellation_and_enters_cancelling() {
+    let mut app = test_app();
+    let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::unbounded_channel();
+    app.cancel_tx = cancel_tx;
+    let session_id = "session-1";
+    app.session_to_tab
+        .insert(session_id.into(), DEFAULT_TAB_ID.into());
+    app.tab_mut(DEFAULT_TAB_ID).session_id = Some(session_id.into());
+    submit_test_prompt(&mut app, "stop this");
+
+    app.turn_cancel(session_id);
+
+    let request = cancel_rx
+        .try_recv()
+        .expect("turn_cancel must request ACP cancellation");
+    assert_eq!(request.tab_id, DEFAULT_TAB_ID);
+    assert_eq!(request.prompt_id, 42);
+    assert_eq!(request.session_id.as_deref(), Some(session_id));
+    assert!(app.current_tab().turn.is_cancelling());
+}
+
+#[test]
 fn cancel_mid_stream_preserves_visible_prose_with_canceled_marker() {
     // Esc while prose is streaming → commit partial prose as a
     // CompletedTurn (default-expanded) with the trailing_marker set

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -30,17 +30,33 @@ impl App {
     /// `prompt_received`. Caller is responsible for actually dispatching the
     /// prompt over ACP (so this method stays free of async / channel
     /// concerns).
+    #[cfg(test)]
     pub fn turn_submit_prompt(&mut self, session_id: &str, prompt: SubmittedPrompt) {
-        let tab_key = self.tab_for_session(session_id);
-        self.turn_submit_prompt_for_tab(&tab_key, prompt);
+        self.turn_submit_prompt_with_cancellation(
+            session_id,
+            prompt,
+            tokio_util::sync::CancellationToken::new(),
+        );
     }
 
-    /// Identical to `turn_submit_prompt` but takes the target tab's id
-    /// directly, bypassing the `session_id → tab_id` lookup. Used by the
-    /// autofix path so a failure in a background tab installs the turn on
-    /// that tab even when its ACP session hasn't been created yet (the ACP
-    /// layer lazy-creates one when the prompt is dispatched).
-    pub fn turn_submit_prompt_for_tab(&mut self, tab_id: &str, prompt: SubmittedPrompt) {
+    pub fn turn_submit_prompt_with_cancellation(
+        &mut self,
+        session_id: &str,
+        prompt: SubmittedPrompt,
+        cancellation: tokio_util::sync::CancellationToken,
+    ) {
+        let tab_key = self.tab_for_session(session_id);
+        self.turn_submit_prompt_for_tab_with_cancellation(&tab_key, prompt, cancellation);
+    }
+
+    /// Install a prompt on a specific tab with the same cancellation token
+    /// carried by the queued [`PromptSubmission`].
+    pub fn turn_submit_prompt_for_tab_with_cancellation(
+        &mut self,
+        tab_id: &str,
+        prompt: SubmittedPrompt,
+        cancellation: tokio_util::sync::CancellationToken,
+    ) {
         prompt_timing_log(
             prompt.id,
             prompt.submitted_at_unix_s,
@@ -82,6 +98,7 @@ impl App {
         tab.scroll_to_bottom();
         tab.activity_frame = 0;
         tab.timing_note = None;
+        tab.set_prompt_cancellation(prompt.id, cancellation);
         tab.turn = TurnState::Submitted(prompt);
         // NOTE: `has_meaningful_conversation` is deliberately NOT set here.
         // It gates `resumable_session_id`, i.e. the session id Terminal writes
@@ -110,7 +127,9 @@ impl App {
     pub fn turn_observe_chunk(&mut self, session_id: &str, kind: ChunkKind, text: &str) -> bool {
         // Stale-autofix check: if the chunk belongs to an autofix turn whose
         // generation no longer matches the tab's counter, drop it.
-        let tab = self.session_tab_mut(session_id);
+        let Some(tab) = self.session_tab_mut_if_current(session_id) else {
+            return false;
+        };
         let current_gen = tab.autofix.generation;
         if let Some(gen) = tab.turn.autofix_generation() {
             if gen != current_gen {
@@ -124,13 +143,7 @@ impl App {
             }
         }
 
-        // A chunk for this turn is proof the agent has taken the prompt, and
-        // therefore that it has written the session the chunk belongs to. That
-        // is the point from which the id is safe to persist — see the note in
-        // `turn_submit_prompt_for_tab`.
-        tab.has_meaningful_conversation = true;
-
-        match (&tab.turn, kind) {
+        let accepted = match (&tab.turn, kind) {
             (TurnState::Submitted(_), _) => {
                 let TurnState::Submitted(prompt) =
                     std::mem::replace(&mut tab.turn, TurnState::Idle)
@@ -180,7 +193,13 @@ impl App {
             (TurnState::Surfaced { .. }, _) => false,
             // Chunks while Idle or while cancellation is draining are stale.
             (TurnState::Idle | TurnState::Cancelling { .. }, _) => false,
+        };
+        if accepted {
+            // Rejected late chunks must not make a replacement session
+            // resumable.
+            tab.has_meaningful_conversation = true;
         }
+        accepted
     }
 
     fn validate_and_stage_terminal_action_proposal(
@@ -399,12 +418,66 @@ impl App {
     /// 2. A direct proposal already surfaced — release the UI gate.
     /// 3. `Submitted` with no chunks — model returned nothing.
     /// 4. `Streaming` with a buffer — commit it as assistant text.
+    pub(super) fn turn_close_terminal_event(&mut self, session_id: &str) {
+        let Some((target_tab, session_is_current)) =
+            self.terminal_event_tab_for_session(session_id)
+        else {
+            tracing::debug!(
+                target: "acp",
+                session_id,
+                "ignoring turn end for an unbound session"
+            );
+            return;
+        };
+
+        let cancelling_prompt_id =
+            self.tab_sessions
+                .get(&target_tab)
+                .and_then(|tab| match &tab.turn {
+                    TurnState::Cancelling { prompt_id } => Some(*prompt_id),
+                    _ => None,
+                });
+        if let Some(prompt_id) = cancelling_prompt_id {
+            let tab = self.tab_mut(&target_tab);
+            if !tab.active_prompt_matches_session(prompt_id, session_id) {
+                tracing::debug!(
+                    target: "acp",
+                    session_id,
+                    prompt_id,
+                    "ignoring turn end that does not own the cancellation barrier"
+                );
+                return;
+            }
+            // AgentMessageEnd proves that this exact prompt reached a terminal
+            // producer boundary. Only the still-current session may make the
+            // tab resumable; an old retired session may release the barrier
+            // but cannot bless its replacement.
+            if session_is_current {
+                tab.has_meaningful_conversation = true;
+            }
+            tab.finish_active_prompt(prompt_id);
+            tab.turn = TurnState::Idle;
+            tab.scroll_to_bottom();
+            self.project_tab_state(&target_tab);
+            return;
+        }
+
+        if !session_is_current {
+            return;
+        }
+        if let Some(summary) = self.session_completion_latency_summary(session_id) {
+            self.push_execution_info(summary);
+        }
+        self.turn_close(session_id);
+        self.tab_mut(&target_tab).scroll_to_bottom();
+    }
+
     pub fn turn_close(&mut self, session_id: &str) {
         if self.session_tab(session_id).turn.is_cancelling() {
-            // The prompt may complete normally just before its cancel signal
-            // is observed. AgentMessageEnd is still a valid producer
-            // quiescence boundary for that cancelled turn.
-            self.session_tab_mut(session_id).turn = TurnState::Idle;
+            // Cancellation barriers require exact terminal-session routing.
+            // Production AgentMessageEnd events enter through
+            // turn_close_terminal_event, which can distinguish a current
+            // binding from a retired session.
             return;
         }
 
@@ -420,6 +493,9 @@ impl App {
                 );
                 self.turn_clear_agent_activity(session_id);
                 let tab = self.session_tab_mut(session_id);
+                if let Some(prompt_id) = tab.turn.prompt_id() {
+                    tab.finish_active_prompt(prompt_id);
+                }
                 tab.messages.clear();
                 tab.reveal_chars = 0;
                 tab.turn = TurnState::Idle;
@@ -562,6 +638,7 @@ impl App {
             });
         }
         tab.scroll_to_bottom();
+        tab.finish_active_prompt(prompt.id);
         tab.turn = TurnState::Surfaced {
             prompt,
             outcome: TurnOutcome::Empty,
@@ -628,6 +705,7 @@ impl App {
     /// distinguish.
     fn turn_release_end_pending_logged(&mut self, session_id: &str, via: &str) {
         let tab = self.session_tab_mut(session_id);
+        let mut completed_prompt_id = None;
         if let TurnState::Surfaced {
             end_pending,
             prompt,
@@ -639,7 +717,11 @@ impl App {
                 let prompt_id = prompt.id;
                 let submitted_at = prompt.submitted_at_unix_s;
                 prompt_timing_log(prompt_id, submitted_at, "prompt_complete", via);
+                completed_prompt_id = Some(prompt_id);
             }
+        }
+        if let Some(prompt_id) = completed_prompt_id {
+            tab.finish_active_prompt(prompt_id);
         }
     }
 
@@ -774,29 +856,28 @@ impl App {
     }
 
     pub(super) fn request_turn_cancel_for_tab(&mut self, target_tab: &str) {
-        let (session_id, prompt_id) = self
-            .tab_sessions
-            .get(target_tab)
-            .map(|tab| {
-                (
-                    tab.session_id.clone(),
-                    tab.turn.prompt().map(|prompt| prompt.id),
-                )
-            })
-            .unwrap_or((None, None));
-        if let Some(prompt_id) = prompt_id {
-            let _ = self.cancel_tx.send(CancelRequest {
-                tab_id: target_tab.to_string(),
-                prompt_id,
-                session_id,
-            });
-        }
         self.turn_cancel_for_tab(target_tab);
     }
 
     /// Cancel the in-flight turn owned by a tab. Pane lifecycle cleanup uses
     /// this before a lazily-created ACP session necessarily has an ID.
     pub(super) fn turn_cancel_for_tab(&mut self, target_tab: &str) {
+        let Some(tab) = self.tab_sessions.get(target_tab) else {
+            return;
+        };
+        if let TurnState::Cancelling { prompt_id } = &tab.turn {
+            tab.cancel_active_prompt(*prompt_id);
+        }
+        if self
+            .tab_sessions
+            .get(target_tab)
+            .is_some_and(|tab| tab.turn.is_cancelling())
+        {
+            let tab = self.tab_mut(target_tab);
+            tab.permission.clear();
+            tab.user_input.clear();
+            return;
+        }
         let cancelled_prompt_id = self.tab_sessions.get(target_tab).and_then(|tab| {
             if tab.turn.is_in_flight() {
                 tab.turn.prompt().map(|prompt| prompt.id)
@@ -804,6 +885,11 @@ impl App {
                 None
             }
         });
+        if let Some(prompt_id) = cancelled_prompt_id {
+            if let Some(tab) = self.tab_sessions.get(target_tab) {
+                tab.cancel_active_prompt(prompt_id);
+            }
+        }
         let direct_proposal_id = self
             .tab_sessions
             .get(target_tab)
@@ -916,10 +1002,12 @@ impl App {
         tab.clear_streaming_thought();
         // Cancel pending session-MCP clarification responders. The user's
         // next prompt draft lives in `input` and is intentionally preserved.
+        tab.permission.clear();
         tab.user_input.clear();
         tab.turn = if let Some(prompt_id) = cancelled_prompt_id {
             TurnState::Cancelling { prompt_id }
         } else {
+            tab.active_prompt_cancellation = None;
             TurnState::Idle
         };
         tab.pending_terminal_action_proposal = None;
@@ -937,52 +1025,63 @@ impl App {
         self.recompute_chip_override(target_tab);
     }
 
-    pub(super) fn settle_prompt_cancellation(
-        &mut self,
-        target_tab: &str,
-        prompt_id: u64,
-        session_id: Option<&str>,
-    ) {
-        if let Some(tab) = self.tab_sessions.get_mut(target_tab) {
-            if matches!(
+    pub(super) fn settle_prompt_cancellation(&mut self, prompt_id: u64, started: bool) {
+        let target_tab = self.tab_sessions.iter().find_map(|(tab_id, tab)| {
+            matches!(
                 tab.turn,
                 TurnState::Cancelling {
                     prompt_id: cancelling_prompt_id
                 } if cancelling_prompt_id == prompt_id
-            ) {
-                tab.turn = TurnState::Idle;
-                return;
-            }
-        }
-
-        let current_tab = if let Some(session_id) = session_id {
-            self.session_to_tab.get(session_id).cloned()
-        } else {
-            // Prompt IDs are process-wide unique. A pre-dispatch cancellation
-            // has no ACP session yet, so this is the stable identity when its
-            // tab was renamed before the queued prompt was consumed.
-            self.tab_sessions.iter().find_map(|(tab_id, tab)| {
-                matches!(
-                    tab.turn,
-                    TurnState::Cancelling {
-                        prompt_id: cancelling_prompt_id
-                    } if cancelling_prompt_id == prompt_id
-                )
-                .then(|| tab_id.clone())
-            })
-        };
-        let Some(current_tab) = current_tab else {
+            )
+            .then(|| tab_id.clone())
+        });
+        let Some(target_tab) = target_tab else {
             return;
         };
-        if let Some(tab) = self.tab_sessions.get_mut(&current_tab) {
-            if matches!(
-                tab.turn,
-                TurnState::Cancelling {
-                    prompt_id: cancelling_prompt_id
-                } if cancelling_prompt_id == prompt_id
-            ) {
+        {
+            let tab = self.tab_mut(&target_tab);
+            let started_on_current_session = started
+                && tab
+                    .active_prompt_cancellation
+                    .as_ref()
+                    .and_then(|active| active.session_id.as_deref())
+                    .is_some_and(|prompt_session_id| {
+                        tab.session_id.as_deref() == Some(prompt_session_id)
+                    });
+            if started_on_current_session {
+                tab.has_meaningful_conversation = true;
+            }
+            tab.finish_active_prompt(prompt_id);
+            tab.turn = TurnState::Idle;
+        }
+        self.project_tab_state(&target_tab);
+    }
+
+    pub(super) fn settle_retired_transport_prompts(&mut self) {
+        let tab_ids = self.tab_sessions.keys().cloned().collect::<Vec<_>>();
+        for tab_id in &tab_ids {
+            if self
+                .tab_sessions
+                .get(tab_id)
+                .is_some_and(|tab| tab.turn.is_in_flight())
+            {
+                self.turn_cancel_for_tab(tab_id);
+            }
+        }
+        for tab_id in &tab_ids {
+            let prompt_id = self
+                .tab_sessions
+                .get(tab_id)
+                .and_then(|tab| match &tab.turn {
+                    TurnState::Cancelling { prompt_id } => Some(*prompt_id),
+                    _ => None,
+                });
+            if let Some(prompt_id) = prompt_id {
+                let tab = self.tab_mut(tab_id);
+                tab.finish_active_prompt(prompt_id);
                 tab.turn = TurnState::Idle;
             }
+            self.project_tab_state(tab_id);
         }
     }
 
@@ -1166,6 +1265,7 @@ impl App {
     /// `prompt_complete` log used by the eager path.
     fn turn_release_end_pending(&mut self, session_id: &str) {
         let tab = self.session_tab_mut(session_id);
+        let mut completed_prompt_id = None;
         if let TurnState::Surfaced {
             end_pending,
             prompt,
@@ -1177,7 +1277,11 @@ impl App {
                 let prompt_id = prompt.id;
                 let submitted_at = prompt.submitted_at_unix_s;
                 prompt_timing_log(prompt_id, submitted_at, "prompt_complete", "via=end_only");
+                completed_prompt_id = Some(prompt_id);
             }
+        }
+        if let Some(prompt_id) = completed_prompt_id {
+            tab.finish_active_prompt(prompt_id);
         }
     }
 }

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -179,7 +179,7 @@ impl App {
             }
             (TurnState::Surfaced { .. }, _) => false,
             // Chunks while Idle or while cancellation is draining are stale.
-            (TurnState::Idle | TurnState::Cancelling, _) => false,
+            (TurnState::Idle | TurnState::Cancelling { .. }, _) => false,
         }
     }
 
@@ -208,7 +208,7 @@ impl App {
                     "a card is already showing for this turn".to_string(),
                 );
             }
-            TurnState::Idle | TurnState::Cancelling => {
+            TurnState::Idle | TurnState::Cancelling { .. } => {
                 return DirectProposalEvaluation::Stale(
                     "no turn is in flight for this session".to_string(),
                 );
@@ -401,6 +401,9 @@ impl App {
     /// 4. `Streaming` with a buffer — commit it as assistant text.
     pub fn turn_close(&mut self, session_id: &str) {
         if self.session_tab(session_id).turn.is_cancelling() {
+            // The prompt may complete normally just before its cancel signal
+            // is observed. AgentMessageEnd is still a valid producer
+            // quiescence boundary for that cancelled turn.
             self.session_tab_mut(session_id).turn = TurnState::Idle;
             return;
         }
@@ -794,10 +797,13 @@ impl App {
     /// Cancel the in-flight turn owned by a tab. Pane lifecycle cleanup uses
     /// this before a lazily-created ACP session necessarily has an ID.
     pub(super) fn turn_cancel_for_tab(&mut self, target_tab: &str) {
-        let cancellation_pending = self
-            .tab_sessions
-            .get(target_tab)
-            .is_some_and(|tab| tab.turn.is_in_flight());
+        let cancelled_prompt_id = self.tab_sessions.get(target_tab).and_then(|tab| {
+            if tab.turn.is_in_flight() {
+                tab.turn.prompt().map(|prompt| prompt.id)
+            } else {
+                None
+            }
+        });
         let direct_proposal_id = self
             .tab_sessions
             .get(target_tab)
@@ -911,8 +917,8 @@ impl App {
         // Cancel pending session-MCP clarification responders. The user's
         // next prompt draft lives in `input` and is intentionally preserved.
         tab.user_input.clear();
-        tab.turn = if cancellation_pending {
-            TurnState::Cancelling
+        tab.turn = if let Some(prompt_id) = cancelled_prompt_id {
+            TurnState::Cancelling { prompt_id }
         } else {
             TurnState::Idle
         };
@@ -929,6 +935,42 @@ impl App {
         // state; release whatever the helper had pinned. C++ falls back to
         // source-of-agent driven rendering.
         self.recompute_chip_override(target_tab);
+    }
+
+    pub(super) fn settle_prompt_cancellation(
+        &mut self,
+        target_tab: &str,
+        prompt_id: u64,
+        session_id: Option<&str>,
+    ) {
+        if let Some(tab) = self.tab_sessions.get_mut(target_tab) {
+            if matches!(
+                tab.turn,
+                TurnState::Cancelling {
+                    prompt_id: cancelling_prompt_id
+                } if cancelling_prompt_id == prompt_id
+            ) {
+                tab.turn = TurnState::Idle;
+                return;
+            }
+        }
+
+        let Some(current_tab) = session_id
+            .and_then(|id| self.session_to_tab.get(id))
+            .cloned()
+        else {
+            return;
+        };
+        if let Some(tab) = self.tab_sessions.get_mut(&current_tab) {
+            if matches!(
+                tab.turn,
+                TurnState::Cancelling {
+                    prompt_id: cancelling_prompt_id
+                } if cancelling_prompt_id == prompt_id
+            ) {
+                tab.turn = TurnState::Idle;
+            }
+        }
     }
 
     // ── Internal surface helpers (shared between eager and end-of-turn). ──

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -908,6 +908,8 @@ impl App {
         tab.rec_scroll.reset();
         tab.activity_frame = 0;
         tab.clear_streaming_thought();
+        // Cancel pending session-MCP clarification responders. The user's
+        // next prompt draft lives in `input` and is intentionally preserved.
         tab.user_input.clear();
         tab.turn = if cancellation_pending {
             TurnState::Cancelling

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -178,8 +178,8 @@ impl App {
                 true
             }
             (TurnState::Surfaced { .. }, _) => false,
-            // Chunks while Idle: shouldn't happen; defensive drop.
-            (TurnState::Idle, _) => false,
+            // Chunks while Idle or while cancellation is draining are stale.
+            (TurnState::Idle | TurnState::Cancelling, _) => false,
         }
     }
 
@@ -208,7 +208,7 @@ impl App {
                     "a card is already showing for this turn".to_string(),
                 );
             }
-            TurnState::Idle => {
+            TurnState::Idle | TurnState::Cancelling => {
                 return DirectProposalEvaluation::Stale(
                     "no turn is in flight for this session".to_string(),
                 );
@@ -400,6 +400,11 @@ impl App {
     /// 3. `Submitted` with no chunks — model returned nothing.
     /// 4. `Streaming` with a buffer — commit it as assistant text.
     pub fn turn_close(&mut self, session_id: &str) {
+        if self.session_tab(session_id).turn.is_cancelling() {
+            self.session_tab_mut(session_id).turn = TurnState::Idle;
+            return;
+        }
+
         // (1) Stale-autofix discard.
         let current_gen = self.session_tab(session_id).autofix.generation;
         if let Some(gen) = self.session_tab(session_id).turn.autofix_generation() {
@@ -766,9 +771,34 @@ impl App {
         self.turn_cancel_for_tab(&target_tab);
     }
 
+    pub(super) fn request_turn_cancel_for_tab(&mut self, target_tab: &str) {
+        let (session_id, prompt_id) = self
+            .tab_sessions
+            .get(target_tab)
+            .map(|tab| {
+                (
+                    tab.session_id.clone(),
+                    tab.turn.prompt().map(|prompt| prompt.id),
+                )
+            })
+            .unwrap_or((None, None));
+        if let Some(prompt_id) = prompt_id {
+            let _ = self.cancel_tx.send(CancelRequest {
+                tab_id: target_tab.to_string(),
+                prompt_id,
+                session_id,
+            });
+        }
+        self.turn_cancel_for_tab(target_tab);
+    }
+
     /// Cancel the in-flight turn owned by a tab. Pane lifecycle cleanup uses
     /// this before a lazily-created ACP session necessarily has an ID.
     pub(super) fn turn_cancel_for_tab(&mut self, target_tab: &str) {
+        let cancellation_pending = self
+            .tab_sessions
+            .get(target_tab)
+            .is_some_and(|tab| tab.turn.is_in_flight());
         let direct_proposal_id = self
             .tab_sessions
             .get(target_tab)
@@ -880,7 +910,11 @@ impl App {
         tab.activity_frame = 0;
         tab.clear_streaming_thought();
         tab.user_input.clear();
-        tab.turn = TurnState::Idle;
+        tab.turn = if cancellation_pending {
+            TurnState::Cancelling
+        } else {
+            TurnState::Idle
+        };
         tab.pending_terminal_action_proposal = None;
         tab.active_direct_proposal_id = None;
         if let Some(proposal_id) = direct_proposal_id.as_deref() {

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -763,12 +763,11 @@ impl App {
         self.recompute_chip_override(&target_tab);
     }
 
-    /// User pressed Esc — cancel the in-flight turn. Bumps
-    /// `autofix_generation` so any chunks that arrive after this point are
-    /// dropped by the stale-check in `turn_observe_chunk`.
+    /// Cancel the in-flight turn for a session and request cancellation from
+    /// the ACP client.
     pub fn turn_cancel(&mut self, session_id: &str) {
         let target_tab = self.tab_for_session(session_id);
-        self.turn_cancel_for_tab(&target_tab);
+        self.request_turn_cancel_for_tab(&target_tab);
     }
 
     pub(super) fn request_turn_cancel_for_tab(&mut self, target_tab: &str) {

--- a/tools/wta/src/app_turn.rs
+++ b/tools/wta/src/app_turn.rs
@@ -955,10 +955,23 @@ impl App {
             }
         }
 
-        let Some(current_tab) = session_id
-            .and_then(|id| self.session_to_tab.get(id))
-            .cloned()
-        else {
+        let current_tab = if let Some(session_id) = session_id {
+            self.session_to_tab.get(session_id).cloned()
+        } else {
+            // Prompt IDs are process-wide unique. A pre-dispatch cancellation
+            // has no ACP session yet, so this is the stable identity when its
+            // tab was renamed before the queued prompt was consumed.
+            self.tab_sessions.iter().find_map(|(tab_id, tab)| {
+                matches!(
+                    tab.turn,
+                    TurnState::Cancelling {
+                        prompt_id: cancelling_prompt_id
+                    } if cancelling_prompt_id == prompt_id
+                )
+                .then(|| tab_id.clone())
+            })
+        };
+        let Some(current_tab) = current_tab else {
             return;
         };
         if let Some(tab) = self.tab_sessions.get_mut(&current_tab) {

--- a/tools/wta/src/autofix_tests.rs
+++ b/tools/wta/src/autofix_tests.rs
@@ -273,7 +273,7 @@ fn closing_source_pane_cancels_pending_autofix() {
     app.handle_event(closed_event_without_tab(pane));
 
     let tab = app.tab_mut(tab);
-    assert!(tab.turn.is_idle());
+    assert!(tab.turn.is_cancelling());
     assert!(tab.autofix.pane_id.is_none());
     assert!(matches!(tab.autofix.bar_snapshot, AutofixBarSnapshot::Idle));
     assert_eq!(tab.autofix.generation, generation.wrapping_add(1));

--- a/tools/wta/src/helper/runtime.rs
+++ b/tools/wta/src/helper/runtime.rs
@@ -600,9 +600,6 @@ async fn run_acp_app(
 
             let shell_mgr_for_recs = Arc::clone(&shell_mgr);
 
-            // Cancel channel for Ctrl+C handling: App produces, ACP client
-            // task consumes (one listener task inside the ACP client loop).
-            let (cancel_tx, cancel_rx) = tokio::sync::mpsc::unbounded_channel();
             // /new channel: App emits a NewSessionForTab, the ACP client
             // drops the cached SessionId for that tab and re-issues
             // new_session(). The resulting SessionAttached event flows
@@ -631,8 +628,8 @@ async fn run_acp_app(
             // reset_tab_session channel: App emits a DropSessionRequest when
             // WT tells us to release a tab's binding (Ctrl+C×2 hide path).
             // ACP client removes the SessionId from tab_to_session and
-            // closes the session after cancelling any in-flight prompt; the
-            // next prompt on that tab lazily creates a fresh session.
+            // asks master to close it; App has already cancelled any active
+            // prompt through the prompt-scoped token.
             let (drop_session_tx, drop_session_rx) = tokio::sync::mpsc::unbounded_channel();
             // tab-drag rename channel: App emits a RenameSessionRequest when
             // WT mints a new stable tab id for an existing tab (cross-window
@@ -775,7 +772,6 @@ async fn run_acp_app(
                 spawn_agent_lifecycle_forwarder(restart_rx, event_tx.clone());
                 drop((
                     prompt_rx,
-                    cancel_rx,
                     new_session_rx,
                     load_session_rx,
                     drop_session_rx,
@@ -812,7 +808,6 @@ async fn run_acp_app(
                         yolo_state_for_client,
                         event_tx_for_pipe.clone(),
                         prompt_rx,
-                        cancel_rx,
                         new_session_rx,
                         load_session_rx,
                         drop_session_rx,
@@ -896,7 +891,7 @@ async fn run_acp_app(
             ));
 
             let autofix_enabled = !config.no_autofix;
-            let mut app_state = app::App::new(prompt_tx, recommendation_tx, permission_tx, cancel_tx, new_session_tx, load_session_tx, drop_session_tx, rename_session_tx, restart_tx, master_ext_tx, debug_capture_enabled, wt_connected, autofix_enabled, Arc::clone(&shell_mgr), Arc::clone(&yolo_state));
+            let mut app_state = app::App::new(prompt_tx, recommendation_tx, permission_tx, new_session_tx, load_session_tx, drop_session_tx, rename_session_tx, restart_tx, master_ext_tx, debug_capture_enabled, wt_connected, autofix_enabled, Arc::clone(&shell_mgr), Arc::clone(&yolo_state));
             app_state.set_proposal_channels(Arc::clone(&proposal_channels));
             app_state.set_allowed_agent_ids(config.allowed_agent_ids.clone());
             // Seed the hot-updatable runtime agent config: the shared

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -108,15 +108,22 @@ fn is_redundant_startup_model_error(identity: &PromptUsageIdentity, error: &acp:
         && error.code == acp::ErrorCode::MethodNotFound
 }
 
-/// User-initiated cancel of an in-flight prompt. The App emits one of
-/// these on Ctrl+C; the ACP client task fires `session/cancel` to the
-/// agent and signals the per-prompt oneshot so the local task drops
-/// out of `conn.prompt().await` immediately even if the agent is slow
-/// or doesn't honor cancel.
+/// User-initiated cancel of an in-flight prompt. Tab and prompt identity form
+/// the local precondition: a delayed cancel must never stop a newer turn that
+/// happens to reuse the same ACP session.
 #[derive(Debug, Clone)]
 pub struct CancelRequest {
-    pub session_id: String,
+    pub tab_id: String,
+    pub prompt_id: u64,
+    pub session_id: Option<String>,
 }
+
+struct PromptCancelEntry {
+    prompt_id: u64,
+    signal: tokio::sync::oneshot::Sender<()>,
+}
+
+type SharedPromptCancelRegistry = Arc<std::sync::Mutex<HashMap<String, PromptCancelEntry>>>;
 
 /// User-initiated request to spin up a fresh ACP session for a given tab,
 /// dropping the previous session's history. Emitted by the `/new` slash
@@ -3404,8 +3411,7 @@ pub async fn run_acp_client_over_pipe(
     let template_memo = TemplateMemo::default();
     let in_flight_tabs: Arc<std::sync::Mutex<HashSet<String>>> =
         Arc::new(std::sync::Mutex::new(HashSet::new()));
-    let cancel_signals: Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<()>>>> =
-        Arc::new(std::sync::Mutex::new(HashMap::new()));
+    let cancel_signals = Arc::new(std::sync::Mutex::new(HashMap::new()));
     let mut prompt_tasks: Vec<tokio::task::JoinHandle<()>> = Vec::new();
 
     let conn = Arc::new(conn);
@@ -4148,7 +4154,7 @@ fn dispatch_load_session(
     req: LoadSessionForTab,
     conn: &conn::ClientLink,
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
-    cancel_signals: &Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<()>>>>,
+    cancel_signals: &SharedPromptCancelRegistry,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
     client_state: Arc<ClientState>,
     inject_pane_meta: bool,
@@ -4187,9 +4193,8 @@ fn dispatch_load_session(
         };
 
         if let Some(ref old) = old_sid {
-            let old_str = old.to_string();
-            if let Some(sig) = cancel_signals.lock().unwrap().remove(&old_str) {
-                let _ = sig.send(());
+            if let Some(entry) = cancel_signals.lock().unwrap().remove(&req.tab_id) {
+                let _ = entry.signal.send(());
             }
             if let Err(e) = conn
                 .cancel(acp::schema::v1::CancelNotification::new(old.clone()))
@@ -4402,7 +4407,7 @@ fn dispatch_new_session(
     conn: &conn::ClientLink,
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
     template_memo: &TemplateMemo,
-    cancel_signals: &Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<()>>>>,
+    cancel_signals: &SharedPromptCancelRegistry,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
     client_state: Arc<ClientState>,
     is_agent_pane: bool,
@@ -4438,8 +4443,8 @@ fn dispatch_new_session(
             crate::protocol::acp::model_select::forget_session(&old_str);
             client_state.native_yolo.forget_session(old);
             template_memo.forget(&old_str).await;
-            if let Some(sig) = cancel_signals.lock().unwrap().remove(&old_str) {
-                let _ = sig.send(());
+            if let Some(entry) = cancel_signals.lock().unwrap().remove(&req.tab_id) {
+                let _ = entry.signal.send(());
             }
             let _ = conn
                 .cancel(acp::schema::v1::CancelNotification::new(old.clone()))
@@ -4528,7 +4533,7 @@ async fn dispatch_drop_session(
     conn: &conn::ClientLink,
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
     template_memo: &TemplateMemo,
-    cancel_signals: &Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<()>>>>,
+    cancel_signals: &SharedPromptCancelRegistry,
     client_state: &ClientState,
 ) {
     tracing::info!(
@@ -4545,8 +4550,8 @@ async fn dispatch_drop_session(
         crate::protocol::acp::model_select::forget_session(&old_str);
         client_state.native_yolo.forget_session(&old);
         template_memo.forget(&old_str).await;
-        if let Some(sig) = cancel_signals.lock().unwrap().remove(&old_str) {
-            let _ = sig.send(());
+        if let Some(entry) = cancel_signals.lock().unwrap().remove(&req.tab_id) {
+            let _ = entry.signal.send(());
         }
     }
 
@@ -4586,22 +4591,43 @@ async fn dispatch_drop_session(
     });
 }
 
-/// Fire the local per-session cancel oneshot (the critical path that
-/// breaks a spawned prompt task out of `conn.prompt().await`) and
-/// best-effort notify the agent via `session/cancel`. Called by
-/// `run_acp_client_over_pipe`.
+/// Signal the exact tab/prompt pair and best-effort notify the agent via
+/// `session/cancel`. Stale requests are ignored rather than risking
+/// cancellation of a newer prompt on the same session.
 fn dispatch_cancel(
     req: CancelRequest,
     conn: &conn::ClientLink,
-    cancel_signals: &Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<()>>>>,
+    cancel_signals: &SharedPromptCancelRegistry,
 ) {
-    let session_id_str = req.session_id.clone();
-    tracing::info!(target: "acp_cancel", session_id = %session_id_str, "cancel requested");
+    tracing::info!(
+        target: "acp_cancel",
+        tab_id = %req.tab_id,
+        prompt_id = req.prompt_id,
+        session_id = ?req.session_id,
+        "cancel requested"
+    );
     // Local oneshot first — it's the critical path for breaking the
     // spawned prompt task out of conn.prompt().
-    if let Some(sig) = cancel_signals.lock().unwrap().remove(&session_id_str) {
-        let _ = sig.send(());
-    }
+    let matched = {
+        let mut registry = cancel_signals.lock().unwrap();
+        match registry.get(&req.tab_id) {
+            Some(entry) if entry.prompt_id == req.prompt_id => registry.remove(&req.tab_id),
+            _ => None,
+        }
+    };
+    let Some(entry) = matched else {
+        tracing::info!(
+            target: "acp_cancel",
+            tab_id = %req.tab_id,
+            prompt_id = req.prompt_id,
+            "ignoring stale cancel request"
+        );
+        return;
+    };
+    let _ = entry.signal.send(());
+    let Some(session_id_str) = req.session_id else {
+        return;
+    };
     // Best-effort agent notification. Spawned so the loop stays
     // responsive even if the agent is slow to ack.
     let conn_for_cancel = conn.clone();
@@ -4662,11 +4688,11 @@ fn build_prompt_content(
 async fn stop_prompt_tasks(
     prompt_tasks: &mut Vec<tokio::task::JoinHandle<()>>,
     in_flight_tabs: &Arc<std::sync::Mutex<HashSet<String>>>,
-    cancel_signals: &Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<()>>>>,
+    cancel_signals: &SharedPromptCancelRegistry,
 ) {
     let signals = std::mem::take(&mut *cancel_signals.lock().unwrap());
-    for (_, signal) in signals {
-        let _ = signal.send(());
+    for (_, entry) in signals {
+        let _ = entry.signal.send(());
     }
     for task in prompt_tasks.drain(..) {
         task.abort();
@@ -4682,7 +4708,7 @@ async fn complete_transport_shutdown(
     event_tx: &mpsc::UnboundedSender<AppEvent>,
     prompt_tasks: &mut Vec<tokio::task::JoinHandle<()>>,
     in_flight_tabs: &Arc<std::sync::Mutex<HashSet<String>>>,
-    cancel_signals: &Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<()>>>>,
+    cancel_signals: &SharedPromptCancelRegistry,
 ) -> AcpClientExit {
     stop_prompt_tasks(prompt_tasks, in_flight_tabs, cancel_signals).await;
     complete_transport_io_task(io_result, suppress_transport_error, event_tx)
@@ -4694,7 +4720,7 @@ fn dispatch_prompt(
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
     template_memo: &TemplateMemo,
     in_flight_tabs: &Arc<std::sync::Mutex<HashSet<String>>>,
-    cancel_signals: &Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<()>>>>,
+    cancel_signals: &SharedPromptCancelRegistry,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
     shell_mgr: &Arc<ShellManager>,
     prompt_timing: &Arc<PromptTimingState>,
@@ -4733,6 +4759,15 @@ fn dispatch_prompt(
     let prompt_usage_identity_task = prompt_usage_identity.clone();
     let proposal_channels_task = Arc::clone(proposal_channels);
     let tab_key_task = tab_key.clone();
+    let prompt_id = prompt.id;
+    let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
+    cancel_signals.lock().unwrap().insert(
+        tab_key.clone(),
+        PromptCancelEntry {
+            prompt_id,
+            signal: cancel_tx,
+        },
+    );
 
     Some(tokio::task::spawn_local(dispatch_prompt_body(
         prompt,
@@ -4747,6 +4782,7 @@ fn dispatch_prompt(
         client_task,
         prompt_usage_identity_task,
         tab_key_task,
+        cancel_rx,
         wt_connected,
         is_agent_pane,
         proposal_commands_supported,
@@ -4764,13 +4800,14 @@ async fn dispatch_prompt_body(
     tab_to_session_task: Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
     template_memo: TemplateMemo,
     in_flight_tabs_task: Arc<std::sync::Mutex<HashSet<String>>>,
-    cancel_signals_task: Arc<std::sync::Mutex<HashMap<String, tokio::sync::oneshot::Sender<()>>>>,
+    cancel_signals_task: SharedPromptCancelRegistry,
     event_tx_task: mpsc::UnboundedSender<AppEvent>,
     shell_mgr_task: Arc<ShellManager>,
     prompt_timing_task: Arc<PromptTimingState>,
     client_task: WtaClient,
     prompt_usage_identity_task: PromptUsageIdentity,
     tab_key_task: String,
+    cancel_rx: tokio::sync::oneshot::Receiver<()>,
     wt_connected: bool,
     is_agent_pane: bool,
     proposal_commands_supported: bool,
@@ -5098,15 +5135,6 @@ async fn dispatch_prompt_body(
             &text,
         );
     }
-    // Register a cancel oneshot for this prompt. The cancel
-    // listener picks the sender out by session_id and signals it
-    // when the user presses Ctrl+C.
-    let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
-    cancel_signals_task
-        .lock()
-        .unwrap()
-        .insert(prompt_session_id_str.clone(), cancel_tx);
-
     // Build the prompt content: the (templated) text block, followed by any
     // images pasted via Alt+V as ACP `ContentBlock::Image` blocks. Images ride
     // through master → agent CLI verbatim; the agent only receives them if it
@@ -5187,9 +5215,37 @@ async fn dispatch_prompt_body(
         },
     );
     tokio::pin!(prompt_fut);
+    let prompt_started = std::cell::Cell::new(false);
+    let tracked_prompt_fut = std::future::poll_fn(|cx| {
+        prompt_started.set(true);
+        std::future::Future::poll(prompt_fut.as_mut(), cx)
+    });
+    tokio::pin!(tracked_prompt_fut);
 
     let completed_successfully = tokio::select! {
-        result = &mut prompt_fut => {
+        biased;
+        _ = cancel_rx => {
+            // Cancellation is a request, not the terminal boundary. If the
+            // prompt has already started, keep its future alive until the
+            // agent resolves it; if cancellation arrived during preparation,
+            // the biased branch wins before the prompt future is first polled.
+            tracing::info!(target: "acp_cancel", session_id = %prompt_session_id_str, "waiting for cancelled prompt to quiesce");
+            let _ = prompt_timing_task.complete(
+                &prompt_session_id_str,
+                false,
+                Some("cancelled"),
+            );
+            if prompt_started.get() {
+                drop(tracked_prompt_fut);
+                let _ = (&mut prompt_fut).await;
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+            }
+            let _ = event_tx_task.send(AppEvent::AgentMessageEnd {
+                session_id: prompt_session_id_str.clone(),
+            });
+            false
+        }
+        result = &mut tracked_prompt_fut => {
             match result {
                 Ok(None) => {
                     let yolo_safety_error = final_yolo_safety_error.lock().unwrap().take();
@@ -5255,24 +5311,7 @@ async fn dispatch_prompt_body(
                 }
             }
         }
-        _ = cancel_rx => {
-            // The user cancelled. Synthesize an AgentMessageEnd
-            // so the App's session_tab cleanup runs even if the
-            // agent never resolves the prompt future.
-            tracing::info!(target: "acp_cancel", session_id = %prompt_session_id_str, "prompt task aborted by cancel");
-            let _ = prompt_timing_task.complete(
-                &prompt_session_id_str,
-                false,
-                Some("cancelled"),
-            );
-            let _ = event_tx_task.send(AppEvent::AgentMessageEnd {
-                session_id: prompt_session_id_str.clone(),
-            });
-            false
-        }
     };
-    // Drop the in-flight prompt future eagerly when cancelled to
-    // release the connection slot for the next prompt on this tab.
     drop(prompt_fut);
 
     if completed_successfully {
@@ -5302,10 +5341,15 @@ async fn dispatch_prompt_body(
         }
     }
 
-    cancel_signals_task
-        .lock()
-        .unwrap()
-        .remove(&prompt_session_id_str);
+    {
+        let mut registry = cancel_signals_task.lock().unwrap();
+        if registry
+            .get(&tab_key_task)
+            .is_some_and(|entry| entry.prompt_id == prompt.id)
+        {
+            registry.remove(&tab_key_task);
+        }
+    }
     in_flight_tabs_task.lock().unwrap().remove(&tab_key_task);
 }
 
@@ -5318,8 +5362,8 @@ mod tests {
         inject_wta_pane_meta, is_redundant_startup_model_error, post_login_authenticate_error,
         session_mcp_tool_from_title, stop_prompt_tasks, timeout_result_failure_fields,
         tool_call_exit_code, tool_call_kind_label, tool_call_location_hint, tool_call_target,
-        AcpClientExit, ClientState, PromptTimingState, PromptUsageIdentity, SessionMcpTool,
-        SoftStopReason, WtaClient,
+        AcpClientExit, ClientState, PromptCancelEntry, PromptTimingState, PromptUsageIdentity,
+        SessionMcpTool, SoftStopReason, WtaClient,
     };
     use crate::app_contracts::AppEvent;
     use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
@@ -5395,8 +5439,11 @@ mod tests {
         let in_flight_tabs = Arc::new(Mutex::new(HashSet::from(["tab-1".to_string()])));
         let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
         let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
-            "session-1".to_string(),
-            cancel_tx,
+            "tab-1".to_string(),
+            PromptCancelEntry {
+                prompt_id: 1,
+                signal: cancel_tx,
+            },
         )])));
         let intentional_shutdown = std::sync::atomic::AtomicBool::new(false);
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
@@ -5476,8 +5523,11 @@ mod tests {
             let in_flight_tabs = Arc::new(Mutex::new(HashSet::from(["tab-1".to_string()])));
             let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
             let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
-                "session-1".to_string(),
-                cancel_tx,
+                "tab-1".to_string(),
+                PromptCancelEntry {
+                    prompt_id: 1,
+                    signal: cancel_tx,
+                },
             )])));
 
             stop_prompt_tasks(&mut tasks, &in_flight_tabs, &cancel_signals).await;

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -118,17 +118,53 @@ pub struct CancelRequest {
     pub session_id: Option<String>,
 }
 
-struct PromptCancelEntry {
-    prompt_id: u64,
-    signal: tokio::sync::oneshot::Sender<()>,
+enum PromptCancelEntry {
+    Pending {
+        prompt_id: u64,
+    },
+    Registered {
+        prompt_id: u64,
+        signal: tokio::sync::oneshot::Sender<()>,
+    },
+}
+
+impl PromptCancelEntry {
+    fn prompt_id(&self) -> u64 {
+        match self {
+            Self::Pending { prompt_id } | Self::Registered { prompt_id, .. } => *prompt_id,
+        }
+    }
+
+    fn signal_registered(self) {
+        if let Self::Registered { signal, .. } = self {
+            let _ = signal.send(());
+        }
+    }
 }
 
 type SharedPromptCancelRegistry = Arc<std::sync::Mutex<HashMap<String, PromptCancelEntry>>>;
+type SharedInFlightPrompts = Arc<std::sync::Mutex<HashMap<String, u64>>>;
+
+fn take_registered_cancel(
+    registry: &mut HashMap<String, PromptCancelEntry>,
+    tab_id: &str,
+) -> Option<tokio::sync::oneshot::Sender<()>> {
+    if !matches!(
+        registry.get(tab_id),
+        Some(PromptCancelEntry::Registered { .. })
+    ) {
+        return None;
+    }
+    match registry.remove(tab_id) {
+        Some(PromptCancelEntry::Registered { signal, .. }) => Some(signal),
+        _ => unreachable!("registered cancel entry changed while locked"),
+    }
+}
 
 struct PromptDispatchCleanup {
     tab_key: String,
     prompt_id: u64,
-    in_flight_tabs: Arc<std::sync::Mutex<HashSet<String>>>,
+    in_flight_tabs: SharedInFlightPrompts,
     cancel_signals: SharedPromptCancelRegistry,
 }
 
@@ -136,14 +172,33 @@ impl Drop for PromptDispatchCleanup {
     fn drop(&mut self) {
         {
             let mut registry = self.cancel_signals.lock().unwrap();
-            if registry
+            let matching_key = if registry
                 .get(&self.tab_key)
-                .is_some_and(|entry| entry.prompt_id == self.prompt_id)
+                .is_some_and(|entry| entry.prompt_id() == self.prompt_id)
             {
-                registry.remove(&self.tab_key);
+                Some(self.tab_key.clone())
+            } else {
+                registry.iter().find_map(|(key, entry)| {
+                    (entry.prompt_id() == self.prompt_id).then(|| key.clone())
+                })
+            };
+            if let Some(key) = matching_key {
+                registry.remove(&key);
             }
         }
-        self.in_flight_tabs.lock().unwrap().remove(&self.tab_key);
+        {
+            let mut in_flight = self.in_flight_tabs.lock().unwrap();
+            let matching_key = if in_flight.get(&self.tab_key) == Some(&self.prompt_id) {
+                Some(self.tab_key.clone())
+            } else {
+                in_flight
+                    .iter()
+                    .find_map(|(key, id)| (*id == self.prompt_id).then(|| key.clone()))
+            };
+            if let Some(key) = matching_key {
+                in_flight.remove(&key);
+            }
+        }
     }
 }
 
@@ -3431,8 +3486,7 @@ pub async fn run_acp_client_over_pipe(
     }
 
     let template_memo = TemplateMemo::default();
-    let in_flight_tabs: Arc<std::sync::Mutex<HashSet<String>>> =
-        Arc::new(std::sync::Mutex::new(HashSet::new()));
+    let in_flight_tabs: SharedInFlightPrompts = Arc::new(std::sync::Mutex::new(HashMap::new()));
     let cancel_signals = Arc::new(std::sync::Mutex::new(HashMap::new()));
     let mut prompt_tasks: Vec<tokio::task::JoinHandle<()>> = Vec::new();
 
@@ -3578,7 +3632,13 @@ pub async fn run_acp_client_over_pipe(
                 ).await;
             }
             Some(req) = rename_session_rx.recv() => {
-                dispatch_rename_session(req, &tab_to_session).await;
+                dispatch_rename_session(
+                    req,
+                    &conn,
+                    &tab_to_session,
+                    &cancel_signals,
+                    &in_flight_tabs,
+                ).await;
             }
             Some(prompt) = prompt_rx.recv() => {
                 prompt_tasks.retain(|task| !task.is_finished());
@@ -4214,10 +4274,12 @@ fn dispatch_load_session(
             g.remove(&req.tab_id)
         };
 
+        if let Some(signal) =
+            take_registered_cancel(&mut cancel_signals.lock().unwrap(), &req.tab_id)
+        {
+            let _ = signal.send(());
+        }
         if let Some(ref old) = old_sid {
-            if let Some(entry) = cancel_signals.lock().unwrap().remove(&req.tab_id) {
-                let _ = entry.signal.send(());
-            }
             if let Err(e) = conn
                 .cancel(acp::schema::v1::CancelNotification::new(old.clone()))
                 .await
@@ -4460,14 +4522,16 @@ fn dispatch_new_session(
             g.remove(&req.tab_id)
         };
 
+        if let Some(signal) =
+            take_registered_cancel(&mut cancel_signals.lock().unwrap(), &req.tab_id)
+        {
+            let _ = signal.send(());
+        }
         if let Some(ref old) = old_sid {
             let old_str = old.to_string();
             crate::protocol::acp::model_select::forget_session(&old_str);
             client_state.native_yolo.forget_session(old);
             template_memo.forget(&old_str).await;
-            if let Some(entry) = cancel_signals.lock().unwrap().remove(&req.tab_id) {
-                let _ = entry.signal.send(());
-            }
             let _ = conn
                 .cancel(acp::schema::v1::CancelNotification::new(old.clone()))
                 .await;
@@ -4567,14 +4631,14 @@ async fn dispatch_drop_session(
         let mut sessions = tab_to_session.lock().await;
         sessions.remove(&req.tab_id)
     };
+    if let Some(signal) = take_registered_cancel(&mut cancel_signals.lock().unwrap(), &req.tab_id) {
+        let _ = signal.send(());
+    }
     if let Some(old) = old_sid {
         let old_str = old.to_string();
         crate::protocol::acp::model_select::forget_session(&old_str);
         client_state.native_yolo.forget_session(&old);
         template_memo.forget(&old_str).await;
-        if let Some(entry) = cancel_signals.lock().unwrap().remove(&req.tab_id) {
-            let _ = entry.signal.send(());
-        }
     }
 
     if !req.notify_master {
@@ -4613,9 +4677,10 @@ async fn dispatch_drop_session(
     });
 }
 
-/// Signal the exact tab/prompt pair and best-effort notify the agent via
-/// `session/cancel`. Stale requests are ignored rather than risking
-/// cancellation of a newer prompt on the same session.
+/// Signal the exact registered tab/prompt pair and best-effort notify the
+/// agent via `session/cancel`. A cancel that wins the main channel select
+/// before prompt registration is latched without notifying the agent because
+/// that prompt has not started. Stale requests never replace newer state.
 fn dispatch_cancel(
     req: CancelRequest,
     conn: &conn::ClientLink,
@@ -4628,25 +4693,53 @@ fn dispatch_cancel(
         session_id = ?req.session_id,
         "cancel requested"
     );
-    // Local oneshot first — it's the critical path for breaking the
-    // spawned prompt task out of conn.prompt().
-    let matched = {
+    // Local oneshot first — it's the critical path for breaking the spawned
+    // prompt task out of conn.prompt(). With no entry, preserve this exact
+    // identity for dispatch_prompt to consume.
+    let signal = {
         let mut registry = cancel_signals.lock().unwrap();
         match registry.get(&req.tab_id) {
-            Some(entry) if entry.prompt_id == req.prompt_id => registry.remove(&req.tab_id),
-            _ => None,
+            Some(entry) if entry.prompt_id() != req.prompt_id => {
+                tracing::info!(
+                    target: "acp_cancel",
+                    tab_id = %req.tab_id,
+                    prompt_id = req.prompt_id,
+                    registered_prompt_id = entry.prompt_id(),
+                    "ignoring stale cancel request"
+                );
+                return;
+            }
+            Some(PromptCancelEntry::Pending { .. }) => {
+                tracing::debug!(
+                    target: "acp_cancel",
+                    tab_id = %req.tab_id,
+                    prompt_id = req.prompt_id,
+                    "matching cancel is already pending prompt registration"
+                );
+                return;
+            }
+            Some(PromptCancelEntry::Registered { .. }) => match registry.remove(&req.tab_id) {
+                Some(PromptCancelEntry::Registered { signal, .. }) => signal,
+                _ => unreachable!("matching registered cancel entry changed while locked"),
+            },
+            None => {
+                registry.insert(
+                    req.tab_id.clone(),
+                    PromptCancelEntry::Pending {
+                        prompt_id: req.prompt_id,
+                    },
+                );
+                tracing::debug!(
+                    target: "acp_cancel",
+                    tab_id = %req.tab_id,
+                    prompt_id = req.prompt_id,
+                    "latched cancel pending prompt registration"
+                );
+                return;
+            }
         }
     };
-    let Some(entry) = matched else {
-        tracing::info!(
-            target: "acp_cancel",
-            tab_id = %req.tab_id,
-            prompt_id = req.prompt_id,
-            "ignoring stale cancel request"
-        );
-        return;
-    };
-    let _ = entry.signal.send(());
+    let _ = signal.send(());
     let Some(session_id_str) = req.session_id else {
         return;
     };
@@ -4671,22 +4764,110 @@ fn dispatch_cancel(
 /// the shared map. No-op when `old_tab_id` is absent.
 async fn dispatch_rename_session(
     req: RenameSessionRequest,
+    conn: &conn::ClientLink,
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
+    cancel_signals: &SharedPromptCancelRegistry,
+    in_flight_tabs: &SharedInFlightPrompts,
 ) {
     rename_helper_owner_tab_id(&req.old_tab_id, &req.new_tab_id);
-    let mut g = tab_to_session.lock().await;
-    let old_existed = if let Some(sid) = g.remove(&req.old_tab_id) {
-        g.insert(req.new_tab_id.clone(), sid);
-        true
-    } else {
-        false
+    let rekeyed_session = {
+        let mut sessions = tab_to_session.lock().await;
+        if let Some(session_id) = sessions.remove(&req.old_tab_id) {
+            sessions.insert(req.new_tab_id.clone(), session_id.clone());
+            Some(session_id)
+        } else {
+            None
+        }
     };
+    let (cancel_rekeyed, cancel_merged, signals) = {
+        let mut registry = cancel_signals.lock().unwrap();
+        if let Some(entry) = registry.remove(&req.old_tab_id) {
+            match registry.remove(&req.new_tab_id) {
+                None => {
+                    registry.insert(req.new_tab_id.clone(), entry);
+                    (true, false, Vec::new())
+                }
+                Some(destination) if entry.prompt_id() == destination.prompt_id() => {
+                    // A tab rename unifies aliases for the same prompt. Pending means
+                    // cancellation already won, so no Registered sender may be lost.
+                    match (entry, destination) {
+                        (
+                            PromptCancelEntry::Pending { prompt_id },
+                            PromptCancelEntry::Pending { .. },
+                        ) => {
+                            registry.insert(
+                                req.new_tab_id.clone(),
+                                PromptCancelEntry::Pending { prompt_id },
+                            );
+                            (true, false, Vec::new())
+                        }
+                        (old, new) => {
+                            let mut signals = Vec::new();
+                            if let PromptCancelEntry::Registered { signal, .. } = old {
+                                signals.push(signal);
+                            }
+                            if let PromptCancelEntry::Registered { signal, .. } = new {
+                                signals.push(signal);
+                            }
+                            (true, true, signals)
+                        }
+                    }
+                }
+                Some(destination) => {
+                    let (keep, discard) = if entry.prompt_id() > destination.prompt_id() {
+                        (entry, destination)
+                    } else {
+                        (destination, entry)
+                    };
+                    let signal = match discard {
+                        PromptCancelEntry::Registered { signal, .. } => Some(signal),
+                        PromptCancelEntry::Pending { .. } => None,
+                    };
+                    registry.insert(req.new_tab_id.clone(), keep);
+                    (true, false, signal.into_iter().collect())
+                }
+            }
+        } else {
+            (false, false, Vec::new())
+        }
+    };
+    for signal in signals {
+        let _ = signal.send(());
+    }
+    let in_flight_rekeyed = {
+        let mut in_flight = in_flight_tabs.lock().unwrap();
+        if let Some(prompt_id) = in_flight.remove(&req.old_tab_id) {
+            in_flight
+                .entry(req.new_tab_id.clone())
+                .and_modify(|destination_id| *destination_id = (*destination_id).max(prompt_id))
+                .or_insert(prompt_id);
+            true
+        } else {
+            false
+        }
+    };
+    if cancel_merged {
+        if let Some(session_id) = rekeyed_session.clone() {
+            let conn_for_cancel = conn.clone();
+            tokio::task::spawn_local(async move {
+                if let Err(e) = conn_for_cancel
+                    .cancel(acp::schema::v1::CancelNotification::new(session_id.clone()))
+                    .await
+                {
+                    tracing::warn!(target: "acp_cancel", session_id = %session_id, error = ?e, "session/cancel rpc failed after tab rename (likely unsupported)");
+                }
+            });
+        }
+    }
     tracing::info!(
         target: "acp_rename_session",
         old_tab_id = %req.old_tab_id,
         new_tab_id = %req.new_tab_id,
-        old_existed,
-        "tab_to_session rekeyed via drag"
+        session_rekeyed = rekeyed_session.is_some(),
+        cancel_rekeyed,
+        cancel_merged,
+        in_flight_rekeyed,
+        "prompt lifecycle state rekeyed via drag"
     );
 }
 
@@ -4709,12 +4890,12 @@ fn build_prompt_content(
 
 async fn stop_prompt_tasks(
     prompt_tasks: &mut Vec<tokio::task::JoinHandle<()>>,
-    in_flight_tabs: &Arc<std::sync::Mutex<HashSet<String>>>,
+    in_flight_tabs: &SharedInFlightPrompts,
     cancel_signals: &SharedPromptCancelRegistry,
 ) {
     let signals = std::mem::take(&mut *cancel_signals.lock().unwrap());
     for (_, entry) in signals {
-        let _ = entry.signal.send(());
+        entry.signal_registered();
     }
     for task in prompt_tasks.drain(..) {
         task.abort();
@@ -4729,7 +4910,7 @@ async fn complete_transport_shutdown(
     suppress_transport_error: &AtomicBool,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
     prompt_tasks: &mut Vec<tokio::task::JoinHandle<()>>,
-    in_flight_tabs: &Arc<std::sync::Mutex<HashSet<String>>>,
+    in_flight_tabs: &SharedInFlightPrompts,
     cancel_signals: &SharedPromptCancelRegistry,
 ) -> AcpClientExit {
     stop_prompt_tasks(prompt_tasks, in_flight_tabs, cancel_signals).await;
@@ -4741,7 +4922,7 @@ fn dispatch_prompt(
     conn: &conn::ClientLink,
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
     template_memo: &TemplateMemo,
-    in_flight_tabs: &Arc<std::sync::Mutex<HashSet<String>>>,
+    in_flight_tabs: &SharedInFlightPrompts,
     cancel_signals: &SharedPromptCancelRegistry,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
     shell_mgr: &Arc<ShellManager>,
@@ -4758,14 +4939,62 @@ fn dispatch_prompt(
         .as_ref()
         .and_then(|c| c.tab_id.clone())
         .unwrap_or_else(|| "0".to_string());
+    let prompt_id = prompt.id;
+
+    {
+        let mut registry = cancel_signals.lock().unwrap();
+        match registry.get(&tab_key) {
+            Some(PromptCancelEntry::Pending {
+                prompt_id: pending_id,
+            }) if *pending_id == prompt_id => {
+                registry.remove(&tab_key);
+                let _ = event_tx.send(AppEvent::PromptCancellationSettled {
+                    tab_id: tab_key,
+                    prompt_id,
+                    session_id: None,
+                });
+                return None;
+            }
+            Some(PromptCancelEntry::Pending {
+                prompt_id: pending_id,
+            }) if *pending_id < prompt_id => {
+                tracing::info!(
+                    target: "acp_cancel",
+                    tab_id = %tab_key,
+                    pending_prompt_id = *pending_id,
+                    prompt_id,
+                    "discarding stale pending cancellation before newer prompt"
+                );
+                registry.remove(&tab_key);
+            }
+            Some(PromptCancelEntry::Pending {
+                prompt_id: pending_id,
+            }) => {
+                tracing::info!(
+                    target: "acp_cancel",
+                    tab_id = %tab_key,
+                    pending_prompt_id = *pending_id,
+                    prompt_id,
+                    "discarding stale queued prompt while preserving newer pending cancellation"
+                );
+                return None;
+            }
+            _ => {}
+        }
+    }
 
     {
         let mut g = in_flight_tabs.lock().unwrap();
-        if !g.insert(tab_key.clone()) {
-            let _ = event_tx.send(AppEvent::AgentBusy {
-                tab_id: tab_key.clone(),
-            });
-            return None;
+        match g.entry(tab_key.clone()) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(prompt_id);
+            }
+            std::collections::hash_map::Entry::Occupied(_) => {
+                let _ = event_tx.send(AppEvent::AgentBusy {
+                    tab_id: tab_key.clone(),
+                });
+                return None;
+            }
         }
     }
 
@@ -4781,11 +5010,10 @@ fn dispatch_prompt(
     let prompt_usage_identity_task = prompt_usage_identity.clone();
     let proposal_channels_task = Arc::clone(proposal_channels);
     let tab_key_task = tab_key.clone();
-    let prompt_id = prompt.id;
     let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
     cancel_signals.lock().unwrap().insert(
         tab_key.clone(),
-        PromptCancelEntry {
+        PromptCancelEntry::Registered {
             prompt_id,
             signal: cancel_tx,
         },
@@ -4821,7 +5049,7 @@ async fn dispatch_prompt_body(
     conn_task: conn::ClientLink,
     tab_to_session_task: Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
     template_memo: TemplateMemo,
-    in_flight_tabs_task: Arc<std::sync::Mutex<HashSet<String>>>,
+    in_flight_tabs_task: SharedInFlightPrompts,
     cancel_signals_task: SharedPromptCancelRegistry,
     event_tx_task: mpsc::UnboundedSender<AppEvent>,
     shell_mgr_task: Arc<ShellManager>,
@@ -4835,6 +5063,7 @@ async fn dispatch_prompt_body(
     proposal_commands_supported: bool,
     proposal_channels: Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
 ) {
+    let prompt_id = prompt.id;
     let _cleanup = PromptDispatchCleanup {
         tab_key: tab_key_task.clone(),
         prompt_id: prompt.id,
@@ -5269,8 +5498,10 @@ async fn dispatch_prompt_body(
                 // compatibility drain here.
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             }
-            let _ = event_tx_task.send(AppEvent::AgentMessageEnd {
-                session_id: prompt_session_id_str.clone(),
+            let _ = event_tx_task.send(AppEvent::PromptCancellationSettled {
+                tab_id: tab_key_task.clone(),
+                prompt_id,
+                session_id: Some(prompt_session_id_str.clone()),
             });
             false
         }
@@ -5378,10 +5609,11 @@ mod tests {
         acp_error_detail, acp_result_failure_fields, bounded_tool_output_parts,
         claim_unexpected_transport_loss, complete_prompt_request, complete_transport_shutdown,
         inject_wta_pane_meta, is_redundant_startup_model_error, post_login_authenticate_error,
-        session_mcp_tool_from_title, stop_prompt_tasks, timeout_result_failure_fields,
-        tool_call_exit_code, tool_call_kind_label, tool_call_location_hint, tool_call_target,
-        AcpClientExit, ClientState, PromptCancelEntry, PromptDispatchCleanup, PromptTimingState,
-        PromptUsageIdentity, SessionMcpTool, SoftStopReason, WtaClient,
+        session_mcp_tool_from_title, stop_prompt_tasks, take_registered_cancel,
+        timeout_result_failure_fields, tool_call_exit_code, tool_call_kind_label,
+        tool_call_location_hint, tool_call_target, AcpClientExit, ClientState, PromptCancelEntry,
+        PromptDispatchCleanup, PromptTimingState, PromptUsageIdentity, SessionMcpTool,
+        SoftStopReason, WtaClient,
     };
     use crate::app_contracts::AppEvent;
     use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
@@ -5392,12 +5624,12 @@ mod tests {
 
     #[test]
     fn prompt_dispatch_cleanup_preserves_newer_cancel_entry() {
-        let in_flight_tabs = Arc::new(Mutex::new(HashSet::from(["tab".to_string()])));
+        let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("tab".to_string(), 1)])));
         let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
         let (newer_signal, mut newer_cancel) = tokio::sync::oneshot::channel();
         cancel_signals.lock().unwrap().insert(
             "tab".to_string(),
-            PromptCancelEntry {
+            PromptCancelEntry::Registered {
                 prompt_id: 2,
                 signal: newer_signal,
             },
@@ -5416,13 +5648,100 @@ mod tests {
                 .lock()
                 .unwrap()
                 .get("tab")
-                .map(|entry| entry.prompt_id),
+                .map(PromptCancelEntry::prompt_id),
             Some(2)
         );
         assert!(matches!(
             newer_cancel.try_recv(),
             Err(tokio::sync::oneshot::error::TryRecvError::Empty)
         ));
+    }
+
+    #[test]
+    fn prompt_dispatch_cleanup_finds_rekeyed_identity() {
+        let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("new-tab".to_string(), 7)])));
+        let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
+            "new-tab".to_string(),
+            PromptCancelEntry::Pending { prompt_id: 7 },
+        )])));
+
+        drop(PromptDispatchCleanup {
+            tab_key: "old-tab".to_string(),
+            prompt_id: 7,
+            in_flight_tabs: Arc::clone(&in_flight_tabs),
+            cancel_signals: Arc::clone(&cancel_signals),
+        });
+
+        assert!(in_flight_tabs.lock().unwrap().is_empty());
+        assert!(cancel_signals.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn prompt_dispatch_cleanup_does_not_remove_newer_rekeyed_identity() {
+        let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([
+            ("old-tab".to_string(), 8),
+            ("new-tab".to_string(), 7),
+        ])));
+        let cancel_signals = Arc::new(Mutex::new(HashMap::from([
+            (
+                "old-tab".to_string(),
+                PromptCancelEntry::Pending { prompt_id: 8 },
+            ),
+            (
+                "new-tab".to_string(),
+                PromptCancelEntry::Pending { prompt_id: 7 },
+            ),
+        ])));
+
+        drop(PromptDispatchCleanup {
+            tab_key: "old-tab".to_string(),
+            prompt_id: 7,
+            in_flight_tabs: Arc::clone(&in_flight_tabs),
+            cancel_signals: Arc::clone(&cancel_signals),
+        });
+
+        assert_eq!(
+            in_flight_tabs.lock().unwrap().get("old-tab").copied(),
+            Some(8)
+        );
+        assert!(!in_flight_tabs.lock().unwrap().contains_key("new-tab"));
+        assert_eq!(
+            cancel_signals
+                .lock()
+                .unwrap()
+                .get("old-tab")
+                .map(PromptCancelEntry::prompt_id),
+            Some(8)
+        );
+        assert!(!cancel_signals.lock().unwrap().contains_key("new-tab"));
+    }
+
+    #[test]
+    fn lifecycle_cancel_take_preserves_pending_and_signals_registered() {
+        let mut registry = HashMap::from([(
+            "tab".to_string(),
+            PromptCancelEntry::Pending { prompt_id: 4 },
+        )]);
+        assert!(take_registered_cancel(&mut registry, "tab").is_none());
+        assert_eq!(
+            registry.get("tab").map(PromptCancelEntry::prompt_id),
+            Some(4)
+        );
+
+        let (signal, mut cancelled) = tokio::sync::oneshot::channel();
+        registry.insert(
+            "tab".to_string(),
+            PromptCancelEntry::Registered {
+                prompt_id: 5,
+                signal,
+            },
+        );
+        take_registered_cancel(&mut registry, "tab")
+            .expect("registered entry must be removed")
+            .send(())
+            .expect("cancel receiver must remain live");
+        assert!(registry.is_empty());
+        assert_eq!(cancelled.try_recv(), Ok(()));
     }
 
     #[test]
@@ -5489,11 +5808,11 @@ mod tests {
         })];
         started_rx.await.expect("prompt task started");
 
-        let in_flight_tabs = Arc::new(Mutex::new(HashSet::from(["tab-1".to_string()])));
+        let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("tab-1".to_string(), 1)])));
         let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
         let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
             "tab-1".to_string(),
-            PromptCancelEntry {
+            PromptCancelEntry::Registered {
                 prompt_id: 1,
                 signal: cancel_tx,
             },
@@ -5533,7 +5852,7 @@ mod tests {
         let intentional_shutdown = std::sync::atomic::AtomicBool::new(true);
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         let mut prompt_tasks = Vec::new();
-        let in_flight_tabs = Arc::new(Mutex::new(HashSet::new()));
+        let in_flight_tabs = Arc::new(Mutex::new(HashMap::new()));
         let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
         let io_result = tokio::spawn(async {}).await;
 
@@ -5573,11 +5892,11 @@ mod tests {
             })];
             tokio::task::yield_now().await;
 
-            let in_flight_tabs = Arc::new(Mutex::new(HashSet::from(["tab-1".to_string()])));
+            let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("tab-1".to_string(), 1)])));
             let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
             let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
                 "tab-1".to_string(),
-                PromptCancelEntry {
+                PromptCancelEntry::Registered {
                     prompt_id: 1,
                     signal: cancel_tx,
                 },

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -14,6 +14,7 @@ use std::sync::{
 };
 use tokio::sync::mpsc;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use tokio_util::sync::CancellationToken;
 
 use crate::app_contracts::{AcpModelInfo, AppEvent, PermOption, PlanEntry, PlanEntryStatus};
 use crate::pane_context::PaneContext;
@@ -71,6 +72,7 @@ pub(crate) mod mock_agent_tests;
 #[derive(Debug, Clone)]
 pub struct PromptSubmission {
     pub id: u64,
+    cancellation: CancellationToken,
     pub text: String,
     pub pane_context: Option<PaneContext>,
     pub submitted_at_unix_s: f64,
@@ -108,104 +110,99 @@ fn is_redundant_startup_model_error(identity: &PromptUsageIdentity, error: &acp:
         && error.code == acp::ErrorCode::MethodNotFound
 }
 
-/// User-initiated cancel of an in-flight prompt. Tab and prompt identity form
-/// the local precondition: a delayed cancel must never stop a newer turn that
-/// happens to reuse the same ACP session.
-#[derive(Debug, Clone)]
-pub struct CancelRequest {
-    pub tab_id: String,
-    pub prompt_id: u64,
-    pub session_id: Option<String>,
-}
-
-enum PromptCancelEntry {
-    Pending {
-        prompt_id: u64,
-    },
-    Registered {
-        prompt_id: u64,
-        signal: tokio::sync::oneshot::Sender<()>,
-    },
-}
-
-impl PromptCancelEntry {
-    fn prompt_id(&self) -> u64 {
-        match self {
-            Self::Pending { prompt_id } | Self::Registered { prompt_id, .. } => *prompt_id,
-        }
-    }
-
-    fn signal_registered(self) {
-        if let Self::Registered { signal, .. } = self {
-            let _ = signal.send(());
-        }
-    }
-}
-
-type SharedPromptCancelRegistry = Arc<std::sync::Mutex<HashMap<String, PromptCancelEntry>>>;
 type SharedInFlightPrompts = Arc<std::sync::Mutex<HashMap<String, u64>>>;
+type SharedTabAliases = Arc<std::sync::Mutex<HashMap<String, String>>>;
+type SharedTabBindingGenerations = Arc<std::sync::Mutex<HashMap<String, u64>>>;
+type LifecycleTask = tokio::task::JoinHandle<()>;
 
-fn take_registered_cancel(
-    registry: &mut HashMap<String, PromptCancelEntry>,
+fn resolve_tab_alias_locked(aliases: &HashMap<String, String>, tab_id: &str) -> String {
+    let mut current = tab_id;
+    let mut visited = HashSet::new();
+    while visited.insert(current.to_string()) {
+        let Some(next) = aliases.get(current) else {
+            break;
+        };
+        current = next;
+    }
+    current.to_string()
+}
+
+fn resolve_tab_alias(aliases: &SharedTabAliases, tab_id: &str) -> String {
+    resolve_tab_alias_locked(&aliases.lock().unwrap(), tab_id)
+}
+
+fn begin_tab_binding_operation(
+    aliases: &SharedTabAliases,
+    generations: &SharedTabBindingGenerations,
     tab_id: &str,
-) -> Option<tokio::sync::oneshot::Sender<()>> {
-    if !matches!(
-        registry.get(tab_id),
-        Some(PromptCancelEntry::Registered { .. })
-    ) {
-        return None;
-    }
-    match registry.remove(tab_id) {
-        Some(PromptCancelEntry::Registered { signal, .. }) => Some(signal),
-        _ => unreachable!("registered cancel entry changed while locked"),
-    }
+) -> (String, u64) {
+    let tab_id = resolve_tab_alias(aliases, tab_id);
+    let mut generations = generations.lock().unwrap();
+    let generation = generations.entry(tab_id.clone()).or_default();
+    *generation = generation.wrapping_add(1);
+    (tab_id, *generation)
+}
+
+fn current_tab_binding_operation(
+    aliases: &SharedTabAliases,
+    generations: &SharedTabBindingGenerations,
+    tab_id: &str,
+    generation: u64,
+) -> Option<String> {
+    let tab_id = resolve_tab_alias(aliases, tab_id);
+    (generations.lock().unwrap().get(&tab_id) == Some(&generation)).then_some(tab_id)
+}
+
+fn invalidate_tab_binding(
+    aliases: &SharedTabAliases,
+    generations: &SharedTabBindingGenerations,
+    tab_id: &str,
+) -> String {
+    begin_tab_binding_operation(aliases, generations, tab_id).0
 }
 
 struct PromptDispatchCleanup {
     tab_key: String,
     prompt_id: u64,
     in_flight_tabs: SharedInFlightPrompts,
-    cancel_signals: SharedPromptCancelRegistry,
+    released: bool,
+}
+
+impl PromptDispatchCleanup {
+    fn release(&mut self) {
+        if self.released {
+            return;
+        }
+        self.released = true;
+        let mut in_flight = self.in_flight_tabs.lock().unwrap();
+        let matching_key = if in_flight.get(&self.tab_key) == Some(&self.prompt_id) {
+            Some(self.tab_key.clone())
+        } else {
+            in_flight
+                .iter()
+                .find_map(|(key, id)| (*id == self.prompt_id).then(|| key.clone()))
+        };
+        if let Some(key) = matching_key {
+            in_flight.remove(&key);
+        }
+    }
 }
 
 impl Drop for PromptDispatchCleanup {
     fn drop(&mut self) {
-        {
-            let mut registry = self.cancel_signals.lock().unwrap();
-            let matching_key = if registry
-                .get(&self.tab_key)
-                .is_some_and(|entry| entry.prompt_id() == self.prompt_id)
-            {
-                Some(self.tab_key.clone())
-            } else {
-                registry.iter().find_map(|(key, entry)| {
-                    (entry.prompt_id() == self.prompt_id).then(|| key.clone())
-                })
-            };
-            if let Some(key) = matching_key {
-                registry.remove(&key);
-            }
-        }
-        {
-            let mut in_flight = self.in_flight_tabs.lock().unwrap();
-            let matching_key = if in_flight.get(&self.tab_key) == Some(&self.prompt_id) {
-                Some(self.tab_key.clone())
-            } else {
-                in_flight
-                    .iter()
-                    .find_map(|(key, id)| (*id == self.prompt_id).then(|| key.clone()))
-            };
-            if let Some(key) = matching_key {
-                in_flight.remove(&key);
-            }
-        }
+        self.release();
     }
+}
+
+struct PromptTask {
+    cancellation: CancellationToken,
+    handle: tokio::task::JoinHandle<()>,
 }
 
 /// User-initiated request to spin up a fresh ACP session for a given tab,
 /// dropping the previous session's history. Emitted by the `/new` slash
 /// command. The ACP client task removes the old SessionId from its
-/// per-tab cache, cancels any active turn, and calls `new_session(cwd)`.
+/// per-tab cache and calls `new_session(cwd)`.
 /// Once the replacement is bound, master retires the old session's routing,
 /// live-registry row, and session-scoped capabilities. The resulting
 /// [`AppEvent::SessionAttached`] then propagates back to the UI to
@@ -255,22 +252,73 @@ struct ClientTransportGuard {
     conn: conn::ClientLink,
     suppress_transport_error: Arc<AtomicBool>,
     event_tx: mpsc::UnboundedSender<AppEvent>,
+    io_task: Option<tokio::task::JoinHandle<()>>,
+    retirement_published: bool,
+}
+
+impl ClientTransportGuard {
+    fn io_task_mut(&mut self) -> &mut tokio::task::JoinHandle<()> {
+        self.io_task.as_mut().expect("ACP I/O task is present")
+    }
+
+    async fn reap_io_task(&mut self) {
+        if let Some(mut task) = self.io_task.take() {
+            if tokio::time::timeout(std::time::Duration::from_secs(1), &mut task)
+                .await
+                .is_err()
+            {
+                task.abort();
+                let _ = task.await;
+            }
+        }
+    }
+
+    fn io_task_completed(&mut self) {
+        self.io_task.take();
+    }
+
+    fn publish_retired(&mut self, report_master_disconnect: bool) {
+        if self.retirement_published {
+            return;
+        }
+        self.retirement_published = true;
+        if report_master_disconnect {
+            let _ = self.event_tx.send(AppEvent::MasterDisconnected);
+        }
+        let _ = self.event_tx.send(AppEvent::AgentTransportRetired);
+    }
 }
 
 impl Drop for ClientTransportGuard {
     fn drop(&mut self) {
-        // A master can disappear while a setup request is in flight. In that
-        // race the request fails and unwinds this guard before the separately
-        // scheduled I/O task reports EOF. Claim and report the already-tripped
-        // transport latch here so the retained helper still reconnects.
+        // Setup can fail after the transport exists but before the main loop
+        // owns prompt/lifecycle tasks. Finish retiring that transport
+        // asynchronously so App never waits forever for AgentTransportRetired.
         let report_master_disconnect = claim_unexpected_transport_loss(
             self.conn.transport_ended(),
             &self.suppress_transport_error,
         );
         self.conn.shutdown();
-        if report_master_disconnect {
-            let _ = self.event_tx.send(AppEvent::MasterDisconnected);
-        }
+        let io_task = self.io_task.take();
+        let event_tx = self.event_tx.clone();
+        let publish_retired = !self.retirement_published;
+        tokio::task::spawn_local(async move {
+            if let Some(mut task) = io_task {
+                if tokio::time::timeout(std::time::Duration::from_secs(1), &mut task)
+                    .await
+                    .is_err()
+                {
+                    task.abort();
+                    let _ = task.await;
+                }
+            }
+            if publish_retired {
+                if report_master_disconnect {
+                    let _ = event_tx.send(AppEvent::MasterDisconnected);
+                }
+                let _ = event_tx.send(AppEvent::AgentTransportRetired);
+            }
+        });
     }
 }
 
@@ -285,8 +333,7 @@ fn claim_unexpected_transport_loss(
 fn complete_transport_io_task(
     io_result: std::result::Result<(), tokio::task::JoinError>,
     suppress_transport_error: &AtomicBool,
-    event_tx: &mpsc::UnboundedSender<AppEvent>,
-) -> AcpClientExit {
+) -> (AcpClientExit, bool) {
     if let Err(error) = io_result {
         tracing::warn!(
             target: "helper",
@@ -294,10 +341,10 @@ fn complete_transport_io_task(
             "ACP I/O task to master failed"
         );
     }
-    if claim_unexpected_transport_loss(true, suppress_transport_error) {
-        let _ = event_tx.send(AppEvent::MasterDisconnected);
-    }
-    AcpClientExit::ChannelsClosed
+    (
+        AcpClientExit::ChannelsClosed,
+        claim_unexpected_transport_loss(true, suppress_transport_error),
+    )
 }
 
 #[derive(Debug, Clone)]
@@ -466,6 +513,7 @@ impl PromptSubmission {
         static NEXT_PROMPT_ID: AtomicU64 = AtomicU64::new(1);
         Self {
             id: NEXT_PROMPT_ID.fetch_add(1, Ordering::Relaxed),
+            cancellation: CancellationToken::new(),
             text,
             pane_context,
             submitted_at_unix_s: now_unix_s(),
@@ -501,6 +549,10 @@ impl PromptSubmission {
 
     pub fn agent_id(&self) -> &str {
         &self.agent_id
+    }
+
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancellation.clone()
     }
 
     /// Attach pasted images (Alt+V) to a human-entered prompt.
@@ -2587,22 +2639,33 @@ async fn apply_native_yolo_checked(
 async fn handle_load_failure(
     old_sid: Option<&acp::schema::v1::SessionId>,
     tab_id: String,
+    binding_generation: u64,
     cwd: std::path::PathBuf,
     conn: conn::ClientLink,
     tab_to_session: Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
+    tab_binding_generations: SharedTabBindingGenerations,
     event_tx: mpsc::UnboundedSender<AppEvent>,
     error_message: String,
     _proposal_channels: Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
     proposal_mcp_enabled: bool,
     client_state: Arc<ClientState>,
+    tab_aliases: SharedTabAliases,
 ) {
+    let Some(current_tab_id) = current_tab_binding_operation(
+        &tab_aliases,
+        &tab_binding_generations,
+        &tab_id,
+        binding_generation,
+    ) else {
+        return;
+    };
     if let Some(old) = old_sid {
         // Mid-life session management load failure path: restore prior binding.
         let mut g = tab_to_session.lock().await;
-        g.insert(tab_id.clone(), old.clone());
+        g.insert(current_tab_id.clone(), old.clone());
         drop(g);
         let _ = event_tx.send(AppEvent::TabError {
-            tab_id,
+            tab_id: current_tab_id,
             message: error_message,
         });
         return;
@@ -2613,7 +2676,7 @@ async fn handle_load_failure(
     // was set). Create a fresh `new_session` so prompts have
     // somewhere to land.
     let _ = event_tx.send(AppEvent::TabError {
-        tab_id: tab_id.clone(),
+        tab_id: current_tab_id.clone(),
         message: format!("{} Starting a fresh session instead.", error_message),
     });
     let mut new_req = acp::schema::v1::NewSessionRequest::new(cwd);
@@ -2632,6 +2695,14 @@ async fn handle_load_failure(
                 );
                 return;
             }
+            let Some(current_tab_id) = current_tab_binding_operation(
+                &tab_aliases,
+                &tab_binding_generations,
+                &tab_id,
+                binding_generation,
+            ) else {
+                return;
+            };
             let new_sid = resp.session_id.clone();
             tracing::info!(
                 target: "acp_load_session",
@@ -2639,10 +2710,10 @@ async fn handle_load_failure(
                 fallback_session_id = %new_sid,
                 "boot-time load fell back to new_session successfully"
             );
-            {
-                let mut g = tab_to_session.lock().await;
-                g.insert(tab_id.clone(), new_sid.clone());
-            }
+            tab_to_session
+                .lock()
+                .await
+                .insert(current_tab_id.clone(), new_sid.clone());
             // Index the fallback session as an agent-pane origin so
             // session management view can show it as a Historical row on next cold start
             // (it is now a real, persistent session).
@@ -2657,8 +2728,9 @@ async fn handle_load_failure(
                 crate::protocol::acp::model_select::models_from_new_session(&resp);
             record_native_yolo(&resp, &client_state);
             let _ = event_tx.send(AppEvent::SessionAttached {
-                tab_id,
+                tab_id: current_tab_id,
                 session_id: new_sid.to_string(),
+                prompt_id: None,
                 available_models,
                 current_model_id,
             });
@@ -2670,14 +2742,22 @@ async fn handle_load_failure(
             );
         }
         Err(e) => {
+            let Some(current_tab_id) = current_tab_binding_operation(
+                &tab_aliases,
+                &tab_binding_generations,
+                &tab_id,
+                binding_generation,
+            ) else {
+                return;
+            };
             tracing::error!(
                 target: "acp_load_session",
-                tab = %tab_id,
+                tab = %current_tab_id,
                 error = ?e,
                 "boot-time load fallback new_session failed"
             );
             let _ = event_tx.send(AppEvent::TabError {
-                tab_id,
+                tab_id: current_tab_id,
                 message: format!("Fallback new_session also failed: {}", e),
             });
         }
@@ -2703,7 +2783,6 @@ pub async fn run_acp_client_over_pipe(
     yolo_state: crate::app_contracts::SharedYoloState,
     event_tx: mpsc::UnboundedSender<AppEvent>,
     mut prompt_rx: mpsc::UnboundedReceiver<PromptSubmission>,
-    mut cancel_rx: mpsc::UnboundedReceiver<CancelRequest>,
     mut new_session_rx: mpsc::UnboundedReceiver<NewSessionForTab>,
     mut load_session_rx: mpsc::UnboundedReceiver<LoadSessionForTab>,
     mut drop_session_rx: mpsc::UnboundedReceiver<DropSessionRequest>,
@@ -2788,6 +2867,7 @@ pub async fn run_acp_client_over_pipe(
                             attempt + 1,
                             e
                         );
+                        let _ = event_tx.send(AppEvent::AgentTransportRetired);
                         return Err(anyhow::Error::new(AgentFailure::HandshakeFailed {
                             stage: HandshakeStage::PipeConnect,
                             detail,
@@ -2938,13 +3018,8 @@ pub async fn run_acp_client_over_pipe(
     startup_probe.log("ACP client connection created (over pipe)");
 
     let intentional_shutdown = Arc::new(AtomicBool::new(false));
-    let _transport_guard = ClientTransportGuard {
-        conn: conn.clone(),
-        suppress_transport_error: Arc::clone(&intentional_shutdown),
-        event_tx: event_tx.clone(),
-    };
     let io_probe = startup_probe.clone();
-    let mut io_task = tokio::task::spawn_local(async move {
+    let io_task = tokio::task::spawn_local(async move {
         io_probe.log("ACP handle_io task started (over pipe)");
         // The I/O loop only ends when the pipe to wta-master is gone. Crucially,
         // a *killed* master resolves this as **Ok(())** (clean EOF on the pipe),
@@ -2963,6 +3038,13 @@ pub async fn run_acp_client_over_pipe(
             }
         }
     });
+    let mut transport_guard = ClientTransportGuard {
+        conn: conn.clone(),
+        suppress_transport_error: Arc::clone(&intentional_shutdown),
+        event_tx: event_tx.clone(),
+        io_task: Some(io_task),
+        retirement_published: false,
+    };
 
     // Initialize — same as the child-process path. We use a 60s timeout
     // here because the first helper to connect to a fresh master may
@@ -3487,8 +3569,11 @@ pub async fn run_acp_client_over_pipe(
 
     let template_memo = TemplateMemo::default();
     let in_flight_tabs: SharedInFlightPrompts = Arc::new(std::sync::Mutex::new(HashMap::new()));
-    let cancel_signals = Arc::new(std::sync::Mutex::new(HashMap::new()));
-    let mut prompt_tasks: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+    let tab_aliases: SharedTabAliases = Arc::new(std::sync::Mutex::new(HashMap::new()));
+    let tab_binding_generations: SharedTabBindingGenerations =
+        Arc::new(std::sync::Mutex::new(HashMap::new()));
+    let mut prompt_tasks: Vec<PromptTask> = Vec::new();
+    let mut lifecycle_tasks: Vec<LifecycleTask> = Vec::new();
 
     let conn = Arc::new(conn);
 
@@ -3514,7 +3599,8 @@ pub async fn run_acp_client_over_pipe(
             }
             Some(event) = session_hook_rx.recv() => {
                 let conn_for_hook = conn.clone();
-                tokio::task::spawn_local(async move {
+                lifecycle_tasks.retain(|task| !task.is_finished());
+                lifecycle_tasks.push(tokio::task::spawn_local(async move {
                     let req = crate::session_registry::build_session_hook_request(&event);
                     match conn_for_hook.ext_method(req).await {
                         Ok(response) => tracing::debug!(
@@ -3530,16 +3616,17 @@ pub async fn run_acp_client_over_pipe(
                             "session_hook ext-request to master failed"
                         ),
                     }
-                });
+                }));
             }
             Some(req) = master_ext_rx.recv() => {
-                dispatch_master_ext_request(
+                lifecycle_tasks.retain(|task| !task.is_finished());
+                lifecycle_tasks.push(dispatch_master_ext_request(
                     req,
                     &conn,
                     &event_tx,
                     &tab_to_session,
                     Arc::clone(&state),
-                );
+                ));
             }
             Some(req) = restart_rx.recv() => {
                 match req {
@@ -3561,42 +3648,72 @@ pub async fn run_acp_client_over_pipe(
                             agent_id = %request.agent_id,
                             "ending helper ACP connection for Agent rebind"
                         );
-                        stop_prompt_tasks(
+                        intentional_shutdown.store(true, Ordering::Release);
+                        close_client_receivers(
+                            &mut prompt_rx,
+                            &mut new_session_rx,
+                            &mut load_session_rx,
+                            &mut drop_session_rx,
+                            &mut rename_session_rx,
+                            &mut restart_rx,
+                            &mut session_hook_rx,
+                            &mut master_ext_rx,
+                        );
+                        finalize_client_transport(
+                            &mut transport_guard,
+                            false,
                             &mut prompt_tasks,
                             &in_flight_tabs,
-                            &cancel_signals,
+                            &mut lifecycle_tasks,
                         )
                         .await;
-                        intentional_shutdown.store(true, Ordering::Release);
-                        conn.shutdown();
-                        let _ = (&mut io_task).await;
                         return Ok(AcpClientExit::RebindAgent(request));
                     }
                 }
             }
-            io_result = &mut io_task => {
-                let exit = complete_transport_shutdown(
-                    io_result,
-                    &intentional_shutdown,
-                    &event_tx,
+            io_result = transport_guard.io_task_mut() => {
+                transport_guard.io_task_completed();
+                close_client_receivers(
+                    &mut prompt_rx,
+                    &mut new_session_rx,
+                    &mut load_session_rx,
+                    &mut drop_session_rx,
+                    &mut rename_session_rx,
+                    &mut restart_rx,
+                    &mut session_hook_rx,
+                    &mut master_ext_rx,
+                );
+                let (exit, report_master_disconnect) =
+                    complete_transport_io_task(io_result, &intentional_shutdown);
+                finalize_client_transport(
+                    &mut transport_guard,
+                    report_master_disconnect,
                     &mut prompt_tasks,
                     &in_flight_tabs,
-                    &cancel_signals,
+                    &mut lifecycle_tasks,
                 )
                 .await;
                 startup_probe.log("run_acp_client_over_pipe transport ended");
                 return Ok(exit);
             }
-            Some(req) = cancel_rx.recv() => {
-                dispatch_cancel(req, &conn, &cancel_signals);
+            Some(req) = rename_session_rx.recv() => {
+                dispatch_rename_session_with_aliases(
+                    req,
+                    &tab_to_session,
+                    &in_flight_tabs,
+                    &tab_aliases,
+                    &tab_binding_generations,
+                ).await;
             }
             Some(req) = new_session_rx.recv() => {
-                dispatch_new_session(
+                lifecycle_tasks.retain(|task| !task.is_finished());
+                lifecycle_tasks.push(dispatch_new_session_with_aliases(
                     req,
                     &conn,
                     &tab_to_session,
+                    &tab_aliases,
+                    &tab_binding_generations,
                     &template_memo,
-                    &cancel_signals,
                     &event_tx,
                     Arc::clone(&state),
                     is_agent_pane,
@@ -3604,14 +3721,16 @@ pub async fn run_acp_client_over_pipe(
                     "HelperPipeNewSessionForTab",
                     &proposal_channels,
                     proposal_commands_supported,
-                );
+                ));
             }
             Some(req) = load_session_rx.recv() => {
-                dispatch_load_session(
+                lifecycle_tasks.retain(|task| !task.is_finished());
+                lifecycle_tasks.push(dispatch_load_session_with_aliases(
                     req,
                     &conn,
                     &tab_to_session,
-                    &cancel_signals,
+                    &tab_aliases,
+                    &tab_binding_generations,
                     &event_tx,
                     Arc::clone(&state),
                     true,
@@ -3619,36 +3738,32 @@ pub async fn run_acp_client_over_pipe(
                     std::time::Duration::from_secs(60),
                     &proposal_channels,
                     proposal_commands_supported,
-                );
+                ));
             }
             Some(req) = drop_session_rx.recv() => {
-                dispatch_drop_session(
+                if let Some(task) = dispatch_drop_session_with_aliases(
                     req,
                     &conn,
                     &tab_to_session,
+                    &tab_aliases,
+                    &tab_binding_generations,
                     &template_memo,
-                    &cancel_signals,
                     &state,
-                ).await;
-            }
-            Some(req) = rename_session_rx.recv() => {
-                dispatch_rename_session(
-                    req,
-                    &conn,
-                    &tab_to_session,
-                    &cancel_signals,
-                    &in_flight_tabs,
-                ).await;
+                ).await {
+                    lifecycle_tasks.retain(|task| !task.is_finished());
+                    lifecycle_tasks.push(task);
+                }
             }
             Some(prompt) = prompt_rx.recv() => {
-                prompt_tasks.retain(|task| !task.is_finished());
-                if let Some(task) = dispatch_prompt(
+                prompt_tasks.retain(|task| !task.handle.is_finished());
+                if let Some(task) = dispatch_prompt_with_aliases(
                     prompt,
                     &conn,
                     &tab_to_session,
                     &template_memo,
                     &in_flight_tabs,
-                    &cancel_signals,
+                    &tab_aliases,
+                    &tab_binding_generations,
                     &event_tx,
                     &shell_mgr,
                     &prompt_timing,
@@ -3666,10 +3781,25 @@ pub async fn run_acp_client_over_pipe(
         }
     }
 
-    stop_prompt_tasks(&mut prompt_tasks, &in_flight_tabs, &cancel_signals).await;
     intentional_shutdown.store(true, Ordering::Release);
-    conn.shutdown();
-    let _ = io_task.await;
+    close_client_receivers(
+        &mut prompt_rx,
+        &mut new_session_rx,
+        &mut load_session_rx,
+        &mut drop_session_rx,
+        &mut rename_session_rx,
+        &mut restart_rx,
+        &mut session_hook_rx,
+        &mut master_ext_rx,
+    );
+    finalize_client_transport(
+        &mut transport_guard,
+        false,
+        &mut prompt_tasks,
+        &in_flight_tabs,
+        &mut lifecycle_tasks,
+    )
+    .await;
     startup_probe.log("run_acp_client_over_pipe loop ended");
     Ok(AcpClientExit::ChannelsClosed)
 }
@@ -3685,7 +3815,7 @@ fn dispatch_master_ext_request(
     event_tx: &mpsc::UnboundedSender<AppEvent>,
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
     client_state: Arc<ClientState>,
-) {
+) -> LifecycleTask {
     dispatch_master_ext_request_with_yolo_timeout(
         req,
         conn,
@@ -3693,7 +3823,7 @@ fn dispatch_master_ext_request(
         tab_to_session,
         client_state,
         super::native_yolo::NATIVE_YOLO_RPC_TIMEOUT,
-    );
+    )
 }
 
 fn dispatch_master_ext_request_with_yolo_timeout(
@@ -3703,7 +3833,7 @@ fn dispatch_master_ext_request_with_yolo_timeout(
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
     client_state: Arc<ClientState>,
     yolo_reconcile_timeout: std::time::Duration,
-) {
+) -> LifecycleTask {
     let reserved_yolo_operations = match &req {
         MasterExtRequest::ReconcileSessionYolo { sessions, .. } => sessions
             .iter()
@@ -4215,12 +4345,12 @@ fn dispatch_master_ext_request_with_yolo_timeout(
                 }
             }
         }
-    });
+    })
 }
 
 /// Resume a historical agent session for a tab via ACP `session/load`
-/// (the session-management Enter resume path). Cancels and
-/// drops any existing binding, calls `load_session` under a timeout, and
+/// (the session-management Enter resume path). Drops any existing binding,
+/// calls `load_session` under a timeout, and
 /// on success rebinds the tab and emits `SessionAttached` +
 /// `TabSystemMessage`. Called by `run_acp_client_over_pipe`.
 ///
@@ -4232,11 +4362,12 @@ fn dispatch_master_ext_request_with_yolo_timeout(
 /// `timeout` bounds the `session/load` call (60s in production; injectable
 /// for tests).
 #[allow(clippy::too_many_arguments)]
-fn dispatch_load_session(
+fn dispatch_load_session_with_aliases(
     req: LoadSessionForTab,
     conn: &conn::ClientLink,
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
-    cancel_signals: &SharedPromptCancelRegistry,
+    tab_aliases: &SharedTabAliases,
+    tab_binding_generations: &SharedTabBindingGenerations,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
     client_state: Arc<ClientState>,
     inject_pane_meta: bool,
@@ -4244,7 +4375,7 @@ fn dispatch_load_session(
     timeout: std::time::Duration,
     proposal_channels: &Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
     proposal_mcp_enabled: bool,
-) {
+) -> LifecycleTask {
     tracing::info!(
         target: "acp_load_session",
         tab = %req.tab_id,
@@ -4256,9 +4387,12 @@ fn dispatch_load_session(
     );
     let conn = conn.clone();
     let tab_to_session = Arc::clone(tab_to_session);
-    let cancel_signals = Arc::clone(cancel_signals);
+    let tab_aliases = Arc::clone(tab_aliases);
+    let tab_binding_generations = Arc::clone(tab_binding_generations);
     let event_tx = event_tx.clone();
     let proposal_channels = Arc::clone(proposal_channels);
+    let (request_tab_id, binding_generation) =
+        begin_tab_binding_operation(&tab_aliases, &tab_binding_generations, &req.tab_id);
     tokio::task::spawn_local(async move {
         let cwd = req
             .cwd
@@ -4266,33 +4400,13 @@ fn dispatch_load_session(
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
 
-        // If the target tab already holds a session, cancel any in-flight
-        // prompt for it and drop the binding — we're about to replace it
-        // with the loaded one. Mirrors the new_session prelude.
-        let old_sid: Option<acp::schema::v1::SessionId> = {
+        // If the target tab already holds a session, drop the binding — the
+        // App has synchronously cancelled that prompt's scoped token before
+        // requesting this lifecycle transition.
+        let old_sid = {
             let mut g = tab_to_session.lock().await;
-            g.remove(&req.tab_id)
+            g.remove(&request_tab_id)
         };
-
-        if let Some(signal) =
-            take_registered_cancel(&mut cancel_signals.lock().unwrap(), &req.tab_id)
-        {
-            let _ = signal.send(());
-        }
-        if let Some(ref old) = old_sid {
-            if let Err(e) = conn
-                .cancel(acp::schema::v1::CancelNotification::new(old.clone()))
-                .await
-            {
-                tracing::warn!(
-                    target: "acp_load_session",
-                    tab = %req.tab_id,
-                    session_id = %old,
-                    error = ?e,
-                    "session/cancel before load failed (likely unsupported)"
-                );
-            }
-        }
 
         let session_id = acp::schema::v1::SessionId::new(req.session_id.clone());
         let mut load_req =
@@ -4321,16 +4435,24 @@ fn dispatch_load_session(
                     );
                     return;
                 }
+                let Some(current_tab_id) = current_tab_binding_operation(
+                    &tab_aliases,
+                    &tab_binding_generations,
+                    &request_tab_id,
+                    binding_generation,
+                ) else {
+                    return;
+                };
                 tracing::info!(
                     target: "acp_load_session",
                     tab = %req.tab_id,
                     session_id = %req.session_id,
                     "load_session succeeded"
                 );
-                {
-                    let mut g = tab_to_session.lock().await;
-                    g.insert(req.tab_id.clone(), session_id.clone());
-                }
+                tab_to_session
+                    .lock()
+                    .await
+                    .insert(current_tab_id.clone(), session_id.clone());
                 if let Some(old) = old_sid
                     .as_ref()
                     .filter(|old| old.0.as_ref() != session_id.0.as_ref())
@@ -4354,8 +4476,9 @@ fn dispatch_load_session(
                 // resuming indicator ends when this event clears
                 // `loading_session`.
                 let _ = event_tx.send(AppEvent::SessionAttached {
-                    tab_id: req.tab_id.clone(),
+                    tab_id: current_tab_id,
                     session_id: session_id.to_string(),
+                    prompt_id: None,
                     available_models,
                     current_model_id,
                 });
@@ -4384,15 +4507,18 @@ fn dispatch_load_session(
                 dispatch_load_failure(
                     use_load_failure_handler,
                     old_sid.as_ref(),
-                    &req.tab_id,
+                    &request_tab_id,
+                    binding_generation,
                     &cwd,
                     &conn,
                     &tab_to_session,
+                    &tab_binding_generations,
                     &event_tx,
                     message,
                     &proposal_channels,
                     proposal_mcp_enabled,
                     Arc::clone(&client_state),
+                    Arc::clone(&tab_aliases),
                 )
                 .await;
             }
@@ -4415,20 +4541,23 @@ fn dispatch_load_session(
                 dispatch_load_failure(
                     use_load_failure_handler,
                     old_sid.as_ref(),
-                    &req.tab_id,
+                    &request_tab_id,
+                    binding_generation,
                     &cwd,
                     &conn,
                     &tab_to_session,
+                    &tab_binding_generations,
                     &event_tx,
                     message,
                     &proposal_channels,
                     proposal_mcp_enabled,
                     Arc::clone(&client_state),
+                    Arc::clone(&tab_aliases),
                 )
                 .await;
             }
         }
-    });
+    })
 }
 
 /// Failure-strategy switch for [`dispatch_load_session`]: the helper path
@@ -4440,44 +4569,55 @@ async fn dispatch_load_failure(
     use_load_failure_handler: bool,
     old_sid: Option<&acp::schema::v1::SessionId>,
     tab_id: &str,
+    binding_generation: u64,
     cwd: &std::path::Path,
     conn: &conn::ClientLink,
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
+    tab_binding_generations: &SharedTabBindingGenerations,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
     message: String,
     proposal_channels: &Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
     proposal_mcp_enabled: bool,
     client_state: Arc<ClientState>,
+    tab_aliases: SharedTabAliases,
 ) {
     if use_load_failure_handler {
         handle_load_failure(
             old_sid,
             tab_id.to_string(),
+            binding_generation,
             cwd.to_path_buf(),
             conn.clone(),
             Arc::clone(tab_to_session),
+            Arc::clone(tab_binding_generations),
             event_tx.clone(),
             message,
             Arc::clone(proposal_channels),
             proposal_mcp_enabled,
             client_state,
+            tab_aliases,
         )
         .await;
     } else {
+        let Some(tab_id) = current_tab_binding_operation(
+            &tab_aliases,
+            tab_binding_generations,
+            tab_id,
+            binding_generation,
+        ) else {
+            return;
+        };
         // TabError routes to the specific new tab (the historical session
         // has no live session_id we could thread through AgentError, and
         // AgentError with session_id=None would land in the currently-
         // active tab instead).
-        let _ = event_tx.send(AppEvent::TabError {
-            tab_id: tab_id.to_string(),
-            message,
-        });
+        let _ = event_tx.send(AppEvent::TabError { tab_id, message });
     }
 }
 
 /// Spin up a fresh ACP session for a tab (the `/new` path), atomically
-/// replacing any existing session. Cancels and forgets the old session,
-/// calls `new_session`, records the agent-pane origin, rebinds the tab,
+/// replacing any existing session. Forgets the old session, calls
+/// `new_session`, records the agent-pane origin, rebinds the tab,
 /// and emits `SessionAttached` (or `AgentError` on failure). Called by
 /// `run_acp_client_over_pipe`.
 ///
@@ -4486,12 +4626,13 @@ async fn dispatch_load_failure(
 /// `pane_session_id` on the registry row; the direct-agent path does not.
 /// `log_label` distinguishes the two paths in the timing log.
 #[allow(clippy::too_many_arguments)]
-fn dispatch_new_session(
+fn dispatch_new_session_with_aliases(
     req: NewSessionForTab,
     conn: &conn::ClientLink,
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
+    tab_aliases: &SharedTabAliases,
+    tab_binding_generations: &SharedTabBindingGenerations,
     template_memo: &TemplateMemo,
-    cancel_signals: &SharedPromptCancelRegistry,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
     client_state: Arc<ClientState>,
     is_agent_pane: bool,
@@ -4499,7 +4640,7 @@ fn dispatch_new_session(
     log_label: &'static str,
     _proposal_channels: &Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
     proposal_mcp_enabled: bool,
-) {
+) -> LifecycleTask {
     tracing::info!(
         target: "acp_new_session",
         tab = %req.tab_id,
@@ -4507,9 +4648,12 @@ fn dispatch_new_session(
     );
     let conn = conn.clone();
     let tab_to_session = Arc::clone(tab_to_session);
+    let tab_aliases = Arc::clone(tab_aliases);
+    let tab_binding_generations = Arc::clone(tab_binding_generations);
     let template_memo = template_memo.clone();
-    let cancel_signals = Arc::clone(cancel_signals);
     let event_tx = event_tx.clone();
+    let (request_tab_id, binding_generation) =
+        begin_tab_binding_operation(&tab_aliases, &tab_binding_generations, &req.tab_id);
     tokio::task::spawn_local(async move {
         let cwd = req
             .cwd
@@ -4517,24 +4661,16 @@ fn dispatch_new_session(
             .map(std::path::PathBuf::from)
             .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
 
-        let old_sid: Option<acp::schema::v1::SessionId> = {
+        let old_sid = {
             let mut g = tab_to_session.lock().await;
-            g.remove(&req.tab_id)
+            g.remove(&request_tab_id)
         };
 
-        if let Some(signal) =
-            take_registered_cancel(&mut cancel_signals.lock().unwrap(), &req.tab_id)
-        {
-            let _ = signal.send(());
-        }
         if let Some(ref old) = old_sid {
             let old_str = old.to_string();
             crate::protocol::acp::model_select::forget_session(&old_str);
             client_state.native_yolo.forget_session(old);
             template_memo.forget(&old_str).await;
-            let _ = conn
-                .cancel(acp::schema::v1::CancelNotification::new(old.clone()))
-                .await;
         }
 
         // Inject WT_SESSION into the request meta so master can record
@@ -4552,9 +4688,17 @@ fn dispatch_new_session(
         let mut new_session = match new_session_result {
             Ok(s) => s,
             Err(e) => {
+                let Some(current_tab_id) = current_tab_binding_operation(
+                    &tab_aliases,
+                    &tab_binding_generations,
+                    &request_tab_id,
+                    binding_generation,
+                ) else {
+                    return;
+                };
                 let _ = event_tx.send(AppEvent::TabError {
-                    tab_id: req.tab_id.clone(),
-                    message: format!("/new failed for tab {}: {}", req.tab_id, e),
+                    tab_id: current_tab_id.clone(),
+                    message: format!("/new failed for tab {}: {}", current_tab_id, e),
                 });
                 return;
             }
@@ -4568,6 +4712,14 @@ fn dispatch_new_session(
             );
             return;
         }
+        let Some(current_tab_id) = current_tab_binding_operation(
+            &tab_aliases,
+            &tab_binding_generations,
+            &request_tab_id,
+            binding_generation,
+        ) else {
+            return;
+        };
 
         let new_sid = new_session.session_id.clone();
         if is_agent_pane {
@@ -4588,14 +4740,15 @@ fn dispatch_new_session(
         let (available_models, current_model_id) =
             crate::protocol::acp::model_select::models_from_new_session(&new_session);
         record_native_yolo(&new_session, &client_state);
-        {
-            let mut g = tab_to_session.lock().await;
-            g.insert(req.tab_id.clone(), new_sid.clone());
-        }
+        tab_to_session
+            .lock()
+            .await
+            .insert(current_tab_id.clone(), new_sid.clone());
 
         let _ = event_tx.send(AppEvent::SessionAttached {
-            tab_id: req.tab_id.clone(),
+            tab_id: current_tab_id,
             session_id: new_sid.to_string(),
+            prompt_id: None,
             available_models,
             current_model_id,
         });
@@ -4605,35 +4758,33 @@ fn dispatch_new_session(
             &new_sid,
             new_session.config_options.as_deref(),
         );
-    });
+    })
 }
 
 /// Close a tab's ACP session without creating a replacement (tab close or
-/// Ctrl+C×2 close-pane path). Signals any in-flight prompt to bail out of
-/// `conn.prompt().await`, forgets its template memo, and asks master to
+/// Ctrl+C×2 close-pane path). Forgets its template memo and asks master to
 /// physically release the session through master's close-by-tab extension.
 /// No-op when the tab holds no session. Called by
 /// `run_acp_client_over_pipe`.
-async fn dispatch_drop_session(
+async fn dispatch_drop_session_with_aliases(
     req: DropSessionRequest,
     conn: &conn::ClientLink,
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
+    tab_aliases: &SharedTabAliases,
+    tab_binding_generations: &SharedTabBindingGenerations,
     template_memo: &TemplateMemo,
-    cancel_signals: &SharedPromptCancelRegistry,
     client_state: &ClientState,
-) {
+) -> Option<LifecycleTask> {
+    let tab_id = invalidate_tab_binding(tab_aliases, tab_binding_generations, &req.tab_id);
     tracing::info!(
         target: "acp_drop_session",
-        tab = %req.tab_id,
+        tab = %tab_id,
         "close session requested (no replacement)"
     );
     let old_sid = {
         let mut sessions = tab_to_session.lock().await;
-        sessions.remove(&req.tab_id)
+        sessions.remove(&tab_id)
     };
-    if let Some(signal) = take_registered_cancel(&mut cancel_signals.lock().unwrap(), &req.tab_id) {
-        let _ = signal.send(());
-    }
     if let Some(old) = old_sid {
         let old_str = old.to_string();
         crate::protocol::acp::model_select::forget_session(&old_str);
@@ -4642,7 +4793,7 @@ async fn dispatch_drop_session(
     }
 
     if !req.notify_master {
-        return;
+        return None;
     }
 
     // The helper that owns the closing tab may be destroyed before it can
@@ -4651,10 +4802,9 @@ async fn dispatch_drop_session(
     // Duplicate requests are intentionally idempotent. Keep the bounded
     // master RPC off the helper's main receive loop so sibling work remains
     // responsive while the agent unwinds the cancelled turn.
-    let close_tab_request = crate::session_registry::build_close_tab_session_request(&req.tab_id);
+    let close_tab_request = crate::session_registry::build_close_tab_session_request(&tab_id);
     let conn = conn.clone();
-    let tab_id = req.tab_id;
-    tokio::task::spawn_local(async move {
+    Some(tokio::task::spawn_local(async move {
         match tokio::time::timeout(
             std::time::Duration::from_secs(18),
             conn.ext_method(close_tab_request),
@@ -4674,87 +4824,7 @@ async fn dispatch_drop_session(
                 "master close-by-tab request timed out"
             ),
         }
-    });
-}
-
-/// Signal the exact registered tab/prompt pair and best-effort notify the
-/// agent via `session/cancel`. A cancel that wins the main channel select
-/// before prompt registration is latched without notifying the agent because
-/// that prompt has not started. Stale requests never replace newer state.
-fn dispatch_cancel(
-    req: CancelRequest,
-    conn: &conn::ClientLink,
-    cancel_signals: &SharedPromptCancelRegistry,
-) {
-    tracing::info!(
-        target: "acp_cancel",
-        tab_id = %req.tab_id,
-        prompt_id = req.prompt_id,
-        session_id = ?req.session_id,
-        "cancel requested"
-    );
-    // Local oneshot first — it's the critical path for breaking the spawned
-    // prompt task out of conn.prompt(). With no entry, preserve this exact
-    // identity for dispatch_prompt to consume.
-    let signal = {
-        let mut registry = cancel_signals.lock().unwrap();
-        match registry.get(&req.tab_id) {
-            Some(entry) if entry.prompt_id() != req.prompt_id => {
-                tracing::info!(
-                    target: "acp_cancel",
-                    tab_id = %req.tab_id,
-                    prompt_id = req.prompt_id,
-                    registered_prompt_id = entry.prompt_id(),
-                    "ignoring stale cancel request"
-                );
-                return;
-            }
-            Some(PromptCancelEntry::Pending { .. }) => {
-                tracing::debug!(
-                    target: "acp_cancel",
-                    tab_id = %req.tab_id,
-                    prompt_id = req.prompt_id,
-                    "matching cancel is already pending prompt registration"
-                );
-                return;
-            }
-            Some(PromptCancelEntry::Registered { .. }) => match registry.remove(&req.tab_id) {
-                Some(PromptCancelEntry::Registered { signal, .. }) => signal,
-                _ => unreachable!("matching registered cancel entry changed while locked"),
-            },
-            None => {
-                registry.insert(
-                    req.tab_id.clone(),
-                    PromptCancelEntry::Pending {
-                        prompt_id: req.prompt_id,
-                    },
-                );
-                tracing::debug!(
-                    target: "acp_cancel",
-                    tab_id = %req.tab_id,
-                    prompt_id = req.prompt_id,
-                    "latched cancel pending prompt registration"
-                );
-                return;
-            }
-        }
-    };
-    let _ = signal.send(());
-    let Some(session_id_str) = req.session_id else {
-        return;
-    };
-    // Best-effort agent notification. Spawned so the loop stays
-    // responsive even if the agent is slow to ack.
-    let conn_for_cancel = conn.clone();
-    tokio::task::spawn_local(async move {
-        let session_id = acp::schema::v1::SessionId::new(session_id_str.clone());
-        if let Err(e) = conn_for_cancel
-            .cancel(acp::schema::v1::CancelNotification::new(session_id))
-            .await
-        {
-            tracing::warn!(target: "acp_cancel", session_id = %session_id_str, error = ?e, "session/cancel rpc failed (likely unsupported)");
-        }
-    });
+    }))
 }
 
 /// Rekey the `tab_to_session` binding when WT mints a new stable tab id
@@ -4762,83 +4832,47 @@ fn dispatch_cancel(
 /// `rename_session_rx` arm of `run_acp_client_over_pipe`, so the rekey
 /// can be unit-tested against
 /// the shared map. No-op when `old_tab_id` is absent.
-async fn dispatch_rename_session(
+async fn dispatch_rename_session_with_aliases(
     req: RenameSessionRequest,
-    conn: &conn::ClientLink,
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
-    cancel_signals: &SharedPromptCancelRegistry,
     in_flight_tabs: &SharedInFlightPrompts,
+    tab_aliases: &SharedTabAliases,
+    tab_binding_generations: &SharedTabBindingGenerations,
 ) {
     rename_helper_owner_tab_id(&req.old_tab_id, &req.new_tab_id);
+    let (old_tab_id, new_tab_id) = {
+        let mut aliases = tab_aliases.lock().unwrap();
+        let old_tab_id = resolve_tab_alias_locked(&aliases, &req.old_tab_id);
+        let new_tab_id = resolve_tab_alias_locked(&aliases, &req.new_tab_id);
+        aliases.insert(req.old_tab_id.clone(), new_tab_id.clone());
+        if old_tab_id != req.old_tab_id {
+            aliases.insert(old_tab_id.clone(), new_tab_id.clone());
+        }
+        (old_tab_id, new_tab_id)
+    };
     let rekeyed_session = {
         let mut sessions = tab_to_session.lock().await;
-        if let Some(session_id) = sessions.remove(&req.old_tab_id) {
-            sessions.insert(req.new_tab_id.clone(), session_id.clone());
+        if let Some(session_id) = sessions.remove(&old_tab_id) {
+            sessions.insert(new_tab_id.clone(), session_id.clone());
             Some(session_id)
         } else {
             None
         }
     };
-    let (cancel_rekeyed, cancel_merged, signals) = {
-        let mut registry = cancel_signals.lock().unwrap();
-        if let Some(entry) = registry.remove(&req.old_tab_id) {
-            match registry.remove(&req.new_tab_id) {
-                None => {
-                    registry.insert(req.new_tab_id.clone(), entry);
-                    (true, false, Vec::new())
-                }
-                Some(destination) if entry.prompt_id() == destination.prompt_id() => {
-                    // A tab rename unifies aliases for the same prompt. Pending means
-                    // cancellation already won, so no Registered sender may be lost.
-                    match (entry, destination) {
-                        (
-                            PromptCancelEntry::Pending { prompt_id },
-                            PromptCancelEntry::Pending { .. },
-                        ) => {
-                            registry.insert(
-                                req.new_tab_id.clone(),
-                                PromptCancelEntry::Pending { prompt_id },
-                            );
-                            (true, false, Vec::new())
-                        }
-                        (old, new) => {
-                            let mut signals = Vec::new();
-                            if let PromptCancelEntry::Registered { signal, .. } = old {
-                                signals.push(signal);
-                            }
-                            if let PromptCancelEntry::Registered { signal, .. } = new {
-                                signals.push(signal);
-                            }
-                            (true, true, signals)
-                        }
-                    }
-                }
-                Some(destination) => {
-                    let (keep, discard) = if entry.prompt_id() > destination.prompt_id() {
-                        (entry, destination)
-                    } else {
-                        (destination, entry)
-                    };
-                    let signal = match discard {
-                        PromptCancelEntry::Registered { signal, .. } => Some(signal),
-                        PromptCancelEntry::Pending { .. } => None,
-                    };
-                    registry.insert(req.new_tab_id.clone(), keep);
-                    (true, false, signal.into_iter().collect())
-                }
-            }
-        } else {
-            (false, false, Vec::new())
-        }
-    };
-    for signal in signals {
-        let _ = signal.send(());
+    {
+        let mut generations = tab_binding_generations.lock().unwrap();
+        let old_generation = generations.remove(&old_tab_id).unwrap_or_default();
+        let destination_generation = generations.remove(&new_tab_id).unwrap_or_default();
+        generations.insert(
+            new_tab_id.clone(),
+            old_generation.max(destination_generation),
+        );
     }
     let in_flight_rekeyed = {
         let mut in_flight = in_flight_tabs.lock().unwrap();
-        if let Some(prompt_id) = in_flight.remove(&req.old_tab_id) {
+        if let Some(prompt_id) = in_flight.remove(&old_tab_id) {
             in_flight
-                .entry(req.new_tab_id.clone())
+                .entry(new_tab_id.clone())
                 .and_modify(|destination_id| *destination_id = (*destination_id).max(prompt_id))
                 .or_insert(prompt_id);
             true
@@ -4846,29 +4880,124 @@ async fn dispatch_rename_session(
             false
         }
     };
-    if cancel_merged {
-        if let Some(session_id) = rekeyed_session.clone() {
-            let conn_for_cancel = conn.clone();
-            tokio::task::spawn_local(async move {
-                if let Err(e) = conn_for_cancel
-                    .cancel(acp::schema::v1::CancelNotification::new(session_id.clone()))
-                    .await
-                {
-                    tracing::warn!(target: "acp_cancel", session_id = %session_id, error = ?e, "session/cancel rpc failed after tab rename (likely unsupported)");
-                }
-            });
-        }
-    }
     tracing::info!(
         target: "acp_rename_session",
         old_tab_id = %req.old_tab_id,
         new_tab_id = %req.new_tab_id,
+        resolved_old_tab_id = %old_tab_id,
+        resolved_new_tab_id = %new_tab_id,
         session_rekeyed = rekeyed_session.is_some(),
-        cancel_rekeyed,
-        cancel_merged,
         in_flight_rekeyed,
         "prompt lifecycle state rekeyed via drag"
     );
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn dispatch_load_session(
+    req: LoadSessionForTab,
+    conn: &conn::ClientLink,
+    tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    client_state: Arc<ClientState>,
+    inject_pane_meta: bool,
+    use_load_failure_handler: bool,
+    timeout: std::time::Duration,
+    proposal_channels: &Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
+    proposal_mcp_enabled: bool,
+) {
+    let tab_aliases = Arc::new(Mutex::new(HashMap::new()));
+    let tab_binding_generations = Arc::new(Mutex::new(HashMap::new()));
+    drop(dispatch_load_session_with_aliases(
+        req,
+        conn,
+        tab_to_session,
+        &tab_aliases,
+        &tab_binding_generations,
+        event_tx,
+        client_state,
+        inject_pane_meta,
+        use_load_failure_handler,
+        timeout,
+        proposal_channels,
+        proposal_mcp_enabled,
+    ));
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
+fn dispatch_new_session(
+    req: NewSessionForTab,
+    conn: &conn::ClientLink,
+    tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
+    template_memo: &TemplateMemo,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    client_state: Arc<ClientState>,
+    is_agent_pane: bool,
+    inject_pane_meta: bool,
+    log_label: &'static str,
+    proposal_channels: &Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
+    proposal_mcp_enabled: bool,
+) {
+    let tab_aliases = Arc::new(Mutex::new(HashMap::new()));
+    let tab_binding_generations = Arc::new(Mutex::new(HashMap::new()));
+    drop(dispatch_new_session_with_aliases(
+        req,
+        conn,
+        tab_to_session,
+        &tab_aliases,
+        &tab_binding_generations,
+        template_memo,
+        event_tx,
+        client_state,
+        is_agent_pane,
+        inject_pane_meta,
+        log_label,
+        proposal_channels,
+        proposal_mcp_enabled,
+    ));
+}
+
+#[cfg(test)]
+async fn dispatch_drop_session(
+    req: DropSessionRequest,
+    conn: &conn::ClientLink,
+    tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
+    template_memo: &TemplateMemo,
+    client_state: &ClientState,
+) {
+    let tab_aliases = Arc::new(Mutex::new(HashMap::new()));
+    let tab_binding_generations = Arc::new(Mutex::new(HashMap::new()));
+    drop(
+        dispatch_drop_session_with_aliases(
+            req,
+            conn,
+            tab_to_session,
+            &tab_aliases,
+            &tab_binding_generations,
+            template_memo,
+            client_state,
+        )
+        .await,
+    );
+}
+
+#[cfg(test)]
+async fn dispatch_rename_session(
+    req: RenameSessionRequest,
+    tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
+    in_flight_tabs: &SharedInFlightPrompts,
+) {
+    let tab_aliases = Arc::new(Mutex::new(HashMap::new()));
+    let tab_binding_generations = Arc::new(Mutex::new(HashMap::new()));
+    dispatch_rename_session_with_aliases(
+        req,
+        tab_to_session,
+        in_flight_tabs,
+        &tab_aliases,
+        &tab_binding_generations,
+    )
+    .await;
 }
 
 /// Assemble the ACP prompt content: the (already-templated) text block,
@@ -4889,41 +5018,113 @@ fn build_prompt_content(
 }
 
 async fn stop_prompt_tasks(
-    prompt_tasks: &mut Vec<tokio::task::JoinHandle<()>>,
+    prompt_tasks: &mut Vec<PromptTask>,
     in_flight_tabs: &SharedInFlightPrompts,
-    cancel_signals: &SharedPromptCancelRegistry,
 ) {
-    let signals = std::mem::take(&mut *cancel_signals.lock().unwrap());
-    for (_, entry) in signals {
-        entry.signal_registered();
+    const PROMPT_TASK_SHUTDOWN_GRACE: std::time::Duration = std::time::Duration::from_millis(100);
+
+    for task in prompt_tasks.iter() {
+        task.cancellation.cancel();
     }
-    for task in prompt_tasks.drain(..) {
-        task.abort();
-        let _ = task.await;
+    let deadline = tokio::time::Instant::now() + PROMPT_TASK_SHUTDOWN_GRACE;
+    for mut task in prompt_tasks.drain(..) {
+        if tokio::time::timeout_at(deadline, &mut task.handle)
+            .await
+            .is_err()
+        {
+            task.handle.abort();
+            let _ = task.handle.await;
+        }
     }
     in_flight_tabs.lock().unwrap().clear();
-    cancel_signals.lock().unwrap().clear();
 }
 
+async fn stop_lifecycle_tasks(lifecycle_tasks: &mut Vec<LifecycleTask>) {
+    for task in lifecycle_tasks.iter() {
+        task.abort();
+    }
+    for task in lifecycle_tasks.drain(..) {
+        let _ = task.await;
+    }
+}
+
+fn retire_queued_prompt_submissions(prompt_rx: &mut mpsc::UnboundedReceiver<PromptSubmission>) {
+    prompt_rx.close();
+    while let Ok(prompt) = prompt_rx.try_recv() {
+        prompt.cancellation.cancel();
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn close_client_receivers(
+    prompt_rx: &mut mpsc::UnboundedReceiver<PromptSubmission>,
+    new_session_rx: &mut mpsc::UnboundedReceiver<NewSessionForTab>,
+    load_session_rx: &mut mpsc::UnboundedReceiver<LoadSessionForTab>,
+    drop_session_rx: &mut mpsc::UnboundedReceiver<DropSessionRequest>,
+    rename_session_rx: &mut mpsc::UnboundedReceiver<RenameSessionRequest>,
+    restart_rx: &mut mpsc::UnboundedReceiver<AgentLifecycleRequest>,
+    session_hook_rx: &mut mpsc::UnboundedReceiver<crate::agent_sessions::SessionEvent>,
+    master_ext_rx: &mut mpsc::UnboundedReceiver<MasterExtRequest>,
+) {
+    retire_queued_prompt_submissions(prompt_rx);
+    new_session_rx.close();
+    load_session_rx.close();
+    drop_session_rx.close();
+    rename_session_rx.close();
+    restart_rx.close();
+    session_hook_rx.close();
+    master_ext_rx.close();
+}
+
+async fn finalize_client_transport(
+    transport_guard: &mut ClientTransportGuard,
+    report_master_disconnect: bool,
+    prompt_tasks: &mut Vec<PromptTask>,
+    in_flight_tabs: &SharedInFlightPrompts,
+    lifecycle_tasks: &mut Vec<LifecycleTask>,
+) {
+    transport_guard.conn.shutdown();
+    stop_lifecycle_tasks(lifecycle_tasks).await;
+    stop_prompt_tasks(prompt_tasks, in_flight_tabs).await;
+    transport_guard.reap_io_task().await;
+    transport_guard.publish_retired(report_master_disconnect);
+}
+
+#[cfg(test)]
 async fn complete_transport_shutdown(
     io_result: std::result::Result<(), tokio::task::JoinError>,
     suppress_transport_error: &AtomicBool,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
-    prompt_tasks: &mut Vec<tokio::task::JoinHandle<()>>,
+    prompt_tasks: &mut Vec<PromptTask>,
     in_flight_tabs: &SharedInFlightPrompts,
-    cancel_signals: &SharedPromptCancelRegistry,
 ) -> AcpClientExit {
-    stop_prompt_tasks(prompt_tasks, in_flight_tabs, cancel_signals).await;
-    complete_transport_io_task(io_result, suppress_transport_error, event_tx)
+    let (exit, report_master_disconnect) =
+        complete_transport_io_task(io_result, suppress_transport_error);
+    stop_prompt_tasks(prompt_tasks, in_flight_tabs).await;
+    if report_master_disconnect {
+        let _ = event_tx.send(AppEvent::MasterDisconnected);
+    }
+    exit
 }
 
+fn publish_prompt_cancellation_settled(
+    cleanup: &mut PromptDispatchCleanup,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    prompt_id: u64,
+    started: bool,
+) {
+    cleanup.release();
+    let _ = event_tx.send(AppEvent::PromptCancellationSettled { prompt_id, started });
+}
+
+#[cfg(test)]
+#[allow(clippy::too_many_arguments)]
 fn dispatch_prompt(
     prompt: PromptSubmission,
     conn: &conn::ClientLink,
     tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
     template_memo: &TemplateMemo,
     in_flight_tabs: &SharedInFlightPrompts,
-    cancel_signals: &SharedPromptCancelRegistry,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
     shell_mgr: &Arc<ShellManager>,
     prompt_timing: &Arc<PromptTimingState>,
@@ -4933,54 +5134,68 @@ fn dispatch_prompt(
     is_agent_pane: bool,
     proposal_commands_supported: bool,
     proposal_channels: &Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
-) -> Option<tokio::task::JoinHandle<()>> {
-    let tab_key = prompt
+) -> Option<PromptTask> {
+    let tab_aliases = Arc::new(Mutex::new(HashMap::new()));
+    let tab_binding_generations = Arc::new(Mutex::new(HashMap::new()));
+    dispatch_prompt_with_aliases(
+        prompt,
+        conn,
+        tab_to_session,
+        template_memo,
+        in_flight_tabs,
+        &tab_aliases,
+        &tab_binding_generations,
+        event_tx,
+        shell_mgr,
+        prompt_timing,
+        client,
+        prompt_usage_identity,
+        wt_connected,
+        is_agent_pane,
+        proposal_commands_supported,
+        proposal_channels,
+    )
+}
+
+fn dispatch_prompt_with_aliases(
+    prompt: PromptSubmission,
+    conn: &conn::ClientLink,
+    tab_to_session: &Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
+    template_memo: &TemplateMemo,
+    in_flight_tabs: &SharedInFlightPrompts,
+    tab_aliases: &SharedTabAliases,
+    tab_binding_generations: &SharedTabBindingGenerations,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    shell_mgr: &Arc<ShellManager>,
+    prompt_timing: &Arc<PromptTimingState>,
+    client: &WtaClient,
+    prompt_usage_identity: &PromptUsageIdentity,
+    wt_connected: bool,
+    is_agent_pane: bool,
+    proposal_commands_supported: bool,
+    proposal_channels: &Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
+) -> Option<PromptTask> {
+    let submitted_tab_key = prompt
         .pane_context
         .as_ref()
         .and_then(|c| c.tab_id.clone())
         .unwrap_or_else(|| "0".to_string());
+    let tab_key = resolve_tab_alias(tab_aliases, &submitted_tab_key);
     let prompt_id = prompt.id;
 
-    {
-        let mut registry = cancel_signals.lock().unwrap();
-        match registry.get(&tab_key) {
-            Some(PromptCancelEntry::Pending {
-                prompt_id: pending_id,
-            }) if *pending_id == prompt_id => {
-                registry.remove(&tab_key);
-                let _ = event_tx.send(AppEvent::PromptCancellationSettled {
-                    tab_id: tab_key,
-                    prompt_id,
-                    session_id: None,
-                });
-                return None;
-            }
-            Some(PromptCancelEntry::Pending {
-                prompt_id: pending_id,
-            }) if *pending_id < prompt_id => {
-                tracing::info!(
-                    target: "acp_cancel",
-                    tab_id = %tab_key,
-                    pending_prompt_id = *pending_id,
-                    prompt_id,
-                    "discarding stale pending cancellation before newer prompt"
-                );
-                registry.remove(&tab_key);
-            }
-            Some(PromptCancelEntry::Pending {
-                prompt_id: pending_id,
-            }) => {
-                tracing::info!(
-                    target: "acp_cancel",
-                    tab_id = %tab_key,
-                    pending_prompt_id = *pending_id,
-                    prompt_id,
-                    "discarding stale queued prompt while preserving newer pending cancellation"
-                );
-                return None;
-            }
-            _ => {}
-        }
+    if prompt.cancellation.is_cancelled() {
+        return Some(PromptTask {
+            cancellation: prompt.cancellation.clone(),
+            handle: tokio::task::spawn_local({
+                let event_tx = event_tx.clone();
+                async move {
+                    let _ = event_tx.send(AppEvent::PromptCancellationSettled {
+                        prompt_id,
+                        started: false,
+                    });
+                }
+            }),
+        });
     }
 
     {
@@ -5002,7 +5217,8 @@ fn dispatch_prompt(
     let tab_to_session_task = Arc::clone(tab_to_session);
     let template_memo_task = template_memo.clone();
     let in_flight_tabs_task = Arc::clone(in_flight_tabs);
-    let cancel_signals_task = Arc::clone(cancel_signals);
+    let tab_aliases_task = Arc::clone(tab_aliases);
+    let tab_binding_generations_task = Arc::clone(tab_binding_generations);
     let event_tx_task = event_tx.clone();
     let shell_mgr_task = Arc::clone(shell_mgr);
     let prompt_timing_task = Arc::clone(prompt_timing);
@@ -5010,34 +5226,30 @@ fn dispatch_prompt(
     let prompt_usage_identity_task = prompt_usage_identity.clone();
     let proposal_channels_task = Arc::clone(proposal_channels);
     let tab_key_task = tab_key.clone();
-    let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
-    cancel_signals.lock().unwrap().insert(
-        tab_key.clone(),
-        PromptCancelEntry::Registered {
-            prompt_id,
-            signal: cancel_tx,
-        },
-    );
-
-    Some(tokio::task::spawn_local(dispatch_prompt_body(
+    let cancellation = prompt.cancellation.clone();
+    let handle = tokio::task::spawn_local(dispatch_prompt_body(
         prompt,
         conn_task,
         tab_to_session_task,
         template_memo_task,
         in_flight_tabs_task,
-        cancel_signals_task,
+        tab_aliases_task,
+        tab_binding_generations_task,
         event_tx_task,
         shell_mgr_task,
         prompt_timing_task,
         client_task,
         prompt_usage_identity_task,
         tab_key_task,
-        cancel_rx,
         wt_connected,
         is_agent_pane,
         proposal_commands_supported,
         proposal_channels_task,
-    )))
+    ));
+    Some(PromptTask {
+        cancellation,
+        handle,
+    })
 }
 
 /// The per-prompt task body: lazily resolves the tab's ACP session,
@@ -5050,33 +5262,52 @@ async fn dispatch_prompt_body(
     tab_to_session_task: Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
     template_memo: TemplateMemo,
     in_flight_tabs_task: SharedInFlightPrompts,
-    cancel_signals_task: SharedPromptCancelRegistry,
+    tab_aliases_task: SharedTabAliases,
+    tab_binding_generations_task: SharedTabBindingGenerations,
     event_tx_task: mpsc::UnboundedSender<AppEvent>,
     shell_mgr_task: Arc<ShellManager>,
     prompt_timing_task: Arc<PromptTimingState>,
     client_task: WtaClient,
     prompt_usage_identity_task: PromptUsageIdentity,
     tab_key_task: String,
-    cancel_rx: tokio::sync::oneshot::Receiver<()>,
     wt_connected: bool,
     is_agent_pane: bool,
     proposal_commands_supported: bool,
     proposal_channels: Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
 ) {
     let prompt_id = prompt.id;
-    let _cleanup = PromptDispatchCleanup {
+    let cancellation = prompt.cancellation.clone();
+    let tab_key_task = resolve_tab_alias(&tab_aliases_task, &tab_key_task);
+    let mut cleanup = PromptDispatchCleanup {
         tab_key: tab_key_task.clone(),
         prompt_id: prompt.id,
         in_flight_tabs: Arc::clone(&in_flight_tabs_task),
-        cancel_signals: Arc::clone(&cancel_signals_task),
+        released: false,
     };
 
+    if cancellation.is_cancelled() {
+        publish_prompt_cancellation_settled(&mut cleanup, &event_tx_task, prompt_id, false);
+        return;
+    }
+
     // Resolve (or lazily create) the ACP session for this tab.
+    let existing_session = {
+        let g = tab_to_session_task.lock().await;
+        g.get(&tab_key_task).cloned()
+    };
     let (prompt_session_id, lazy_yolo_operation) = {
-        let mut g = tab_to_session_task.lock().await;
-        if let Some(sid) = g.get(&tab_key_task) {
-            (sid.clone(), None)
+        if cancellation.is_cancelled() {
+            publish_prompt_cancellation_settled(&mut cleanup, &event_tx_task, prompt_id, false);
+            return;
+        }
+        if let Some(sid) = existing_session {
+            (sid, None)
         } else {
+            let (binding_tab_id, binding_generation) = begin_tab_binding_operation(
+                &tab_aliases_task,
+                &tab_binding_generations_task,
+                &tab_key_task,
+            );
             let cwd = prompt
                 .pane_context
                 .as_ref()
@@ -5094,10 +5325,20 @@ async fn dispatch_prompt_body(
             );
             let mut new_session = match new_session_result {
                 Ok(s) => s,
+                Err(_) if cancellation.is_cancelled() => {
+                    publish_prompt_cancellation_settled(
+                        &mut cleanup,
+                        &event_tx_task,
+                        prompt_id,
+                        false,
+                    );
+                    return;
+                }
                 Err(e) => {
-                    let _ = event_tx_task.send(AppEvent::AgentError {
-                        session_id: None,
-                        failure: AgentFailure::from_acp_error(&e),
+                    let current_tab_id = resolve_tab_alias(&tab_aliases_task, &tab_key_task);
+                    let _ = event_tx_task.send(AppEvent::PromptError {
+                        tab_id: current_tab_id,
+                        prompt_id,
                         message: format!("new_session failed for tab {}: {}", tab_key_task, e),
                     });
                     return;
@@ -5110,8 +5351,20 @@ async fn dispatch_prompt_body(
                     session_id = %new_session.session_id,
                     "abandoning prompt because its lazy session was retired during tab reset or close"
                 );
+                cancellation.cancelled().await;
+                publish_prompt_cancellation_settled(&mut cleanup, &event_tx_task, prompt_id, false);
                 return;
             }
+            let Some(current_tab_key) = current_tab_binding_operation(
+                &tab_aliases_task,
+                &tab_binding_generations_task,
+                &binding_tab_id,
+                binding_generation,
+            ) else {
+                cancellation.cancelled().await;
+                publish_prompt_cancellation_settled(&mut cleanup, &event_tx_task, prompt_id, false);
+                return;
+            };
             let new_sid = new_session.session_id.clone();
             if is_agent_pane {
                 let pane_session_id = std::env::var("WT_SESSION").unwrap_or_default();
@@ -5147,9 +5400,14 @@ async fn dispatch_prompt_body(
                 .lock()
                 .unwrap()
                 .mark_client_reconciled(new_sid.to_string(), enabled);
+            tab_to_session_task
+                .lock()
+                .await
+                .insert(current_tab_key.clone(), new_sid.clone());
             let _ = event_tx_task.send(AppEvent::SessionAttached {
-                tab_id: tab_key_task.clone(),
+                tab_id: current_tab_key.clone(),
                 session_id: new_sid.to_string(),
+                prompt_id: Some(prompt_id),
                 available_models,
                 current_model_id,
             });
@@ -5159,7 +5417,6 @@ async fn dispatch_prompt_body(
                 &new_sid,
                 new_session.config_options.as_deref(),
             );
-            g.insert(tab_key_task.clone(), new_sid.clone());
             (new_sid, Some((enabled, yolo_operation)))
         }
     };
@@ -5173,6 +5430,10 @@ async fn dispatch_prompt_body(
             super::native_yolo::NATIVE_YOLO_RPC_TIMEOUT,
         )
         .await;
+        if cancellation.is_cancelled() {
+            publish_prompt_cancellation_settled(&mut cleanup, &event_tx_task, prompt_id, false);
+            return;
+        }
         match yolo_result {
             Err(error) => {
                 // As with config/reconcile, an ordinary ACP rejection
@@ -5223,6 +5484,11 @@ async fn dispatch_prompt_body(
                 }
             }
         }
+    }
+
+    if cancellation.is_cancelled() {
+        publish_prompt_cancellation_settled(&mut cleanup, &event_tx_task, prompt_id, false);
+        return;
     }
 
     let policy_blocked = client_task
@@ -5343,6 +5609,11 @@ async fn dispatch_prompt_body(
         let _ = event_tx_task.send(AppEvent::PromptTemplateLoaded { name });
         (text, source, target)
     };
+    if cancellation.is_cancelled() {
+        let _ = prompt_timing_task.complete(&prompt_session_id_str, false, Some("cancelled"));
+        publish_prompt_cancellation_settled(&mut cleanup, &event_tx_task, prompt_id, false);
+        return;
+    }
     if proposal_commands_supported {
         match proposal_channels.issue(
             prompt_session_id_str.clone(),
@@ -5365,7 +5636,11 @@ async fn dispatch_prompt_body(
     // uses this authoritative value instead of a model-generated action target.
     if let Some(pane_id) = resolved_target_pane {
         let _ = event_tx_task.send(AppEvent::PromptTargetResolved {
-            tab_id: prompt.pane_context.as_ref().and_then(|c| c.tab_id.clone()),
+            tab_id: prompt
+                .pane_context
+                .as_ref()
+                .and_then(|c| c.tab_id.as_deref())
+                .map(|tab_id| resolve_tab_alias(&tab_aliases_task, tab_id)),
             prompt_id: prompt.id,
             pane_id,
         });
@@ -5412,13 +5687,22 @@ async fn dispatch_prompt_body(
     let telemetry_agent_id = prompt.agent_id().to_string();
     let telemetry_prompt_id = prompt.id;
     let telemetry_is_agent_command = prompt.is_agent_command();
+    let prompt_started = Arc::new(AtomicBool::new(false));
+    let cancelled_at_send = Arc::new(AtomicBool::new(false));
     let prompt_fut = conn_task.prompt_if(
         acp::schema::v1::PromptRequest::new(prompt_session_id.clone(), content),
         {
             let privileged_agent_command = privileged_agent_command.clone();
             let final_yolo_safety_error = Arc::clone(&final_yolo_safety_error);
             let guard_session_id = prompt_session_id.clone();
+            let cancellation = cancellation.clone();
+            let prompt_started = Arc::clone(&prompt_started);
+            let cancelled_at_send = Arc::clone(&cancelled_at_send);
             move || {
+                if cancellation.is_cancelled() {
+                    cancelled_at_send.store(true, Ordering::Release);
+                    return false;
+                }
                 let policy_blocked = yolo_state.lock().unwrap().policy_blocked();
                 let provider_command_blocked = privileged_agent_command.is_some() && policy_blocked;
                 let yolo_safety_error = if provider_command_blocked {
@@ -5442,6 +5726,7 @@ async fn dispatch_prompt_body(
                     *final_yolo_safety_error.lock().unwrap() = Some(error);
                 }
                 if should_send {
+                    prompt_started.store(true, Ordering::Release);
                     if telemetry_is_agent_command {
                         tracing::info!(
                             target: "acp",
@@ -5466,28 +5751,27 @@ async fn dispatch_prompt_body(
         },
     );
     tokio::pin!(prompt_fut);
-    let prompt_started = std::cell::Cell::new(false);
-    let tracked_prompt_fut = std::future::poll_fn(|cx| {
-        prompt_started.set(true);
-        std::future::Future::poll(prompt_fut.as_mut(), cx)
-    });
-    tokio::pin!(tracked_prompt_fut);
 
     let completed_successfully = tokio::select! {
         biased;
-        _ = cancel_rx => {
+        _ = cancellation.cancelled() => {
             // Cancellation is a request, not the terminal boundary. If the
-            // prompt has already started, keep its future alive until the
-            // agent resolves it; if cancellation arrived during preparation,
-            // the biased branch wins before the prompt future is first polled.
+            // prompt has already been sent, notify that exact resolved ACP
+            // session and keep its future alive until the producer resolves.
+            let started = prompt_started.load(Ordering::Acquire);
             tracing::info!(target: "acp_cancel", session_id = %prompt_session_id_str, "waiting for cancelled prompt to quiesce");
             let _ = prompt_timing_task.complete(
                 &prompt_session_id_str,
                 false,
                 Some("cancelled"),
             );
-            if prompt_started.get() {
-                drop(tracked_prompt_fut);
+            if started {
+                if let Err(e) = conn_task
+                    .cancel(acp::schema::v1::CancelNotification::new(prompt_session_id.clone()))
+                    .await
+                {
+                    tracing::warn!(target: "acp_cancel", session_id = %prompt_session_id_str, error = ?e, "session/cancel rpc failed (likely unsupported)");
+                }
                 // ACP updates identify only the session, not the prompt. Do
                 // not synthesize completion on a timeout unless master can
                 // atomically retire this exact session; otherwise late output
@@ -5498,15 +5782,30 @@ async fn dispatch_prompt_body(
                 // compatibility drain here.
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             }
-            let _ = event_tx_task.send(AppEvent::PromptCancellationSettled {
-                tab_id: tab_key_task.clone(),
+            publish_prompt_cancellation_settled(
+                &mut cleanup,
+                &event_tx_task,
                 prompt_id,
-                session_id: Some(prompt_session_id_str.clone()),
-            });
+                started,
+            );
             false
         }
-        result = &mut tracked_prompt_fut => {
+        result = &mut prompt_fut => {
             match result {
+                Ok(None) if cancelled_at_send.load(Ordering::Acquire) => {
+                    let _ = prompt_timing_task.complete(
+                        &prompt_session_id_str,
+                        false,
+                        Some("cancelled"),
+                    );
+                    publish_prompt_cancellation_settled(
+                        &mut cleanup,
+                        &event_tx_task,
+                        prompt_id,
+                        false,
+                    );
+                    false
+                }
                 Ok(None) => {
                     let yolo_safety_error = final_yolo_safety_error.lock().unwrap().take();
                     let (message, completion_reason) =
@@ -5559,6 +5858,7 @@ async fn dispatch_prompt_body(
                         .ok()
                         .and_then(|resp| SoftStopReason::from_stop_reason(resp.stop_reason));
                     let successful = result.is_ok();
+                    cleanup.release();
                     complete_prompt_request(
                         result,
                         soft_stop,
@@ -5609,11 +5909,11 @@ mod tests {
         acp_error_detail, acp_result_failure_fields, bounded_tool_output_parts,
         claim_unexpected_transport_loss, complete_prompt_request, complete_transport_shutdown,
         inject_wta_pane_meta, is_redundant_startup_model_error, post_login_authenticate_error,
-        session_mcp_tool_from_title, stop_prompt_tasks, take_registered_cancel,
+        retire_queued_prompt_submissions, session_mcp_tool_from_title, stop_prompt_tasks,
         timeout_result_failure_fields, tool_call_exit_code, tool_call_kind_label,
-        tool_call_location_hint, tool_call_target, AcpClientExit, ClientState, PromptCancelEntry,
-        PromptDispatchCleanup, PromptTimingState, PromptUsageIdentity, SessionMcpTool,
-        SoftStopReason, WtaClient,
+        tool_call_location_hint, tool_call_target, AcpClientExit, ClientState,
+        PromptDispatchCleanup, PromptSubmission, PromptTask, PromptTimingState,
+        PromptUsageIdentity, SessionMcpTool, SoftStopReason, WtaClient,
     };
     use crate::app_contracts::AppEvent;
     use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
@@ -5621,59 +5921,20 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::sync::{Arc, Mutex};
     use tokio::sync::mpsc;
-
-    #[test]
-    fn prompt_dispatch_cleanup_preserves_newer_cancel_entry() {
-        let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("tab".to_string(), 1)])));
-        let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
-        let (newer_signal, mut newer_cancel) = tokio::sync::oneshot::channel();
-        cancel_signals.lock().unwrap().insert(
-            "tab".to_string(),
-            PromptCancelEntry::Registered {
-                prompt_id: 2,
-                signal: newer_signal,
-            },
-        );
-
-        drop(PromptDispatchCleanup {
-            tab_key: "tab".to_string(),
-            prompt_id: 1,
-            in_flight_tabs: Arc::clone(&in_flight_tabs),
-            cancel_signals: Arc::clone(&cancel_signals),
-        });
-
-        assert!(in_flight_tabs.lock().unwrap().is_empty());
-        assert_eq!(
-            cancel_signals
-                .lock()
-                .unwrap()
-                .get("tab")
-                .map(PromptCancelEntry::prompt_id),
-            Some(2)
-        );
-        assert!(matches!(
-            newer_cancel.try_recv(),
-            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
-        ));
-    }
+    use tokio_util::sync::CancellationToken;
 
     #[test]
     fn prompt_dispatch_cleanup_finds_rekeyed_identity() {
         let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("new-tab".to_string(), 7)])));
-        let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
-            "new-tab".to_string(),
-            PromptCancelEntry::Pending { prompt_id: 7 },
-        )])));
 
         drop(PromptDispatchCleanup {
             tab_key: "old-tab".to_string(),
             prompt_id: 7,
             in_flight_tabs: Arc::clone(&in_flight_tabs),
-            cancel_signals: Arc::clone(&cancel_signals),
+            released: false,
         });
 
         assert!(in_flight_tabs.lock().unwrap().is_empty());
-        assert!(cancel_signals.lock().unwrap().is_empty());
     }
 
     #[test]
@@ -5682,22 +5943,11 @@ mod tests {
             ("old-tab".to_string(), 8),
             ("new-tab".to_string(), 7),
         ])));
-        let cancel_signals = Arc::new(Mutex::new(HashMap::from([
-            (
-                "old-tab".to_string(),
-                PromptCancelEntry::Pending { prompt_id: 8 },
-            ),
-            (
-                "new-tab".to_string(),
-                PromptCancelEntry::Pending { prompt_id: 7 },
-            ),
-        ])));
-
         drop(PromptDispatchCleanup {
             tab_key: "old-tab".to_string(),
             prompt_id: 7,
             in_flight_tabs: Arc::clone(&in_flight_tabs),
-            cancel_signals: Arc::clone(&cancel_signals),
+            released: false,
         });
 
         assert_eq!(
@@ -5705,43 +5955,6 @@ mod tests {
             Some(8)
         );
         assert!(!in_flight_tabs.lock().unwrap().contains_key("new-tab"));
-        assert_eq!(
-            cancel_signals
-                .lock()
-                .unwrap()
-                .get("old-tab")
-                .map(PromptCancelEntry::prompt_id),
-            Some(8)
-        );
-        assert!(!cancel_signals.lock().unwrap().contains_key("new-tab"));
-    }
-
-    #[test]
-    fn lifecycle_cancel_take_preserves_pending_and_signals_registered() {
-        let mut registry = HashMap::from([(
-            "tab".to_string(),
-            PromptCancelEntry::Pending { prompt_id: 4 },
-        )]);
-        assert!(take_registered_cancel(&mut registry, "tab").is_none());
-        assert_eq!(
-            registry.get("tab").map(PromptCancelEntry::prompt_id),
-            Some(4)
-        );
-
-        let (signal, mut cancelled) = tokio::sync::oneshot::channel();
-        registry.insert(
-            "tab".to_string(),
-            PromptCancelEntry::Registered {
-                prompt_id: 5,
-                signal,
-            },
-        );
-        take_registered_cancel(&mut registry, "tab")
-            .expect("registered entry must be removed")
-            .send(())
-            .expect("cancel receiver must remain live");
-        assert!(registry.is_empty());
-        assert_eq!(cancelled.try_recv(), Ok(()));
     }
 
     #[test]
@@ -5790,7 +6003,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transport_completion_exits_despite_perpetual_refetch_and_cleans_prompts() {
+    async fn transport_completion_aborts_prompt_task_that_ignores_cancel() {
         struct DropFlag(Arc<std::sync::atomic::AtomicBool>);
         impl Drop for DropFlag {
             fn drop(&mut self) {
@@ -5801,22 +6014,19 @@ mod tests {
         let dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let dropped_for_task = Arc::clone(&dropped);
         let (started_tx, started_rx) = tokio::sync::oneshot::channel();
-        let mut prompt_tasks = vec![tokio::spawn(async move {
+        let cancellation = CancellationToken::new();
+        let handle = tokio::spawn(async move {
             let _flag = DropFlag(dropped_for_task);
             let _ = started_tx.send(());
             std::future::pending::<()>().await;
-        })];
+        });
+        let mut prompt_tasks = vec![PromptTask {
+            cancellation,
+            handle,
+        }];
         started_rx.await.expect("prompt task started");
 
         let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("tab-1".to_string(), 1)])));
-        let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
-        let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
-            "tab-1".to_string(),
-            PromptCancelEntry::Registered {
-                prompt_id: 1,
-                signal: cancel_tx,
-            },
-        )])));
         let intentional_shutdown = std::sync::atomic::AtomicBool::new(false);
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         let mut io_task = tokio::spawn(async {});
@@ -5825,15 +6035,18 @@ mod tests {
             result = &mut io_task => result,
             _ = std::future::pending::<()>() => unreachable!("perpetual refetch cannot win"),
         };
-        let exit = complete_transport_shutdown(
-            io_result,
-            &intentional_shutdown,
-            &event_tx,
-            &mut prompt_tasks,
-            &in_flight_tabs,
-            &cancel_signals,
+        let exit = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            complete_transport_shutdown(
+                io_result,
+                &intentional_shutdown,
+                &event_tx,
+                &mut prompt_tasks,
+                &in_flight_tabs,
+            ),
         )
-        .await;
+        .await
+        .expect("transport shutdown must not wait for provider cooperation");
 
         assert_eq!(exit, AcpClientExit::ChannelsClosed);
         assert!(matches!(
@@ -5843,7 +6056,6 @@ mod tests {
         assert!(event_rx.try_recv().is_err(), "disconnect must be sent once");
         assert!(prompt_tasks.is_empty());
         assert!(in_flight_tabs.lock().unwrap().is_empty());
-        assert!(cancel_signals.lock().unwrap().is_empty());
         assert!(dropped.load(std::sync::atomic::Ordering::Acquire));
     }
 
@@ -5853,7 +6065,6 @@ mod tests {
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         let mut prompt_tasks = Vec::new();
         let in_flight_tabs = Arc::new(Mutex::new(HashMap::new()));
-        let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
         let io_result = tokio::spawn(async {}).await;
 
         let exit = complete_transport_shutdown(
@@ -5862,7 +6073,6 @@ mod tests {
             &event_tx,
             &mut prompt_tasks,
             &in_flight_tabs,
-            &cancel_signals,
         )
         .await;
 
@@ -5871,7 +6081,7 @@ mod tests {
     }
 
     #[test]
-    fn stop_prompt_tasks_aborts_pre_prompt_work_and_clears_tracking() {
+    fn rebind_or_shutdown_reaps_preparation_task_that_ignores_cancel() {
         struct DropFlag(Arc<std::sync::atomic::AtomicBool>);
         impl Drop for DropFlag {
             fn drop(&mut self) {
@@ -5886,29 +6096,50 @@ mod tests {
         tokio::task::LocalSet::new().block_on(&runtime, async {
             let dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
             let dropped_for_task = Arc::clone(&dropped);
-            let mut tasks = vec![tokio::task::spawn_local(async move {
+            let cancellation = CancellationToken::new();
+            let handle = tokio::task::spawn_local(async move {
                 let _flag = DropFlag(dropped_for_task);
                 std::future::pending::<()>().await;
-            })];
+            });
+            let mut tasks = vec![PromptTask {
+                cancellation,
+                handle,
+            }];
             tokio::task::yield_now().await;
 
             let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("tab-1".to_string(), 1)])));
-            let (cancel_tx, _cancel_rx) = tokio::sync::oneshot::channel();
-            let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
-                "tab-1".to_string(),
-                PromptCancelEntry::Registered {
-                    prompt_id: 1,
-                    signal: cancel_tx,
-                },
-            )])));
 
-            stop_prompt_tasks(&mut tasks, &in_flight_tabs, &cancel_signals).await;
+            tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                stop_prompt_tasks(&mut tasks, &in_flight_tabs),
+            )
+            .await
+            .expect("rebind/shutdown must abort non-cooperative prompt preparation");
 
             assert!(tasks.is_empty());
             assert!(in_flight_tabs.lock().unwrap().is_empty());
-            assert!(cancel_signals.lock().unwrap().is_empty());
             assert!(dropped.load(std::sync::atomic::Ordering::Acquire));
         });
+    }
+
+    #[test]
+    fn transport_retirement_cancels_and_drains_queued_prompts() {
+        let (prompt_tx, mut prompt_rx) = mpsc::unbounded_channel();
+        let first = PromptSubmission::new("first".into(), None);
+        let second = PromptSubmission::new("second".into(), None);
+        let first_token = first.cancellation_token();
+        let second_token = second.cancellation_token();
+        prompt_tx.send(first).unwrap();
+        prompt_tx.send(second).unwrap();
+
+        retire_queued_prompt_submissions(&mut prompt_rx);
+
+        assert!(first_token.is_cancelled());
+        assert!(second_token.is_cancelled());
+        assert!(prompt_rx.try_recv().is_err());
+        assert!(prompt_tx
+            .send(PromptSubmission::new("late".into(), None))
+            .is_err());
     }
 
     #[test]

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -5259,7 +5259,14 @@ async fn dispatch_prompt_body(
             );
             if prompt_started.get() {
                 drop(tracked_prompt_fut);
+                // ACP updates identify only the session, not the prompt. Do
+                // not synthesize completion on a timeout unless master can
+                // atomically retire this exact session; otherwise late output
+                // can be attached to the next turn on the same session.
                 let _ = (&mut prompt_fut).await;
+                // Some providers flush trailing chunks just after returning
+                // PromptResponse, so a scheduler yield is not a sufficient
+                // compatibility drain here.
                 tokio::time::sleep(std::time::Duration::from_millis(50)).await;
             }
             let _ = event_tx_task.send(AppEvent::AgentMessageEnd {

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -125,6 +125,28 @@ struct PromptCancelEntry {
 
 type SharedPromptCancelRegistry = Arc<std::sync::Mutex<HashMap<String, PromptCancelEntry>>>;
 
+struct PromptDispatchCleanup {
+    tab_key: String,
+    prompt_id: u64,
+    in_flight_tabs: Arc<std::sync::Mutex<HashSet<String>>>,
+    cancel_signals: SharedPromptCancelRegistry,
+}
+
+impl Drop for PromptDispatchCleanup {
+    fn drop(&mut self) {
+        {
+            let mut registry = self.cancel_signals.lock().unwrap();
+            if registry
+                .get(&self.tab_key)
+                .is_some_and(|entry| entry.prompt_id == self.prompt_id)
+            {
+                registry.remove(&self.tab_key);
+            }
+        }
+        self.in_flight_tabs.lock().unwrap().remove(&self.tab_key);
+    }
+}
+
 /// User-initiated request to spin up a fresh ACP session for a given tab,
 /// dropping the previous session's history. Emitted by the `/new` slash
 /// command. The ACP client task removes the old SessionId from its
@@ -4813,6 +4835,13 @@ async fn dispatch_prompt_body(
     proposal_commands_supported: bool,
     proposal_channels: Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
 ) {
+    let _cleanup = PromptDispatchCleanup {
+        tab_key: tab_key_task.clone(),
+        prompt_id: prompt.id,
+        in_flight_tabs: Arc::clone(&in_flight_tabs_task),
+        cancel_signals: Arc::clone(&cancel_signals_task),
+    };
+
     // Resolve (or lazily create) the ACP session for this tab.
     let (prompt_session_id, lazy_yolo_operation) = {
         let mut g = tab_to_session_task.lock().await;
@@ -4842,7 +4871,6 @@ async fn dispatch_prompt_body(
                         failure: AgentFailure::from_acp_error(&e),
                         message: format!("new_session failed for tab {}: {}", tab_key_task, e),
                     });
-                    in_flight_tabs_task.lock().unwrap().remove(&tab_key_task);
                     return;
                 }
             };
@@ -4853,7 +4881,6 @@ async fn dispatch_prompt_body(
                     session_id = %new_session.session_id,
                     "abandoning prompt because its lazy session was retired during tab reset or close"
                 );
-                in_flight_tabs_task.lock().unwrap().remove(&tab_key_task);
                 return;
             }
             let new_sid = new_session.session_id.clone();
@@ -4946,7 +4973,6 @@ async fn dispatch_prompt_body(
                         restart_required,
                         result: Err(error),
                     });
-                    in_flight_tabs_task.lock().unwrap().remove(&tab_key_task);
                     return;
                 }
             }
@@ -4964,7 +4990,6 @@ async fn dispatch_prompt_body(
                         "ending first prompt with a retryable error because its lazy-session Yolo operation was superseded"
                     );
                     publish_retryable_lazy_yolo_error(&event_tx_task, &prompt_session_id_str);
-                    in_flight_tabs_task.lock().unwrap().remove(&tab_key_task);
                     return;
                 }
             }
@@ -4996,7 +5021,6 @@ async fn dispatch_prompt_body(
             },
             message,
         });
-        in_flight_tabs_task.lock().unwrap().remove(&tab_key_task);
         return;
     }
 
@@ -5020,7 +5044,6 @@ async fn dispatch_prompt_body(
             },
             message,
         });
-        in_flight_tabs_task.lock().unwrap().remove(&tab_key_task);
         return;
     }
 
@@ -5051,7 +5074,6 @@ async fn dispatch_prompt_body(
                 },
                 message,
             });
-            in_flight_tabs_task.lock().unwrap().remove(&tab_key_task);
             return;
         }
     }
@@ -5340,17 +5362,6 @@ async fn dispatch_prompt_body(
             }
         }
     }
-
-    {
-        let mut registry = cancel_signals_task.lock().unwrap();
-        if registry
-            .get(&tab_key_task)
-            .is_some_and(|entry| entry.prompt_id == prompt.id)
-        {
-            registry.remove(&tab_key_task);
-        }
-    }
-    in_flight_tabs_task.lock().unwrap().remove(&tab_key_task);
 }
 
 #[cfg(test)]
@@ -5362,8 +5373,8 @@ mod tests {
         inject_wta_pane_meta, is_redundant_startup_model_error, post_login_authenticate_error,
         session_mcp_tool_from_title, stop_prompt_tasks, timeout_result_failure_fields,
         tool_call_exit_code, tool_call_kind_label, tool_call_location_hint, tool_call_target,
-        AcpClientExit, ClientState, PromptCancelEntry, PromptTimingState, PromptUsageIdentity,
-        SessionMcpTool, SoftStopReason, WtaClient,
+        AcpClientExit, ClientState, PromptCancelEntry, PromptDispatchCleanup, PromptTimingState,
+        PromptUsageIdentity, SessionMcpTool, SoftStopReason, WtaClient,
     };
     use crate::app_contracts::AppEvent;
     use crate::protocol::acp::failure::{AgentFailure, HandshakeStage};
@@ -5371,6 +5382,41 @@ mod tests {
     use std::collections::{HashMap, HashSet};
     use std::sync::{Arc, Mutex};
     use tokio::sync::mpsc;
+
+    #[test]
+    fn prompt_dispatch_cleanup_preserves_newer_cancel_entry() {
+        let in_flight_tabs = Arc::new(Mutex::new(HashSet::from(["tab".to_string()])));
+        let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
+        let (newer_signal, mut newer_cancel) = tokio::sync::oneshot::channel();
+        cancel_signals.lock().unwrap().insert(
+            "tab".to_string(),
+            PromptCancelEntry {
+                prompt_id: 2,
+                signal: newer_signal,
+            },
+        );
+
+        drop(PromptDispatchCleanup {
+            tab_key: "tab".to_string(),
+            prompt_id: 1,
+            in_flight_tabs: Arc::clone(&in_flight_tabs),
+            cancel_signals: Arc::clone(&cancel_signals),
+        });
+
+        assert!(in_flight_tabs.lock().unwrap().is_empty());
+        assert_eq!(
+            cancel_signals
+                .lock()
+                .unwrap()
+                .get("tab")
+                .map(|entry| entry.prompt_id),
+            Some(2)
+        );
+        assert!(matches!(
+            newer_cancel.try_recv(),
+            Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+        ));
+    }
 
     #[test]
     fn fetch_target_strips_credentials_query_and_fragment() {

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -13,12 +13,14 @@
 //! harness and assert on real `App` state (see the spec, "option 2").
 
 use super::{
-    dispatch_cancel, dispatch_drop_session, dispatch_load_session, dispatch_master_ext_request,
-    dispatch_master_ext_request_with_yolo_timeout, dispatch_new_session, dispatch_prompt,
-    dispatch_rename_session, publish_current_native_config_options, take_retired_session_result,
-    AutofixTextKind, CancelRequest, DropSessionRequest, LoadSessionForTab, MasterExtRequest,
-    NewSessionForTab, PromptCancelEntry, PromptDispatchCleanup, PromptSubmission,
-    RenameSessionRequest,
+    dispatch_drop_session, dispatch_drop_session_with_aliases, dispatch_load_session,
+    dispatch_load_session_with_aliases, dispatch_master_ext_request,
+    dispatch_master_ext_request_with_yolo_timeout, dispatch_new_session,
+    dispatch_new_session_with_aliases, dispatch_prompt, dispatch_prompt_with_aliases,
+    dispatch_rename_session, dispatch_rename_session_with_aliases, finalize_client_transport,
+    publish_current_native_config_options, take_retired_session_result, AutofixTextKind,
+    ClientTransportGuard, DropSessionRequest, LoadSessionForTab, MasterExtRequest,
+    NewSessionForTab, PromptSubmission, RenameSessionRequest,
 };
 use super::{ClientState, PromptUsageIdentity, ProviderProbeCapture, WtaClient};
 use crate::app_contracts::{AppEvent, PlanEntry, PlanEntryStatus};
@@ -30,8 +32,11 @@ use agent_client_protocol as acp;
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
-use tokio::sync::{mpsc, oneshot, OnceCell};
-use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use tokio::sync::{mpsc, OnceCell};
+use tokio_util::{
+    compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt},
+    sync::CancellationToken,
+};
 
 /// What the mock does when it receives a `prompt`.
 #[derive(Clone, Copy)]
@@ -85,6 +90,9 @@ struct MockAgent {
     /// When set, `new_session` returns an error instead of a session id —
     /// simulates the agent/transport dropping during session establishment.
     fail_new_session: Arc<AtomicBool>,
+    block_new_session: Arc<AtomicBool>,
+    new_session_started: Arc<tokio::sync::Notify>,
+    new_session_release: Arc<tokio::sync::Notify>,
     /// When set, `load_session` returns an error instead of a response —
     /// simulates the agent not recognizing the session id / `session/load`
     /// being unsupported.
@@ -92,6 +100,9 @@ struct MockAgent {
     /// When set, `load_session` sleeps long enough that a short injected
     /// dispatch timeout elapses first — exercises the timeout path.
     slow_load: Arc<AtomicBool>,
+    block_load_session: Arc<AtomicBool>,
+    load_session_started: Arc<tokio::sync::Notify>,
+    load_session_release: Arc<tokio::sync::Notify>,
     new_session_advertises_native_yolo: Arc<AtomicBool>,
     new_session_starts_in_native_yolo: Arc<AtomicBool>,
     fail_native_updates: Arc<AtomicBool>,
@@ -160,6 +171,10 @@ impl MockAgent {
         &self,
         _args: acp::schema::v1::NewSessionRequest,
     ) -> acp::Result<acp::schema::v1::NewSessionResponse> {
+        if self.block_new_session.load(Ordering::SeqCst) {
+            self.new_session_started.notify_one();
+            self.new_session_release.notified().await;
+        }
         if self.fail_new_session.load(Ordering::SeqCst) {
             return Err(acp::Error::internal_error().data("mock new_session failure".to_string()));
         }
@@ -456,6 +471,10 @@ impl MockAgent {
         &self,
         _args: acp::schema::v1::LoadSessionRequest,
     ) -> acp::Result<acp::schema::v1::LoadSessionResponse> {
+        if self.block_load_session.load(Ordering::SeqCst) {
+            self.load_session_started.notify_one();
+            self.load_session_release.notified().await;
+        }
         if self.slow_load.load(Ordering::SeqCst) {
             // Outlast any short injected dispatch timeout so the
             // dispatcher takes its `Err(_)` (timeout) branch, but stay
@@ -515,8 +534,14 @@ fn connect_with(
         seen_config_updates: Arc::new(Mutex::new(Vec::new())),
         close_tab_requests: Arc::new(Mutex::new(Vec::new())),
         fail_new_session: Arc::new(AtomicBool::new(false)),
+        block_new_session: Arc::new(AtomicBool::new(false)),
+        new_session_started: Arc::new(tokio::sync::Notify::new()),
+        new_session_release: Arc::new(tokio::sync::Notify::new()),
         fail_load_session: Arc::new(AtomicBool::new(false)),
         slow_load: Arc::new(AtomicBool::new(false)),
+        block_load_session: Arc::new(AtomicBool::new(false)),
+        load_session_started: Arc::new(tokio::sync::Notify::new()),
+        load_session_release: Arc::new(tokio::sync::Notify::new()),
         new_session_advertises_native_yolo: Arc::new(AtomicBool::new(false)),
         new_session_starts_in_native_yolo: Arc::new(AtomicBool::new(false)),
         fail_native_updates: Arc::new(AtomicBool::new(false)),
@@ -872,18 +897,23 @@ pub(crate) struct DispatchHarness {
     /// Agent-side record of every image content block (mime, base64) assembled
     /// onto the wire — the Alt+V image-paste assertion target.
     pub seen_images: Arc<Mutex<Vec<(String, String)>>>,
-    pub closed_sessions: Arc<Mutex<Vec<String>>>,
     pub seen_config_updates: Arc<Mutex<Vec<(String, String)>>>,
     pub close_tab_requests: Arc<Mutex<Vec<String>>>,
     /// Flip to `true` before dispatching to make the mock's `new_session`
     /// fail, exercising the dispatcher's session-establishment error path.
     pub fail_new_session: Arc<AtomicBool>,
+    pub block_new_session: Arc<AtomicBool>,
+    pub new_session_started: Arc<tokio::sync::Notify>,
+    pub new_session_release: Arc<tokio::sync::Notify>,
     /// Flip to `true` before dispatching to make the mock's `load_session`
     /// return an error, exercising the resume-failure path.
     pub fail_load_session: Arc<AtomicBool>,
     /// Flip to `true` before dispatching to make the mock's `load_session`
     /// sleep past a short injected timeout, exercising the resume-timeout path.
     pub slow_load: Arc<AtomicBool>,
+    pub block_load_session: Arc<AtomicBool>,
+    pub load_session_started: Arc<tokio::sync::Notify>,
+    pub load_session_release: Arc<tokio::sync::Notify>,
     pub new_session_advertises_native_yolo: Arc<AtomicBool>,
     pub new_session_starts_in_native_yolo: Arc<AtomicBool>,
     pub fail_native_updates: Arc<AtomicBool>,
@@ -925,8 +955,14 @@ fn connect_for_dispatch(behavior: MockBehavior) -> DispatchHarness {
     let seen_config_updates = Arc::new(Mutex::new(Vec::new()));
     let close_tab_requests = Arc::new(Mutex::new(Vec::new()));
     let fail_new_session = Arc::new(AtomicBool::new(false));
+    let block_new_session = Arc::new(AtomicBool::new(false));
+    let new_session_started = Arc::new(tokio::sync::Notify::new());
+    let new_session_release = Arc::new(tokio::sync::Notify::new());
     let fail_load_session = Arc::new(AtomicBool::new(false));
     let slow_load = Arc::new(AtomicBool::new(false));
+    let block_load_session = Arc::new(AtomicBool::new(false));
+    let load_session_started = Arc::new(tokio::sync::Notify::new());
+    let load_session_release = Arc::new(tokio::sync::Notify::new());
     let new_session_advertises_native_yolo = Arc::new(AtomicBool::new(false));
     let new_session_starts_in_native_yolo = Arc::new(AtomicBool::new(false));
     let fail_native_updates = Arc::new(AtomicBool::new(false));
@@ -946,8 +982,14 @@ fn connect_for_dispatch(behavior: MockBehavior) -> DispatchHarness {
         seen_config_updates: seen_config_updates.clone(),
         close_tab_requests: close_tab_requests.clone(),
         fail_new_session: fail_new_session.clone(),
+        block_new_session: block_new_session.clone(),
+        new_session_started: new_session_started.clone(),
+        new_session_release: new_session_release.clone(),
         fail_load_session: fail_load_session.clone(),
         slow_load: slow_load.clone(),
+        block_load_session: block_load_session.clone(),
+        load_session_started: load_session_started.clone(),
+        load_session_release: load_session_release.clone(),
         new_session_advertises_native_yolo: new_session_advertises_native_yolo.clone(),
         new_session_starts_in_native_yolo: new_session_starts_in_native_yolo.clone(),
         fail_native_updates: fail_native_updates.clone(),
@@ -971,12 +1013,17 @@ fn connect_for_dispatch(behavior: MockBehavior) -> DispatchHarness {
         seen_cancels,
         permission_outcome,
         seen_images,
-        closed_sessions,
         seen_config_updates,
         close_tab_requests,
         fail_new_session,
+        block_new_session,
+        new_session_started,
+        new_session_release,
         fail_load_session,
         slow_load,
+        block_load_session,
+        load_session_started,
+        load_session_release,
         new_session_advertises_native_yolo,
         new_session_starts_in_native_yolo,
         fail_native_updates,
@@ -987,18 +1034,15 @@ fn connect_for_dispatch(behavior: MockBehavior) -> DispatchHarness {
     }
 }
 
-/// Fresh, empty per-tab dispatcher state (session map, single-flight set,
-/// cancel registry, template memo) for one `dispatch_prompt` invocation.
+/// Fresh, empty per-tab dispatcher state for one `dispatch_prompt` invocation.
 #[allow(clippy::type_complexity)]
 fn fresh_dispatch_state() -> (
     Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
     Arc<std::sync::Mutex<HashMap<String, u64>>>,
-    Arc<std::sync::Mutex<HashMap<String, PromptCancelEntry>>>,
     TemplateMemo,
 ) {
     (
         Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-        Arc::new(std::sync::Mutex::new(HashMap::new())),
         Arc::new(std::sync::Mutex::new(HashMap::new())),
         TemplateMemo::default(),
     )
@@ -1007,6 +1051,7 @@ fn fresh_dispatch_state() -> (
 fn test_prompt(id: u64, text: &str, is_autofix: bool) -> PromptSubmission {
     PromptSubmission {
         id,
+        cancellation: CancellationToken::new(),
         text: text.to_string(),
         pane_context: None,
         submitted_at_unix_s: 0.0,
@@ -1080,7 +1125,7 @@ async fn dispatch_prompt_busy_tab_emits_agent_busy_and_drops() {
     local
         .run_until(async {
             let h = connect_for_dispatch(MockBehavior::Reply);
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             // A turn is already running for the default tab ("0").
             in_flight.lock().unwrap().insert("0".to_string(), 0);
             let mut event_rx = h.event_rx;
@@ -1091,7 +1136,6 @@ async fn dispatch_prompt_busy_tab_emits_agent_busy_and_drops() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -1137,7 +1181,7 @@ async fn copilot_permission_regression_blocks_prompt_when_yolo_is_off() {
                 .expect("initialize failed");
             let session_id =
                 record_copilot_yolo_state(&h, "affected-copilot-disabled-session", "off");
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             tab_to_session
                 .lock()
                 .await
@@ -1149,7 +1193,6 @@ async fn copilot_permission_regression_blocks_prompt_when_yolo_is_off() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -1202,7 +1245,7 @@ async fn copilot_permission_regression_preserves_missing_capability_interactive_
                 ))
                 .await
                 .expect("initialize failed");
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
 
             dispatch_prompt(
                 test_prompt(1, "unsupported capability remains interactive", false),
@@ -1210,7 +1253,6 @@ async fn copilot_permission_regression_preserves_missing_capability_interactive_
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -1252,7 +1294,7 @@ async fn copilot_permission_regression_blocks_acknowledged_off_with_global_on() 
                 .await
                 .expect("initialize failed");
             let session_id = record_copilot_yolo_state(&h, "manual-config-disabled-session", "on");
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             tab_to_session
                 .lock()
                 .await
@@ -1296,7 +1338,6 @@ async fn copilot_permission_regression_blocks_acknowledged_off_with_global_on() 
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -1343,7 +1384,7 @@ async fn manual_native_enable_with_global_off_allows_prompt_after_ack() {
                 .await
                 .expect("initialize failed");
             let session_id = record_copilot_yolo_state(&h, "manual-config-enabled-session", "off");
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             tab_to_session
                 .lock()
                 .await
@@ -1387,7 +1428,6 @@ async fn manual_native_enable_with_global_off_allows_prompt_after_ack() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -1428,7 +1468,7 @@ async fn copilot_permission_regression_allows_explicit_yolo_prompt() {
                 ))
                 .await
                 .expect("initialize failed");
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
 
             dispatch_prompt(
                 test_prompt(1, "explicit Yolo may reach Copilot", false),
@@ -1436,7 +1476,6 @@ async fn copilot_permission_regression_allows_explicit_yolo_prompt() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -1487,7 +1526,7 @@ async fn copilot_permission_regression_rechecks_hot_disable_at_send_boundary() {
                     release: Arc::clone(&context_release),
                 },
             )));
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             tab_to_session
                 .lock()
                 .await
@@ -1507,7 +1546,6 @@ async fn copilot_permission_regression_rechecks_hot_disable_at_send_boundary() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -1584,7 +1622,7 @@ async fn hot_policy_blocks_acknowledged_on_before_send_boundary() {
                     release: Arc::clone(&context_release),
                 },
             )));
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             tab_to_session
                 .lock()
                 .await
@@ -1604,7 +1642,6 @@ async fn hot_policy_blocks_acknowledged_on_before_send_boundary() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -1665,7 +1702,7 @@ async fn superseding_disable_with_enable_keeps_prompt_blocked_until_enable_ack()
                 .unwrap()
                 .update_runtime(true, false);
             let session_id = record_copilot_yolo_state(&h, "superseded-disable-session", "on");
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             tab_to_session
                 .lock()
                 .await
@@ -1709,7 +1746,6 @@ async fn superseding_disable_with_enable_keeps_prompt_blocked_until_enable_ack()
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -1758,7 +1794,7 @@ async fn copilot_last_good_permission_version_keeps_prompt_path_available() {
                 ))
                 .await
                 .expect("initialize failed");
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
 
             dispatch_prompt(
                 test_prompt(1, "safe Copilot may request permission", false),
@@ -1766,7 +1802,6 @@ async fn copilot_last_good_permission_version_keeps_prompt_path_available() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -1803,7 +1838,7 @@ async fn dispatch_prompt_round_trips_through_agent() {
                 .await
                 .expect("initialize failed");
 
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             let mut event_rx = h.event_rx;
 
             dispatch_prompt(
@@ -1812,7 +1847,6 @@ async fn dispatch_prompt_round_trips_through_agent() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -1896,7 +1930,7 @@ async fn lazy_session_disables_native_yolo_before_first_prompt() {
                 ))
                 .await
                 .expect("initialize failed");
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
 
             dispatch_prompt(
                 test_prompt(1, "must wait", false),
@@ -1904,7 +1938,6 @@ async fn lazy_session_disables_native_yolo_before_first_prompt() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -1966,7 +1999,7 @@ async fn superseded_lazy_yolo_operation_reports_retryable_error_instead_of_silen
                 ))
                 .await
                 .expect("initialize failed");
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
 
             dispatch_prompt(
                 test_prompt(1, "must receive a retryable result", false),
@@ -1974,7 +2007,6 @@ async fn superseded_lazy_yolo_operation_reports_retryable_error_instead_of_silen
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -2117,14 +2149,13 @@ async fn policy_blocked_lazy_yolo_operation_reports_retryable_error_instead_of_s
             .await
             .expect("blocking native update did not acquire the session gate");
 
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             dispatch_prompt(
                 test_prompt(1, "must receive a policy error", false),
                 &h.conn,
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -2229,7 +2260,7 @@ async fn native_yolo_active_permission_request_remains_pending_for_user() {
                 ))
                 .await
                 .expect("initialize failed");
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
 
             dispatch_prompt(
                 test_prompt(1, "permission after native Yolo", false),
@@ -2237,7 +2268,6 @@ async fn native_yolo_active_permission_request_remains_pending_for_user() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -2323,7 +2353,7 @@ async fn lazy_session_native_disable_failure_keeps_first_prompt_blocked() {
                 ))
                 .await
                 .expect("initialize failed");
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
 
             dispatch_prompt(
                 test_prompt(1, "must never send", false),
@@ -2331,7 +2361,6 @@ async fn lazy_session_native_disable_failure_keeps_first_prompt_blocked() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -2381,7 +2410,7 @@ async fn dispatch_agent_command_reaches_agent_verbatim() {
                 .await
                 .expect("initialize failed");
 
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             let mut prompt = test_prompt(1, "/usage", false);
             prompt.agent_command = true;
 
@@ -2391,7 +2420,6 @@ async fn dispatch_agent_command_reaches_agent_verbatim() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -2471,7 +2499,7 @@ async fn policy_block_allows_nonprivileged_or_non_copilot_agent_commands() {
                     .unwrap()
                     .update_runtime(false, true);
 
-                let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+                let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
                 let mut prompt = test_prompt(1, command, false);
                 prompt.agent_command = true;
 
@@ -2481,7 +2509,6 @@ async fn policy_block_allows_nonprivileged_or_non_copilot_agent_commands() {
                     &tab_to_session,
                     &memo,
                     &in_flight,
-                    &cancel_signals,
                     &h.event_tx,
                     &h.shell_mgr,
                     &h.prompt_timing,
@@ -2527,7 +2554,7 @@ async fn policy_block_rejects_copilot_allow_all_agent_command_before_acp() {
                 .unwrap()
                 .update_runtime(false, true);
 
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             let mut prompt = test_prompt(1, "/allow_all", false);
             prompt.agent_command = true;
 
@@ -2537,7 +2564,6 @@ async fn policy_block_rejects_copilot_allow_all_agent_command_before_acp() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -2593,14 +2619,13 @@ async fn policy_block_rejects_copilot_allow_all_before_command_classification() 
                 .unwrap()
                 .update_runtime(false, true);
 
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             dispatch_prompt(
                 test_prompt(1, "/allow_all", false),
                 &h.conn,
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -2647,7 +2672,7 @@ async fn dispatch_prompt_does_not_advertise_unavailable_proposals() {
                 .await
                 .expect("initialize failed");
 
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             let mut event_rx = h.event_rx;
             dispatch_prompt(
                 test_prompt(1, "hello from WSL", false),
@@ -2655,7 +2680,6 @@ async fn dispatch_prompt_does_not_advertise_unavailable_proposals() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -2717,7 +2741,7 @@ async fn dispatch_prompt_sends_clipboard_image_to_agent() {
                 .await
                 .expect("initialize failed");
 
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             let mut event_rx = h.event_rx;
 
             // The user typed text *and* pasted an image, then pressed Enter.
@@ -2730,7 +2754,6 @@ async fn dispatch_prompt_sends_clipboard_image_to_agent() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -2789,7 +2812,7 @@ async fn dispatch_prompt_new_session_failure_emits_error_and_releases_slot() {
             // Make the mock reject session establishment.
             h.fail_new_session.store(true, Ordering::SeqCst);
 
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             let mut event_rx = h.event_rx;
 
             dispatch_prompt(
@@ -2798,7 +2821,6 @@ async fn dispatch_prompt_new_session_failure_emits_error_and_releases_slot() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -2811,23 +2833,25 @@ async fn dispatch_prompt_new_session_failure_emits_error_and_releases_slot() {
             );
 
             match tokio::time::timeout(std::time::Duration::from_secs(5), event_rx.recv()).await {
-                Ok(Some(AppEvent::AgentError { message, .. })) => {
+                Ok(Some(AppEvent::PromptError {
+                    tab_id,
+                    prompt_id,
+                    message,
+                })) => {
+                    assert_eq!(tab_id, "0");
+                    assert_eq!(prompt_id, 1);
                     assert!(
                         message.contains("new_session failed"),
                         "error must name the failed step; got {message:?}"
                     );
                 }
-                _ => panic!("expected AgentError, got nothing"),
+                _ => panic!("expected PromptError, got nothing"),
             }
             // The slot is released so a retry isn't permanently blocked, no
             // session was cached, and the agent never saw the prompt.
             assert!(
                 in_flight.lock().unwrap().is_empty(),
                 "single-flight slot must be released on new_session failure"
-            );
-            assert!(
-                cancel_signals.lock().unwrap().is_empty(),
-                "new_session failure must remove the prompt's cancel entry"
             );
             assert!(tab_to_session.lock().await.is_empty());
             assert!(h.seen_prompts.lock().unwrap().is_empty());
@@ -2850,7 +2874,7 @@ async fn dispatch_prompt_first_autofix_includes_base_and_overlay() {
                 .await
                 .expect("initialize failed");
 
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             let mut event_rx = h.event_rx;
 
             dispatch_prompt(
@@ -2859,7 +2883,6 @@ async fn dispatch_prompt_first_autofix_includes_base_and_overlay() {
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -2890,18 +2913,13 @@ async fn dispatch_prompt_first_autofix_includes_base_and_overlay() {
         .await;
 }
 
-/// `dispatch_rename_session` must rekey an existing tab binding from the old
-/// tab id to the new one (cross-window drag), preserving the SessionId, and
-/// be a no-op when the old tab id is absent.
 #[tokio::test]
-async fn dispatch_rename_session_rekeys_existing_and_ignores_missing() {
+async fn dispatch_rename_session_rekeys_session_and_in_flight_owner() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            let h = connect_for_dispatch(MockBehavior::Reply);
-            let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
-            let in_flight_tabs = Arc::new(Mutex::new(HashMap::new()));
+            let tab_to_session = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+            let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("old-tab".to_string(), 7)])));
             let sid = acp::schema::v1::SessionId::new("sess-rekey");
             super::set_helper_owner_tab_id(Some("old-tab"));
             tab_to_session
@@ -2909,412 +2927,119 @@ async fn dispatch_rename_session_rekeys_existing_and_ignores_missing() {
                 .await
                 .insert("old-tab".to_string(), sid.clone());
 
-            // Rekey old-tab -> new-tab.
             dispatch_rename_session(
                 RenameSessionRequest {
                     old_tab_id: "old-tab".to_string(),
                     new_tab_id: "new-tab".to_string(),
                 },
-                &h.conn,
                 &tab_to_session,
-                &cancel_signals,
-                &in_flight_tabs,
-            )
-            .await;
-            {
-                let g = tab_to_session.lock().await;
-                assert!(!g.contains_key("old-tab"));
-                assert_eq!(g.get("new-tab"), Some(&sid));
-            }
-            assert_eq!(
-                super::helper_owner_tab_id().as_deref(),
-                Some("new-tab"),
-                "future session metadata must use the dragged tab id"
-            );
-
-            // No-op: renaming a ghost tab leaves the map untouched.
-            dispatch_rename_session(
-                RenameSessionRequest {
-                    old_tab_id: "ghost".to_string(),
-                    new_tab_id: "phantom".to_string(),
-                },
-                &h.conn,
-                &tab_to_session,
-                &cancel_signals,
-                &in_flight_tabs,
-            )
-            .await;
-            let g = tab_to_session.lock().await;
-            assert!(!g.contains_key("phantom"), "missing old id must be a no-op");
-            assert!(
-                g.contains_key("new-tab"),
-                "existing binding must survive the no-op"
-            );
-        })
-        .await;
-}
-
-#[tokio::test]
-async fn dispatch_rename_session_rekeys_registered_cancellation_and_in_flight_owner() {
-    let local = tokio::task::LocalSet::new();
-    local
-        .run_until(async {
-            let h = connect_for_dispatch(MockBehavior::Reply);
-            let tab_to_session = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let (signal, cancelled) = oneshot::channel();
-            let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
-                "old-tab".to_string(),
-                PromptCancelEntry::Registered {
-                    prompt_id: 7,
-                    signal,
-                },
-            )])));
-            let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("old-tab".to_string(), 7)])));
-
-            dispatch_rename_session(
-                RenameSessionRequest {
-                    old_tab_id: "old-tab".to_string(),
-                    new_tab_id: "new-tab".to_string(),
-                },
-                &h.conn,
-                &tab_to_session,
-                &cancel_signals,
                 &in_flight_tabs,
             )
             .await;
 
+            let sessions = tab_to_session.lock().await;
+            assert!(!sessions.contains_key("old-tab"));
+            assert_eq!(sessions.get("new-tab"), Some(&sid));
+            drop(sessions);
             assert_eq!(
                 in_flight_tabs.lock().unwrap().get("new-tab").copied(),
                 Some(7)
             );
-            assert!(!in_flight_tabs.lock().unwrap().contains_key("old-tab"));
-            dispatch_cancel(
-                CancelRequest {
-                    tab_id: "new-tab".to_string(),
-                    prompt_id: 7,
-                    session_id: None,
-                },
-                &h.conn,
-                &cancel_signals,
-            );
-            assert!(
-                cancelled.await.is_ok(),
-                "cancel under the renamed tab id must signal the original prompt"
-            );
+            assert_eq!(super::helper_owner_tab_id().as_deref(), Some("new-tab"));
         })
         .await;
 }
 
 #[tokio::test]
-async fn dispatch_rename_session_rekeys_pending_cancellation() {
+async fn alias_chain_and_stale_cleanup_preserve_newer_prompt_owner() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            let h = connect_for_dispatch(MockBehavior::Reply);
             let tab_to_session = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
-                "old-tab".to_string(),
-                PromptCancelEntry::Pending { prompt_id: 9 },
-            )])));
-            let in_flight_tabs = Arc::new(Mutex::new(HashMap::new()));
+            let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("old-tab".to_string(), 7)])));
+            let tab_aliases = Arc::new(Mutex::new(HashMap::new()));
+            let tab_binding_generations = Arc::new(Mutex::new(HashMap::new()));
 
-            dispatch_rename_session(
+            dispatch_rename_session_with_aliases(
                 RenameSessionRequest {
                     old_tab_id: "old-tab".to_string(),
+                    new_tab_id: "middle-tab".to_string(),
+                },
+                &tab_to_session,
+                &in_flight_tabs,
+                &tab_aliases,
+                &tab_binding_generations,
+            )
+            .await;
+            in_flight_tabs
+                .lock()
+                .unwrap()
+                .insert("middle-tab".to_string(), 8);
+            dispatch_rename_session_with_aliases(
+                RenameSessionRequest {
+                    old_tab_id: "middle-tab".to_string(),
                     new_tab_id: "new-tab".to_string(),
                 },
-                &h.conn,
                 &tab_to_session,
-                &cancel_signals,
                 &in_flight_tabs,
+                &tab_aliases,
+                &tab_binding_generations,
             )
             .await;
 
-            let registry = cancel_signals.lock().unwrap();
-            assert!(!registry.contains_key("old-tab"));
-            assert_eq!(
-                registry.get("new-tab").map(PromptCancelEntry::prompt_id),
-                Some(9)
-            );
-        })
-        .await;
-}
-
-#[tokio::test]
-async fn dispatch_rename_session_merges_queued_cancel_with_registered_prompt() {
-    let local = tokio::task::LocalSet::new();
-    local
-        .run_until(async {
-            let h = connect_for_dispatch(MockBehavior::Reply);
-            let sid = acp::schema::v1::SessionId::new("sess-rename-cancel");
-            let tab_to_session = Arc::new(tokio::sync::Mutex::new(HashMap::from([(
-                "old-tab".to_string(),
-                sid,
-            )])));
-            let (signal, cancelled) = oneshot::channel();
-            let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
-                "old-tab".to_string(),
-                PromptCancelEntry::Registered {
-                    prompt_id: 11,
-                    signal,
-                },
-            )])));
-            let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("old-tab".to_string(), 11)])));
-
-            dispatch_cancel(
-                CancelRequest {
-                    tab_id: "new-tab".to_string(),
-                    prompt_id: 11,
-                    session_id: Some("sess-rename-cancel".to_string()),
-                },
-                &h.conn,
-                &cancel_signals,
-            );
-            assert_eq!(h.seen_cancels.load(Ordering::Acquire), 0);
-
-            dispatch_rename_session(
-                RenameSessionRequest {
-                    old_tab_id: "old-tab".to_string(),
-                    new_tab_id: "new-tab".to_string(),
-                },
-                &h.conn,
-                &tab_to_session,
-                &cancel_signals,
-                &in_flight_tabs,
-            )
-            .await;
-
-            assert!(
-                cancelled.await.is_ok(),
-                "registered prompt must be signalled"
-            );
-            for _ in 0..10 {
-                if h.seen_cancels.load(Ordering::Acquire) == 1 {
-                    break;
-                }
-                tokio::task::yield_now().await;
-            }
-            assert_eq!(h.seen_cancels.load(Ordering::Acquire), 1);
-            assert!(cancel_signals.lock().unwrap().is_empty());
-            assert_eq!(
-                *in_flight_tabs.lock().unwrap(),
-                HashMap::from([("new-tab".to_string(), 11)])
-            );
-
-            drop(PromptDispatchCleanup {
+            assert_eq!(super::resolve_tab_alias(&tab_aliases, "old-tab"), "new-tab");
+            drop(super::PromptDispatchCleanup {
                 tab_key: "old-tab".to_string(),
-                prompt_id: 11,
+                prompt_id: 7,
                 in_flight_tabs: Arc::clone(&in_flight_tabs),
-                cancel_signals: Arc::clone(&cancel_signals),
+                released: false,
             });
-            assert!(in_flight_tabs.lock().unwrap().is_empty());
+            assert_eq!(
+                in_flight_tabs.lock().unwrap().get("new-tab").copied(),
+                Some(8),
+                "stale cleanup must not release the newer prompt after chained rekeys"
+            );
         })
         .await;
 }
 
 #[tokio::test]
-async fn dispatch_rename_session_preserves_newer_destination_identity() {
+async fn queued_prompt_after_rename_uses_only_the_current_tab_alias() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
             let h = connect_for_dispatch(MockBehavior::Reply);
-            let sid = acp::schema::v1::SessionId::new("sess-stale-rename");
-            let tab_to_session = Arc::new(tokio::sync::Mutex::new(HashMap::from([(
-                "old-tab".to_string(),
-                sid,
-            )])));
-            let (old_signal, old_cancelled) = oneshot::channel();
-            let cancel_signals = Arc::new(Mutex::new(HashMap::from([
-                (
-                    "old-tab".to_string(),
-                    PromptCancelEntry::Registered {
-                        prompt_id: 7,
-                        signal: old_signal,
-                    },
-                ),
-                (
-                    "new-tab".to_string(),
-                    PromptCancelEntry::Pending { prompt_id: 8 },
-                ),
-            ])));
-            let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([
-                ("old-tab".to_string(), 7),
-                ("new-tab".to_string(), 8),
-            ])));
-
-            dispatch_rename_session(
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
+            let tab_aliases = Arc::new(Mutex::new(HashMap::new()));
+            let tab_binding_generations = Arc::new(Mutex::new(HashMap::new()));
+            dispatch_rename_session_with_aliases(
                 RenameSessionRequest {
                     old_tab_id: "old-tab".to_string(),
                     new_tab_id: "new-tab".to_string(),
                 },
-                &h.conn,
                 &tab_to_session,
-                &cancel_signals,
-                &in_flight_tabs,
+                &in_flight,
+                &tab_aliases,
+                &tab_binding_generations,
             )
             .await;
-
-            assert!(old_cancelled.await.is_ok(), "stale local prompt must stop");
-            tokio::task::yield_now().await;
-            assert_eq!(
-                h.seen_cancels.load(Ordering::Acquire),
-                0,
-                "a mismatched merge must not cancel the newer provider prompt"
-            );
-            assert_eq!(
-                cancel_signals
-                    .lock()
-                    .unwrap()
-                    .get("new-tab")
-                    .map(PromptCancelEntry::prompt_id),
-                Some(8)
-            );
-            assert_eq!(
-                *in_flight_tabs.lock().unwrap(),
-                HashMap::from([("new-tab".to_string(), 8)])
-            );
-        })
-        .await;
-}
-
-/// `dispatch_cancel` must signal only the matching tab/prompt pair and remove
-/// it from the registry. The agent-side `session/cancel` is best-effort.
-#[tokio::test]
-async fn dispatch_cancel_fires_local_signal_and_removes_registry_entry() {
-    let local = tokio::task::LocalSet::new();
-    local
-        .run_until(async {
-            let h = connect_for_dispatch(MockBehavior::Reply);
-            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
-            let (tx, rx) = oneshot::channel::<()>();
-            cancel_signals.lock().unwrap().insert(
-                "tab-cancel".to_string(),
-                PromptCancelEntry::Registered {
-                    prompt_id: 7,
-                    signal: tx,
-                },
-            );
-
-            dispatch_cancel(
-                CancelRequest {
-                    tab_id: "tab-cancel".to_string(),
-                    prompt_id: 7,
-                    session_id: Some("sess-cancel".to_string()),
-                },
-                &h.conn,
-                &cancel_signals,
-            );
-
-            // The local oneshot is fired synchronously inside dispatch_cancel.
-            assert!(rx.await.is_ok(), "local cancel signal must be fired");
-            assert!(
-                !cancel_signals.lock().unwrap().contains_key("tab-cancel"),
-                "the fired signal must be removed from the registry"
-            );
-
-            let (new_tx, mut new_rx) = oneshot::channel::<()>();
-            cancel_signals.lock().unwrap().insert(
-                "tab-cancel".to_string(),
-                PromptCancelEntry::Registered {
-                    prompt_id: 8,
-                    signal: new_tx,
-                },
-            );
-            dispatch_cancel(
-                CancelRequest {
-                    tab_id: "tab-cancel".to_string(),
-                    prompt_id: 7,
-                    session_id: Some("sess-cancel".to_string()),
-                },
-                &h.conn,
-                &cancel_signals,
-            );
-            assert!(
-                matches!(
-                    new_rx.try_recv(),
-                    Err(tokio::sync::oneshot::error::TryRecvError::Empty)
-                ),
-                "a stale cancel must not signal the newer prompt"
-            );
-            assert_eq!(
-                cancel_signals
-                    .lock()
-                    .unwrap()
-                    .get("tab-cancel")
-                    .map(PromptCancelEntry::prompt_id),
-                Some(8)
-            );
-            cancel_signals.lock().unwrap().remove("tab-cancel");
-
-            cancel_signals.lock().unwrap().insert(
-                "tab-pending".to_string(),
-                PromptCancelEntry::Pending { prompt_id: 10 },
-            );
-            dispatch_cancel(
-                CancelRequest {
-                    tab_id: "tab-pending".to_string(),
-                    prompt_id: 9,
-                    session_id: Some("sess-pending".to_string()),
-                },
-                &h.conn,
-                &cancel_signals,
-            );
-            assert_eq!(
-                cancel_signals
-                    .lock()
-                    .unwrap()
-                    .get("tab-pending")
-                    .map(PromptCancelEntry::prompt_id),
-                Some(10),
-                "a stale cancel must not replace a newer pending prompt"
-            );
-        })
-        .await;
-}
-
-#[tokio::test]
-async fn prompt_then_cancel_channels_latch_cancel_before_prompt_dispatch() {
-    let local = tokio::task::LocalSet::new();
-    local
-        .run_until(async {
-            let h = connect_for_dispatch(MockBehavior::Reply);
-            h.conn
-                .initialize(acp::schema::v1::InitializeRequest::new(
-                    acp::schema::ProtocolVersion::LATEST,
-                ))
-                .await
-                .expect("initialize failed");
-
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let mut prompt = test_prompt(81, "queued before rename", false);
+            prompt.pane_context = Some(crate::pane_context::PaneContext {
+                pane_id: None,
+                tab_id: Some("old-tab".to_string()),
+                window_id: None,
+                cwd: None,
+                source_pane_id: None,
+            });
             let mut event_rx = h.event_rx;
-            let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
-            let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::unbounded_channel();
-
-            prompt_tx
-                .send(test_prompt(1, "must never run", false))
-                .unwrap();
-            cancel_tx
-                .send(CancelRequest {
-                    tab_id: "0".to_string(),
-                    prompt_id: 1,
-                    session_id: Some("mock-session-1".to_string()),
-                })
-                .unwrap();
-
-            let cancel = tokio::select! {
-                biased;
-                req = cancel_rx.recv() => req.expect("cancel channel closed"),
-                _ = prompt_rx.recv() => panic!("production ordering must select cancel first"),
-            };
-            dispatch_cancel(cancel, &h.conn, &cancel_signals);
-            let prompt = prompt_rx.recv().await.expect("prompt channel closed");
-            dispatch_prompt(
+            let task = dispatch_prompt_with_aliases(
                 prompt,
                 &h.conn,
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
+                &tab_aliases,
+                &tab_binding_generations,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -3324,52 +3049,394 @@ async fn prompt_then_cancel_channels_latch_cancel_before_prompt_dispatch() {
                 false,
                 true,
                 &h.proposal_channels,
-            );
+            )
+            .expect("prompt must dispatch");
 
-            tokio::time::timeout(std::time::Duration::from_secs(5), async {
-                loop {
-                    match event_rx.recv().await {
-                        Some(AppEvent::PromptCancellationSettled {
-                            tab_id,
-                            prompt_id,
-                            session_id,
-                        }) => {
-                            assert_eq!(tab_id, "0");
-                            assert_eq!(prompt_id, 1);
-                            assert_eq!(session_id, None);
-                            break;
-                        }
-                        Some(AppEvent::AgentMessageChunk { .. }) => {
-                            panic!("cancelled prompt emitted agent output")
-                        }
-                        Some(_) => continue,
-                        None => panic!("event channel closed before cancellation settled"),
+            loop {
+                match event_rx.recv().await {
+                    Some(AppEvent::SessionAttached {
+                        tab_id, prompt_id, ..
+                    }) => {
+                        assert_eq!(tab_id, "new-tab");
+                        assert_eq!(prompt_id, Some(81));
+                        break;
                     }
+                    Some(_) => {}
+                    None => panic!("event channel closed before session attachment"),
                 }
-            })
-            .await
-            .expect("cancelled prompt did not reach its terminal boundary");
-            assert!(
-                h.seen_prompts.lock().unwrap().is_empty(),
-                "a latched cancel must prevent the old prompt from reaching the agent"
-            );
-            assert_eq!(
-                h.seen_cancels.load(Ordering::SeqCst),
-                0,
-                "a pre-registration cancel must not notify an unstarted ACP session"
-            );
-            assert!(
-                tab_to_session.lock().await.is_empty(),
-                "a queued cancellation must not lazily create a session"
-            );
-            assert!(in_flight.lock().unwrap().is_empty());
-            assert!(cancel_signals.lock().unwrap().is_empty());
+            }
+            task.handle.await.expect("prompt task failed");
+            let sessions = tab_to_session.lock().await;
+            assert!(!sessions.contains_key("old-tab"));
+            assert!(sessions.contains_key("new-tab"));
         })
         .await;
 }
 
 #[tokio::test]
-async fn registered_cancel_settles_after_prompt_finishes() {
+async fn in_progress_lazy_session_rename_binds_only_the_current_alias() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::Reply);
+            h.block_new_session.store(true, Ordering::SeqCst);
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
+            let tab_aliases = Arc::new(Mutex::new(HashMap::new()));
+            let tab_binding_generations = Arc::new(Mutex::new(HashMap::new()));
+            let mut prompt = test_prompt(82, "rename while creating", false);
+            prompt.pane_context = Some(crate::pane_context::PaneContext {
+                pane_id: None,
+                tab_id: Some("old-tab".to_string()),
+                window_id: None,
+                cwd: None,
+                source_pane_id: None,
+            });
+            let mut event_rx = h.event_rx;
+            let task = dispatch_prompt_with_aliases(
+                prompt,
+                &h.conn,
+                &tab_to_session,
+                &memo,
+                &in_flight,
+                &tab_aliases,
+                &tab_binding_generations,
+                &h.event_tx,
+                &h.shell_mgr,
+                &h.prompt_timing,
+                &h.client,
+                &PromptUsageIdentity::default(),
+                false,
+                false,
+                true,
+                &h.proposal_channels,
+            )
+            .expect("prompt must dispatch");
+
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                h.new_session_started.notified(),
+            )
+            .await
+            .expect("lazy session did not reach the controlled boundary");
+            dispatch_rename_session_with_aliases(
+                RenameSessionRequest {
+                    old_tab_id: "old-tab".to_string(),
+                    new_tab_id: "new-tab".to_string(),
+                },
+                &tab_to_session,
+                &in_flight,
+                &tab_aliases,
+                &tab_binding_generations,
+            )
+            .await;
+            h.new_session_release.notify_one();
+
+            loop {
+                match event_rx.recv().await {
+                    Some(AppEvent::SessionAttached {
+                        tab_id, prompt_id, ..
+                    }) => {
+                        assert_eq!(tab_id, "new-tab");
+                        assert_eq!(prompt_id, Some(82));
+                        break;
+                    }
+                    Some(_) => {}
+                    None => panic!("event channel closed before session attachment"),
+                }
+            }
+            task.handle.await.expect("prompt task failed");
+            let sessions = tab_to_session.lock().await;
+            assert!(!sessions.contains_key("old-tab"));
+            assert!(sessions.contains_key("new-tab"));
+            assert!(in_flight.lock().unwrap().is_empty());
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn retired_new_and_load_tasks_cannot_emit_after_replacement_starts() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::Reply);
+            h.block_new_session.store(true, Ordering::SeqCst);
+            let tab_to_session = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+            let tab_aliases = Arc::new(Mutex::new(HashMap::new()));
+            let tab_binding_generations = Arc::new(Mutex::new(HashMap::new()));
+            let memo = TemplateMemo::default();
+            let mut event_rx = h.event_rx;
+            let mut lifecycle_tasks = vec![dispatch_new_session_with_aliases(
+                NewSessionForTab {
+                    tab_id: "old-new-tab".to_string(),
+                    cwd: None,
+                },
+                &h.conn,
+                &tab_to_session,
+                &tab_aliases,
+                &tab_binding_generations,
+                &memo,
+                &h.event_tx,
+                Arc::clone(&h.client.state),
+                false,
+                false,
+                "RetiredNewTest",
+                &h.proposal_channels,
+                false,
+            )];
+
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                h.new_session_started.notified(),
+            )
+            .await
+            .expect("old /new task did not start");
+            let mut guard = ClientTransportGuard {
+                conn: h.conn.clone(),
+                suppress_transport_error: Arc::new(AtomicBool::new(true)),
+                event_tx: h.event_tx.clone(),
+                io_task: Some(tokio::task::spawn_local(std::future::pending::<()>())),
+                retirement_published: false,
+            };
+            let mut prompt_tasks = Vec::new();
+            let in_flight = Arc::new(Mutex::new(HashMap::new()));
+            finalize_client_transport(
+                &mut guard,
+                false,
+                &mut prompt_tasks,
+                &in_flight,
+                &mut lifecycle_tasks,
+            )
+            .await;
+            h.event_tx
+                .send(AppEvent::SessionAttached {
+                    tab_id: "replacement-tab".to_string(),
+                    session_id: "replacement-session".to_string(),
+                    prompt_id: None,
+                    available_models: Vec::new(),
+                    current_model_id: None,
+                })
+                .unwrap();
+            h.new_session_release.notify_one();
+
+            assert!(matches!(
+                event_rx.recv().await,
+                Some(AppEvent::AgentTransportRetired)
+            ));
+            assert!(matches!(
+                event_rx.recv().await,
+                Some(AppEvent::SessionAttached { tab_id, .. }) if tab_id == "replacement-tab"
+            ));
+            tokio::task::yield_now().await;
+            assert!(event_rx.try_recv().is_err());
+
+            let h = connect_for_dispatch(MockBehavior::Reply);
+            h.block_load_session.store(true, Ordering::SeqCst);
+            let tab_to_session = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+            let tab_aliases = Arc::new(Mutex::new(HashMap::new()));
+            let tab_binding_generations = Arc::new(Mutex::new(HashMap::new()));
+            let mut event_rx = h.event_rx;
+            let mut lifecycle_tasks = vec![dispatch_load_session_with_aliases(
+                LoadSessionForTab {
+                    tab_id: "old-load-tab".to_string(),
+                    session_id: "old-load-session".to_string(),
+                    cwd: None,
+                },
+                &h.conn,
+                &tab_to_session,
+                &tab_aliases,
+                &tab_binding_generations,
+                &h.event_tx,
+                Arc::clone(&h.client.state),
+                false,
+                false,
+                std::time::Duration::from_secs(5),
+                &h.proposal_channels,
+                false,
+            )];
+
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                h.load_session_started.notified(),
+            )
+            .await
+            .expect("old load task did not start");
+            let mut guard = ClientTransportGuard {
+                conn: h.conn.clone(),
+                suppress_transport_error: Arc::new(AtomicBool::new(true)),
+                event_tx: h.event_tx.clone(),
+                io_task: Some(tokio::task::spawn_local(std::future::pending::<()>())),
+                retirement_published: false,
+            };
+            let mut prompt_tasks = Vec::new();
+            let in_flight = Arc::new(Mutex::new(HashMap::new()));
+            finalize_client_transport(
+                &mut guard,
+                false,
+                &mut prompt_tasks,
+                &in_flight,
+                &mut lifecycle_tasks,
+            )
+            .await;
+            h.event_tx
+                .send(AppEvent::SessionAttached {
+                    tab_id: "replacement-tab".to_string(),
+                    session_id: "replacement-session".to_string(),
+                    prompt_id: None,
+                    available_models: Vec::new(),
+                    current_model_id: None,
+                })
+                .unwrap();
+            h.load_session_release.notify_one();
+
+            assert!(matches!(
+                event_rx.recv().await,
+                Some(AppEvent::AgentTransportRetired)
+            ));
+            assert!(matches!(
+                event_rx.recv().await,
+                Some(AppEvent::SessionAttached { tab_id, .. }) if tab_id == "replacement-tab"
+            ));
+            tokio::task::yield_now().await;
+            assert!(event_rx.try_recv().is_err());
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn setup_unwind_still_publishes_transport_retired() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::Reply);
+            let mut event_rx = h.event_rx;
+            let guard = ClientTransportGuard {
+                conn: h.conn,
+                suppress_transport_error: Arc::new(AtomicBool::new(true)),
+                event_tx: h.event_tx,
+                io_task: Some(tokio::task::spawn_local(async {})),
+                retirement_published: false,
+            };
+
+            drop(guard);
+
+            assert!(matches!(
+                tokio::time::timeout(std::time::Duration::from_secs(2), event_rx.recv())
+                    .await
+                    .expect("transport retirement was not published"),
+                Some(AppEvent::AgentTransportRetired)
+            ));
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn tab_reset_invalidates_queued_and_in_progress_session_operations() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::Reply);
+            h.block_new_session.store(true, Ordering::SeqCst);
+            let tab_to_session = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+            let tab_aliases = Arc::new(Mutex::new(HashMap::new()));
+            let tab_binding_generations = Arc::new(Mutex::new(HashMap::new()));
+            let memo = TemplateMemo::default();
+            let mut event_rx = h.event_rx;
+            let task = dispatch_new_session_with_aliases(
+                NewSessionForTab {
+                    tab_id: "reset-tab".into(),
+                    cwd: None,
+                },
+                &h.conn,
+                &tab_to_session,
+                &tab_aliases,
+                &tab_binding_generations,
+                &memo,
+                &h.event_tx,
+                Arc::clone(&h.client.state),
+                false,
+                false,
+                "ResetGenerationTest",
+                &h.proposal_channels,
+                false,
+            );
+
+            dispatch_drop_session_with_aliases(
+                DropSessionRequest {
+                    tab_id: "reset-tab".into(),
+                    notify_master: false,
+                },
+                &h.conn,
+                &tab_to_session,
+                &tab_aliases,
+                &tab_binding_generations,
+                &memo,
+                &h.client.state,
+            )
+            .await;
+            h.new_session_release.notify_one();
+            task.await.expect("new-session task failed");
+
+            assert!(tab_to_session.lock().await.is_empty());
+            while let Ok(event) = event_rx.try_recv() {
+                assert!(
+                    !matches!(event, AppEvent::SessionAttached { .. }),
+                    "retired session operation must not attach after reset"
+                );
+            }
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn cancelled_queued_prompt_never_reaches_provider_or_creates_session() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::Reply);
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
+            let mut event_rx = h.event_rx;
+            let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+            let prompt = test_prompt(1, "must never run", false);
+            prompt_tx.send(prompt.clone()).unwrap();
+            prompt.cancellation.cancel();
+
+            let queued = prompt_rx.recv().await.expect("prompt channel closed");
+            let task = dispatch_prompt(
+                queued,
+                &h.conn,
+                &tab_to_session,
+                &memo,
+                &in_flight,
+                &h.event_tx,
+                &h.shell_mgr,
+                &h.prompt_timing,
+                &h.client,
+                &PromptUsageIdentity::default(),
+                false,
+                false,
+                true,
+                &h.proposal_channels,
+            )
+            .expect("cancelled prompt still owns a settlement task");
+
+            assert!(matches!(
+                event_rx.recv().await,
+                Some(AppEvent::PromptCancellationSettled {
+                    prompt_id: 1,
+                    started: false,
+                })
+            ));
+            assert!(h.seen_prompts.lock().unwrap().is_empty());
+            assert_eq!(h.seen_cancels.load(Ordering::SeqCst), 0);
+            assert!(tab_to_session.lock().await.is_empty());
+            assert!(in_flight.lock().unwrap().is_empty());
+            task.handle.await.expect("settlement task failed");
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn started_prompt_cancels_its_resolved_session_before_app_attaches_it() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
@@ -3381,15 +3448,16 @@ async fn registered_cancel_settles_after_prompt_finishes() {
                 .await
                 .expect("initialize failed");
 
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
             let mut event_rx = h.event_rx;
+            let prompt = test_prompt(7, "wait for cancellation", false);
+            let cancellation = prompt.cancellation.clone();
             let task = dispatch_prompt(
-                test_prompt(7, "wait for cancellation", false),
+                prompt,
                 &h.conn,
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
@@ -3400,7 +3468,7 @@ async fn registered_cancel_settles_after_prompt_finishes() {
                 true,
                 &h.proposal_channels,
             )
-            .expect("prompt must be registered");
+            .expect("prompt must dispatch");
 
             tokio::time::timeout(std::time::Duration::from_secs(5), async {
                 while h.seen_prompts.lock().unwrap().is_empty() {
@@ -3409,32 +3477,27 @@ async fn registered_cancel_settles_after_prompt_finishes() {
             })
             .await
             .expect("prompt did not start");
+            cancellation.cancel();
 
-            dispatch_cancel(
-                CancelRequest {
-                    tab_id: "0".to_string(),
-                    prompt_id: 7,
-                    session_id: Some("mock-session-1".to_string()),
-                },
-                &h.conn,
-                &cancel_signals,
-            );
-
+            let mut attached_seen = false;
             tokio::time::timeout(std::time::Duration::from_secs(5), async {
                 loop {
                     match event_rx.recv().await {
-                        Some(AppEvent::PromptCancellationSettled {
-                            tab_id,
-                            prompt_id,
+                        Some(AppEvent::SessionAttached {
                             session_id,
+                            prompt_id,
+                            ..
                         }) => {
-                            assert_eq!(tab_id, "0");
-                            assert_eq!(prompt_id, 7);
-                            assert_eq!(session_id.as_deref(), Some("mock-session-1"));
-                            break;
+                            assert_eq!(session_id, "mock-session-1");
+                            assert_eq!(prompt_id, Some(7));
+                            attached_seen = true;
                         }
+                        Some(AppEvent::PromptCancellationSettled {
+                            prompt_id: 7,
+                            started: true,
+                        }) => break,
                         Some(AppEvent::AgentMessageEnd { .. }) => {
-                            panic!("cancelled prompt must not emit AgentMessageEnd")
+                            panic!("cancelled prompt must settle through its prompt identity")
                         }
                         Some(_) => {}
                         None => panic!("event channel closed before cancellation settled"),
@@ -3442,137 +3505,115 @@ async fn registered_cancel_settles_after_prompt_finishes() {
                 }
             })
             .await
-            .expect("registered cancellation did not settle");
+            .expect("started cancellation did not settle");
 
-            task.await.expect("prompt task failed");
-            tokio::time::timeout(std::time::Duration::from_secs(5), async {
-                while h.seen_cancels.load(Ordering::SeqCst) != 1 {
-                    tokio::task::yield_now().await;
-                }
-            })
-            .await
-            .expect("session/cancel was not delivered");
-            assert!(in_flight.lock().unwrap().is_empty());
-            assert!(cancel_signals.lock().unwrap().is_empty());
+            assert!(
+                in_flight.lock().unwrap().is_empty(),
+                "settlement must not release the UI before single-flight ownership"
+            );
+            task.handle.await.expect("prompt task failed");
+            assert!(
+                attached_seen,
+                "session attachment remained queued in App events"
+            );
+            assert_eq!(h.seen_cancels.load(Ordering::SeqCst), 1);
         })
         .await;
 }
 
 #[tokio::test]
-async fn stale_pending_cancel_does_not_cancel_newer_prompt() {
+async fn cancellation_during_prompt_preparation_settles_without_provider_cancel() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
-            let h = connect_for_dispatch(MockBehavior::Reply);
+            let mut h = connect_for_dispatch(MockBehavior::Reply);
             h.conn
                 .initialize(acp::schema::v1::InitializeRequest::new(
                     acp::schema::ProtocolVersion::LATEST,
                 ))
                 .await
                 .expect("initialize failed");
-
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let context_started = Arc::new(tokio::sync::Notify::new());
+            let context_release = Arc::new(tokio::sync::Notify::new());
+            h.shell_mgr = Arc::new(ShellManager::new().with_wt_channel(Arc::new(
+                BlockingPromptContextChannel {
+                    started: Arc::clone(&context_started),
+                    release: Arc::clone(&context_release),
+                },
+            )));
+            let (tab_to_session, in_flight, memo) = fresh_dispatch_state();
+            tab_to_session.lock().await.insert(
+                "0".to_string(),
+                acp::schema::v1::SessionId::new("prepared-session"),
+            );
+            let mut prompt = test_prompt(8, "cancel during context", false);
+            prompt.pane_context = Some(crate::pane_context::PaneContext {
+                pane_id: Some("agent-pane".to_string()),
+                tab_id: Some("0".to_string()),
+                window_id: Some("window-1".to_string()),
+                cwd: Some("C:\\work".to_string()),
+                source_pane_id: None,
+            });
+            let cancellation = prompt.cancellation.clone();
             let mut event_rx = h.event_rx;
-            cancel_signals
-                .lock()
-                .unwrap()
-                .insert("0".to_string(), PromptCancelEntry::Pending { prompt_id: 1 });
-
-            dispatch_prompt(
-                test_prompt(2, "newer prompt must run", false),
+            let task = dispatch_prompt(
+                prompt,
                 &h.conn,
                 &tab_to_session,
                 &memo,
                 &in_flight,
-                &cancel_signals,
                 &h.event_tx,
                 &h.shell_mgr,
                 &h.prompt_timing,
                 &h.client,
                 &PromptUsageIdentity::default(),
-                false,
+                true,
                 false,
                 true,
                 &h.proposal_channels,
-            );
+            )
+            .expect("prompt must enter preparation");
 
-            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                context_started.notified(),
+            )
+            .await
+            .expect("prompt preparation did not reach the controlled boundary");
+            cancellation.cancel();
+            context_release.notify_one();
+
+            tokio::time::timeout(std::time::Duration::from_secs(2), async {
                 loop {
-                    if matches!(
-                        event_rx.recv().await,
-                        Some(AppEvent::AgentMessageEnd { .. })
-                    ) {
-                        break;
+                    match event_rx.recv().await {
+                        Some(AppEvent::PromptCancellationSettled {
+                            prompt_id: 8,
+                            started: false,
+                        }) => break,
+                        Some(_) => {}
+                        None => panic!("event channel closed before cancellation settled"),
                     }
                 }
             })
             .await
-            .expect("newer prompt did not complete");
-            let seen_prompts = h.seen_prompts.lock().unwrap();
-            assert_eq!(seen_prompts.len(), 1);
-            assert!(seen_prompts[0].contains("newer prompt must run"));
+            .expect("pre-dispatch cancellation did not settle");
             assert!(in_flight.lock().unwrap().is_empty());
-            assert!(cancel_signals.lock().unwrap().is_empty());
-        })
-        .await;
-}
-
-#[tokio::test]
-async fn newer_pending_cancel_survives_stale_older_prompt() {
-    let local = tokio::task::LocalSet::new();
-    local
-        .run_until(async {
-            let h = connect_for_dispatch(MockBehavior::Reply);
-            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
-            cancel_signals
-                .lock()
-                .unwrap()
-                .insert("0".to_string(), PromptCancelEntry::Pending { prompt_id: 2 });
-
-            let task = dispatch_prompt(
-                test_prompt(1, "stale prompt must not run", false),
-                &h.conn,
-                &tab_to_session,
-                &memo,
-                &in_flight,
-                &cancel_signals,
-                &h.event_tx,
-                &h.shell_mgr,
-                &h.prompt_timing,
-                &h.client,
-                &PromptUsageIdentity::default(),
-                false,
-                false,
-                true,
-                &h.proposal_channels,
-            );
-
-            assert!(task.is_none());
-            assert!(tab_to_session.lock().await.is_empty());
-            assert!(in_flight.lock().unwrap().is_empty());
+            task.handle.await.expect("prompt task failed");
             assert!(h.seen_prompts.lock().unwrap().is_empty());
-            assert_eq!(
-                cancel_signals
-                    .lock()
-                    .unwrap()
-                    .get("0")
-                    .map(PromptCancelEntry::prompt_id),
-                Some(2)
-            );
+            assert_eq!(h.seen_cancels.load(Ordering::SeqCst), 0);
         })
         .await;
 }
 
-/// `dispatch_drop_session` must close and unbind the tab's session, fire its
-/// in-flight cancel signal, and be a no-op for a tab that holds no session.
+/// `dispatch_drop_session` unbinds local state and asks master to retire the
+/// exact tab session. Prompt cancellation is owned by the prompt token.
 #[tokio::test]
-async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_missing() {
+async fn dispatch_drop_session_closes_and_unbinds_then_ignores_missing() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
             let h = connect_for_dispatch(MockBehavior::Reply);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let memo = TemplateMemo::default();
 
             let sid = acp::schema::v1::SessionId::new("sess-drop");
@@ -3580,14 +3621,6 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
                 .lock()
                 .await
                 .insert("t1".to_string(), sid.clone());
-            let (tx, rx) = oneshot::channel::<()>();
-            cancel_signals.lock().unwrap().insert(
-                "t1".to_string(),
-                PromptCancelEntry::Registered {
-                    prompt_id: 1,
-                    signal: tx,
-                },
-            );
 
             dispatch_drop_session(
                 DropSessionRequest {
@@ -3597,25 +3630,13 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
                 &h.conn,
                 &tab_to_session,
                 &memo,
-                &cancel_signals,
                 &h.client.state,
             )
             .await;
 
-            // The in-flight cancel oneshot fires before the close request completes.
-            assert!(
-                tokio::time::timeout(std::time::Duration::from_secs(5), rx)
-                    .await
-                    .is_ok(),
-                "drop must fire the in-flight cancel signal"
-            );
             assert!(
                 !tab_to_session.lock().await.contains_key("t1"),
                 "drop must unbind the tab's session"
-            );
-            assert!(
-                !cancel_signals.lock().unwrap().contains_key("t1"),
-                "drop must remove the cancel signal from the registry"
             );
             tokio::time::timeout(std::time::Duration::from_secs(5), async {
                 loop {
@@ -3628,13 +3649,6 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
             .await
             .expect("drop must ask master to resolve and close the destroyed tab");
 
-            // An unbound tab can still have a cancel latched ahead of prompt
-            // registration. Lifecycle operations must preserve that pending
-            // identity for the queued prompt to consume.
-            cancel_signals.lock().unwrap().insert(
-                "unbound".to_string(),
-                PromptCancelEntry::Pending { prompt_id: 3 },
-            );
             dispatch_drop_session(
                 DropSessionRequest {
                     tab_id: "unbound".to_string(),
@@ -3643,20 +3657,10 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
                 &h.conn,
                 &tab_to_session,
                 &memo,
-                &cancel_signals,
                 &h.client.state,
             )
             .await;
             assert!(tab_to_session.lock().await.is_empty());
-            assert_eq!(
-                cancel_signals
-                    .lock()
-                    .unwrap()
-                    .get("unbound")
-                    .map(PromptCancelEntry::prompt_id),
-                Some(3),
-                "drop must preserve a pending pre-registration cancel"
-            );
             tokio::time::timeout(std::time::Duration::from_secs(5), async {
                 loop {
                     if h.close_tab_requests.lock().unwrap().as_slice()
@@ -3675,14 +3679,6 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
                 .lock()
                 .await
                 .insert("reset-tab".to_string(), reset_sid.clone());
-            let (reset_tx, reset_rx) = oneshot::channel::<()>();
-            cancel_signals.lock().unwrap().insert(
-                "reset-tab".to_string(),
-                PromptCancelEntry::Registered {
-                    prompt_id: 2,
-                    signal: reset_tx,
-                },
-            );
 
             dispatch_drop_session(
                 DropSessionRequest {
@@ -3692,17 +3688,10 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
                 &h.conn,
                 &tab_to_session,
                 &memo,
-                &cancel_signals,
                 &h.client.state,
             )
             .await;
 
-            assert!(
-                tokio::time::timeout(std::time::Duration::from_secs(5), reset_rx)
-                    .await
-                    .is_ok(),
-                "WT reset must still cancel the helper-local in-flight prompt"
-            );
             assert!(!tab_to_session.lock().await.contains_key("reset-tab"));
             for _ in 0..10 {
                 tokio::task::yield_now().await;
@@ -3740,11 +3729,6 @@ async fn dispatch_new_session_creates_binds_and_emits_attached() {
         .run_until(async {
             let h = connect_for_dispatch(MockBehavior::Reply);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
-            cancel_signals.lock().unwrap().insert(
-                "t1".to_string(),
-                PromptCancelEntry::Pending { prompt_id: 8 },
-            );
             let memo = TemplateMemo::default();
             let mut event_rx = h.event_rx;
 
@@ -3756,7 +3740,6 @@ async fn dispatch_new_session_creates_binds_and_emits_attached() {
                 &h.conn,
                 &tab_to_session,
                 &memo,
-                &cancel_signals,
                 &h.event_tx,
                 Arc::clone(&h.client.state),
                 false,
@@ -3780,15 +3763,6 @@ async fn dispatch_new_session_creates_binds_and_emits_attached() {
                 Some("mock-session-1".to_string()),
                 "new session must be bound to the tab"
             );
-            assert_eq!(
-                cancel_signals
-                    .lock()
-                    .unwrap()
-                    .get("t1")
-                    .map(PromptCancelEntry::prompt_id),
-                Some(8),
-                "new-session lifecycle must preserve queued cancellation"
-            );
         })
         .await;
 }
@@ -3803,7 +3777,6 @@ async fn dispatch_new_session_failure_emits_tab_error_and_leaves_unbound() {
             let h = connect_for_dispatch(MockBehavior::Reply);
             h.fail_new_session.store(true, Ordering::SeqCst);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let memo = TemplateMemo::default();
             let mut event_rx = h.event_rx;
 
@@ -3815,7 +3788,6 @@ async fn dispatch_new_session_failure_emits_tab_error_and_leaves_unbound() {
                 &h.conn,
                 &tab_to_session,
                 &memo,
-                &cancel_signals,
                 &h.event_tx,
                 Arc::clone(&h.client.state),
                 false,
@@ -3843,16 +3815,15 @@ async fn dispatch_new_session_failure_emits_tab_error_and_leaves_unbound() {
         .await;
 }
 
-/// `dispatch_new_session` replacing an existing session: the old session's
-/// in-flight cancel signal fires, and the tab is rebound to the new session.
+/// `dispatch_new_session` replaces an existing binding. Any active prompt is
+/// independently cancelled through its prompt-scoped token.
 #[tokio::test]
-async fn dispatch_new_session_replaces_old_and_fires_its_cancel() {
+async fn dispatch_new_session_replaces_old_binding() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
             let h = connect_for_dispatch(MockBehavior::Reply);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let memo = TemplateMemo::default();
             let mut event_rx = h.event_rx;
 
@@ -3861,14 +3832,6 @@ async fn dispatch_new_session_replaces_old_and_fires_its_cancel() {
                 .lock()
                 .await
                 .insert("t1".to_string(), old.clone());
-            let (tx_old, rx_old) = oneshot::channel::<()>();
-            cancel_signals.lock().unwrap().insert(
-                "t1".to_string(),
-                PromptCancelEntry::Registered {
-                    prompt_id: 1,
-                    signal: tx_old,
-                },
-            );
 
             dispatch_new_session(
                 NewSessionForTab {
@@ -3878,7 +3841,6 @@ async fn dispatch_new_session_replaces_old_and_fires_its_cancel() {
                 &h.conn,
                 &tab_to_session,
                 &memo,
-                &cancel_signals,
                 &h.event_tx,
                 Arc::clone(&h.client.state),
                 false,
@@ -3888,12 +3850,6 @@ async fn dispatch_new_session_replaces_old_and_fires_its_cancel() {
                 false,
             );
 
-            assert!(
-                tokio::time::timeout(std::time::Duration::from_secs(5), rx_old)
-                    .await
-                    .is_ok(),
-                "replacing a session must fire the old session's cancel signal"
-            );
             match tokio::time::timeout(std::time::Duration::from_secs(5), event_rx.recv()).await {
                 Ok(Some(AppEvent::SessionAttached { session_id, .. })) => {
                     assert_eq!(session_id, "mock-session-1");
@@ -3919,11 +3875,6 @@ async fn dispatch_load_session_binds_and_emits_attached() {
         .run_until(async {
             let h = connect_for_dispatch(MockBehavior::Reply);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
-            cancel_signals.lock().unwrap().insert(
-                "t1".to_string(),
-                PromptCancelEntry::Pending { prompt_id: 9 },
-            );
             let mut event_rx = h.event_rx;
 
             dispatch_load_session(
@@ -3934,7 +3885,6 @@ async fn dispatch_load_session_binds_and_emits_attached() {
                 },
                 &h.conn,
                 &tab_to_session,
-                &cancel_signals,
                 &h.event_tx,
                 Arc::clone(&h.client.state),
                 false,
@@ -3958,15 +3908,6 @@ async fn dispatch_load_session_binds_and_emits_attached() {
                 Some("hist-sess-7".to_string()),
                 "loaded session must be bound to the tab"
             );
-            assert_eq!(
-                cancel_signals
-                    .lock()
-                    .unwrap()
-                    .get("t1")
-                    .map(PromptCancelEntry::prompt_id),
-                Some(9),
-                "load-session lifecycle must preserve queued cancellation"
-            );
         })
         .await;
 }
@@ -3982,7 +3923,6 @@ async fn dispatch_load_session_failure_inline_emits_tab_error() {
             let h = connect_for_dispatch(MockBehavior::Reply);
             h.fail_load_session.store(true, Ordering::SeqCst);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let mut event_rx = h.event_rx;
 
             dispatch_load_session(
@@ -3993,7 +3933,6 @@ async fn dispatch_load_session_failure_inline_emits_tab_error() {
                 },
                 &h.conn,
                 &tab_to_session,
-                &cancel_signals,
                 &h.event_tx,
                 Arc::clone(&h.client.state),
                 false,
@@ -4032,7 +3971,6 @@ async fn dispatch_load_session_failure_handler_restores_prior_binding() {
             let h = connect_for_dispatch(MockBehavior::Reply);
             h.fail_load_session.store(true, Ordering::SeqCst);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let mut event_rx = h.event_rx;
 
             let old = acp::schema::v1::SessionId::new("old-sess");
@@ -4049,7 +3987,6 @@ async fn dispatch_load_session_failure_handler_restores_prior_binding() {
                 },
                 &h.conn,
                 &tab_to_session,
-                &cancel_signals,
                 &h.event_tx,
                 Arc::clone(&h.client.state),
                 false,
@@ -4089,7 +4026,6 @@ async fn dispatch_load_session_timeout_emits_tab_error() {
             let h = connect_for_dispatch(MockBehavior::Reply);
             h.slow_load.store(true, Ordering::SeqCst);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let mut event_rx = h.event_rx;
 
             dispatch_load_session(
@@ -4100,7 +4036,6 @@ async fn dispatch_load_session_timeout_emits_tab_error() {
                 },
                 &h.conn,
                 &tab_to_session,
-                &cancel_signals,
                 &h.event_tx,
                 Arc::clone(&h.client.state),
                 false,

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -17,7 +17,7 @@ use super::{
     dispatch_master_ext_request_with_yolo_timeout, dispatch_new_session, dispatch_prompt,
     dispatch_rename_session, publish_current_native_config_options, take_retired_session_result,
     AutofixTextKind, CancelRequest, DropSessionRequest, LoadSessionForTab, MasterExtRequest,
-    NewSessionForTab, PromptSubmission, RenameSessionRequest,
+    NewSessionForTab, PromptCancelEntry, PromptSubmission, RenameSessionRequest,
 };
 use super::{ClientState, PromptUsageIdentity, ProviderProbeCapture, WtaClient};
 use crate::app_contracts::{AppEvent, PlanEntry, PlanEntryStatus};
@@ -979,7 +979,7 @@ fn connect_for_dispatch(behavior: MockBehavior) -> DispatchHarness {
 fn fresh_dispatch_state() -> (
     Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
     Arc<std::sync::Mutex<HashSet<String>>>,
-    Arc<std::sync::Mutex<HashMap<String, oneshot::Sender<()>>>>,
+    Arc<std::sync::Mutex<HashMap<String, PromptCancelEntry>>>,
     TemplateMemo,
 ) {
     (
@@ -2927,26 +2927,29 @@ async fn dispatch_rename_session_rekeys_existing_and_ignores_missing() {
         .await;
 }
 
-/// `dispatch_cancel` must fire the local per-session cancel oneshot (so an
-/// in-flight prompt task drops out of `conn.prompt().await`) and remove the
-/// signal from the registry. The agent-side `session/cancel` is best-effort.
+/// `dispatch_cancel` must signal only the matching tab/prompt pair and remove
+/// it from the registry. The agent-side `session/cancel` is best-effort.
 #[tokio::test]
 async fn dispatch_cancel_fires_local_signal_and_removes_registry_entry() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
             let h = connect_for_dispatch(MockBehavior::Reply);
-            let cancel_signals: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>> =
-                Arc::new(Mutex::new(HashMap::new()));
+            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let (tx, rx) = oneshot::channel::<()>();
-            cancel_signals
-                .lock()
-                .unwrap()
-                .insert("sess-cancel".to_string(), tx);
+            cancel_signals.lock().unwrap().insert(
+                "tab-cancel".to_string(),
+                PromptCancelEntry {
+                    prompt_id: 7,
+                    signal: tx,
+                },
+            );
 
             dispatch_cancel(
                 CancelRequest {
-                    session_id: "sess-cancel".to_string(),
+                    tab_id: "tab-cancel".to_string(),
+                    prompt_id: 7,
+                    session_id: Some("sess-cancel".to_string()),
                 },
                 &h.conn,
                 &cancel_signals,
@@ -2955,14 +2958,50 @@ async fn dispatch_cancel_fires_local_signal_and_removes_registry_entry() {
             // The local oneshot is fired synchronously inside dispatch_cancel.
             assert!(rx.await.is_ok(), "local cancel signal must be fired");
             assert!(
-                !cancel_signals.lock().unwrap().contains_key("sess-cancel"),
+                !cancel_signals.lock().unwrap().contains_key("tab-cancel"),
                 "the fired signal must be removed from the registry"
             );
 
-            // Cancelling an unknown session is a harmless no-op (no panic).
+            let (new_tx, mut new_rx) = oneshot::channel::<()>();
+            cancel_signals.lock().unwrap().insert(
+                "tab-cancel".to_string(),
+                PromptCancelEntry {
+                    prompt_id: 8,
+                    signal: new_tx,
+                },
+            );
             dispatch_cancel(
                 CancelRequest {
-                    session_id: "ghost".to_string(),
+                    tab_id: "tab-cancel".to_string(),
+                    prompt_id: 7,
+                    session_id: Some("sess-cancel".to_string()),
+                },
+                &h.conn,
+                &cancel_signals,
+            );
+            assert!(
+                matches!(
+                    new_rx.try_recv(),
+                    Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+                ),
+                "a stale cancel must not signal the newer prompt"
+            );
+            assert_eq!(
+                cancel_signals
+                    .lock()
+                    .unwrap()
+                    .get("tab-cancel")
+                    .map(|entry| entry.prompt_id),
+                Some(8)
+            );
+            cancel_signals.lock().unwrap().remove("tab-cancel");
+
+            // Cancelling an unknown tab is a harmless no-op.
+            dispatch_cancel(
+                CancelRequest {
+                    tab_id: "ghost-tab".to_string(),
+                    prompt_id: 9,
+                    session_id: Some("ghost".to_string()),
                 },
                 &h.conn,
                 &cancel_signals,
@@ -2971,6 +3010,76 @@ async fn dispatch_cancel_fires_local_signal_and_removes_registry_entry() {
             for _ in 0..10 {
                 tokio::task::yield_now().await;
             }
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn first_turn_cancel_before_prompt_task_starts_prevents_dispatch() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::Reply);
+            h.conn
+                .initialize(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .await
+                .expect("initialize failed");
+
+            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let mut event_rx = h.event_rx;
+
+            dispatch_prompt(
+                test_prompt(1, "must never run", false),
+                &h.conn,
+                &tab_to_session,
+                &memo,
+                &in_flight,
+                &cancel_signals,
+                &h.event_tx,
+                &h.shell_mgr,
+                &h.prompt_timing,
+                &h.client,
+                &PromptUsageIdentity::default(),
+                false,
+                false,
+                true,
+                &h.proposal_channels,
+            );
+            dispatch_cancel(
+                CancelRequest {
+                    tab_id: "0".to_string(),
+                    prompt_id: 1,
+                    session_id: None,
+                },
+                &h.conn,
+                &cancel_signals,
+            );
+
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                loop {
+                    match event_rx.recv().await {
+                        Some(AppEvent::AgentMessageEnd { session_id }) => {
+                            assert_eq!(session_id, "mock-session-1");
+                            break;
+                        }
+                        Some(AppEvent::AgentMessageChunk { .. }) => {
+                            panic!("cancelled prompt emitted agent output")
+                        }
+                        Some(_) => continue,
+                        None => panic!("event channel closed before cancellation settled"),
+                    }
+                }
+            })
+            .await
+            .expect("cancelled prompt did not reach its terminal boundary");
+            assert!(
+                h.seen_prompts.lock().unwrap().is_empty(),
+                "a latched cancel must prevent the old prompt from reaching the agent"
+            );
+            assert!(in_flight.lock().unwrap().is_empty());
+            assert!(cancel_signals.lock().unwrap().is_empty());
         })
         .await;
 }
@@ -2984,8 +3093,7 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
         .run_until(async {
             let h = connect_for_dispatch(MockBehavior::Reply);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>> =
-                Arc::new(Mutex::new(HashMap::new()));
+            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let memo = TemplateMemo::default();
 
             let sid = acp::schema::v1::SessionId::new("sess-drop");
@@ -2994,7 +3102,13 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
                 .await
                 .insert("t1".to_string(), sid.clone());
             let (tx, rx) = oneshot::channel::<()>();
-            cancel_signals.lock().unwrap().insert(sid.to_string(), tx);
+            cancel_signals.lock().unwrap().insert(
+                "t1".to_string(),
+                PromptCancelEntry {
+                    prompt_id: 1,
+                    signal: tx,
+                },
+            );
 
             dispatch_drop_session(
                 DropSessionRequest {
@@ -3021,7 +3135,7 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
                 "drop must unbind the tab's session"
             );
             assert!(
-                !cancel_signals.lock().unwrap().contains_key("sess-drop"),
+                !cancel_signals.lock().unwrap().contains_key("t1"),
                 "drop must remove the cancel signal from the registry"
             );
             tokio::time::timeout(std::time::Duration::from_secs(5), async {
@@ -3068,10 +3182,13 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
                 .await
                 .insert("reset-tab".to_string(), reset_sid.clone());
             let (reset_tx, reset_rx) = oneshot::channel::<()>();
-            cancel_signals
-                .lock()
-                .unwrap()
-                .insert(reset_sid.to_string(), reset_tx);
+            cancel_signals.lock().unwrap().insert(
+                "reset-tab".to_string(),
+                PromptCancelEntry {
+                    prompt_id: 2,
+                    signal: reset_tx,
+                },
+            );
 
             dispatch_drop_session(
                 DropSessionRequest {
@@ -3129,8 +3246,7 @@ async fn dispatch_new_session_creates_binds_and_emits_attached() {
         .run_until(async {
             let h = connect_for_dispatch(MockBehavior::Reply);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>> =
-                Arc::new(Mutex::new(HashMap::new()));
+            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let memo = TemplateMemo::default();
             let mut event_rx = h.event_rx;
 
@@ -3180,8 +3296,7 @@ async fn dispatch_new_session_failure_emits_tab_error_and_leaves_unbound() {
             let h = connect_for_dispatch(MockBehavior::Reply);
             h.fail_new_session.store(true, Ordering::SeqCst);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>> =
-                Arc::new(Mutex::new(HashMap::new()));
+            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let memo = TemplateMemo::default();
             let mut event_rx = h.event_rx;
 
@@ -3230,8 +3345,7 @@ async fn dispatch_new_session_replaces_old_and_fires_its_cancel() {
         .run_until(async {
             let h = connect_for_dispatch(MockBehavior::Reply);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>> =
-                Arc::new(Mutex::new(HashMap::new()));
+            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let memo = TemplateMemo::default();
             let mut event_rx = h.event_rx;
 
@@ -3241,10 +3355,13 @@ async fn dispatch_new_session_replaces_old_and_fires_its_cancel() {
                 .await
                 .insert("t1".to_string(), old.clone());
             let (tx_old, rx_old) = oneshot::channel::<()>();
-            cancel_signals
-                .lock()
-                .unwrap()
-                .insert(old.to_string(), tx_old);
+            cancel_signals.lock().unwrap().insert(
+                "t1".to_string(),
+                PromptCancelEntry {
+                    prompt_id: 1,
+                    signal: tx_old,
+                },
+            );
 
             dispatch_new_session(
                 NewSessionForTab {
@@ -3295,8 +3412,7 @@ async fn dispatch_load_session_binds_and_emits_attached() {
         .run_until(async {
             let h = connect_for_dispatch(MockBehavior::Reply);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>> =
-                Arc::new(Mutex::new(HashMap::new()));
+            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let mut event_rx = h.event_rx;
 
             dispatch_load_session(
@@ -3346,8 +3462,7 @@ async fn dispatch_load_session_failure_inline_emits_tab_error() {
             let h = connect_for_dispatch(MockBehavior::Reply);
             h.fail_load_session.store(true, Ordering::SeqCst);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>> =
-                Arc::new(Mutex::new(HashMap::new()));
+            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let mut event_rx = h.event_rx;
 
             dispatch_load_session(
@@ -3397,8 +3512,7 @@ async fn dispatch_load_session_failure_handler_restores_prior_binding() {
             let h = connect_for_dispatch(MockBehavior::Reply);
             h.fail_load_session.store(true, Ordering::SeqCst);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>> =
-                Arc::new(Mutex::new(HashMap::new()));
+            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let mut event_rx = h.event_rx;
 
             let old = acp::schema::v1::SessionId::new("old-sess");
@@ -3455,8 +3569,7 @@ async fn dispatch_load_session_timeout_emits_tab_error() {
             let h = connect_for_dispatch(MockBehavior::Reply);
             h.slow_load.store(true, Ordering::SeqCst);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-            let cancel_signals: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>> =
-                Arc::new(Mutex::new(HashMap::new()));
+            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
             let mut event_rx = h.event_rx;
 
             dispatch_load_session(

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -17,7 +17,8 @@ use super::{
     dispatch_master_ext_request_with_yolo_timeout, dispatch_new_session, dispatch_prompt,
     dispatch_rename_session, publish_current_native_config_options, take_retired_session_result,
     AutofixTextKind, CancelRequest, DropSessionRequest, LoadSessionForTab, MasterExtRequest,
-    NewSessionForTab, PromptCancelEntry, PromptSubmission, RenameSessionRequest,
+    NewSessionForTab, PromptCancelEntry, PromptDispatchCleanup, PromptSubmission,
+    RenameSessionRequest,
 };
 use super::{ClientState, PromptUsageIdentity, ProviderProbeCapture, WtaClient};
 use crate::app_contracts::{AppEvent, PlanEntry, PlanEntryStatus};
@@ -27,7 +28,7 @@ use crate::protocol::acp::turn_metrics::PromptTimingState;
 use crate::shell::ShellManager;
 use agent_client_protocol as acp;
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::{mpsc, oneshot, OnceCell};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
@@ -49,6 +50,8 @@ enum MockBehavior {
     /// Stream the reply in two `AgentMessageChunk`s (`MOCK_` + `OK`), then end
     /// the turn — exercises streaming coalescing.
     StreamTwoChunks,
+    /// Keep the prompt request in flight briefly so cancellation can race it.
+    DelayedReply,
 }
 
 /// Deterministic ACP agent. Implements only what the scenarios need; the rest
@@ -64,6 +67,8 @@ struct MockAgent {
     behavior: MockBehavior,
     /// Side-channel: every prompt's user text.
     seen_prompts: Arc<Mutex<Vec<String>>>,
+    /// Side-channel: number of `session/cancel` notifications received.
+    seen_cancels: Arc<AtomicUsize>,
     /// Side-channel: every image content block (mime, base64 data) that reached
     /// the agent on the wire — used by the Alt+V image-paste integration test.
     seen_images: Arc<Mutex<Vec<(String, String)>>>,
@@ -431,6 +436,9 @@ impl MockAgent {
                         }
                     });
                 }
+                MockBehavior::DelayedReply => {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
             }
         }
 
@@ -440,6 +448,7 @@ impl MockAgent {
     }
 
     async fn cancel(&self, _args: acp::schema::v1::CancelNotification) -> acp::Result<()> {
+        self.seen_cancels.fetch_add(1, Ordering::SeqCst);
         Ok(())
     }
 
@@ -499,6 +508,7 @@ fn connect_with(
         conn: conn_cell.clone(),
         behavior,
         seen_prompts: seen_prompts.clone(),
+        seen_cancels: Arc::new(AtomicUsize::new(0)),
         seen_images: Arc::new(Mutex::new(Vec::new())),
         permission_outcome: permission_outcome.clone(),
         closed_sessions: Arc::new(Mutex::new(Vec::new())),
@@ -857,6 +867,7 @@ pub(crate) struct DispatchHarness {
     pub proposal_channels:
         Arc<crate::agent_tools::action_proposal::channel::ProposalChannelManager>,
     pub seen_prompts: Arc<Mutex<Vec<String>>>,
+    pub seen_cancels: Arc<AtomicUsize>,
     pub permission_outcome: Arc<Mutex<Option<String>>>,
     /// Agent-side record of every image content block (mime, base64) assembled
     /// onto the wire — the Alt+V image-paste assertion target.
@@ -907,6 +918,7 @@ fn connect_for_dispatch(behavior: MockBehavior) -> DispatchHarness {
     let wta = WtaClient { state };
 
     let seen_prompts = Arc::new(Mutex::new(Vec::new()));
+    let seen_cancels = Arc::new(AtomicUsize::new(0));
     let seen_images = Arc::new(Mutex::new(Vec::new()));
     let permission_outcome = Arc::new(Mutex::new(None));
     let closed_sessions = Arc::new(Mutex::new(Vec::new()));
@@ -927,6 +939,7 @@ fn connect_for_dispatch(behavior: MockBehavior) -> DispatchHarness {
         conn: conn_cell.clone(),
         behavior,
         seen_prompts: seen_prompts.clone(),
+        seen_cancels: seen_cancels.clone(),
         seen_images: seen_images.clone(),
         permission_outcome: permission_outcome.clone(),
         closed_sessions: closed_sessions.clone(),
@@ -955,6 +968,7 @@ fn connect_for_dispatch(behavior: MockBehavior) -> DispatchHarness {
         prompt_timing,
         proposal_channels,
         seen_prompts,
+        seen_cancels,
         permission_outcome,
         seen_images,
         closed_sessions,
@@ -978,13 +992,13 @@ fn connect_for_dispatch(behavior: MockBehavior) -> DispatchHarness {
 #[allow(clippy::type_complexity)]
 fn fresh_dispatch_state() -> (
     Arc<tokio::sync::Mutex<HashMap<String, acp::schema::v1::SessionId>>>,
-    Arc<std::sync::Mutex<HashSet<String>>>,
+    Arc<std::sync::Mutex<HashMap<String, u64>>>,
     Arc<std::sync::Mutex<HashMap<String, PromptCancelEntry>>>,
     TemplateMemo,
 ) {
     (
         Arc::new(tokio::sync::Mutex::new(HashMap::new())),
-        Arc::new(std::sync::Mutex::new(HashSet::new())),
+        Arc::new(std::sync::Mutex::new(HashMap::new())),
         Arc::new(std::sync::Mutex::new(HashMap::new())),
         TemplateMemo::default(),
     )
@@ -1068,7 +1082,7 @@ async fn dispatch_prompt_busy_tab_emits_agent_busy_and_drops() {
             let h = connect_for_dispatch(MockBehavior::Reply);
             let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
             // A turn is already running for the default tab ("0").
-            in_flight.lock().unwrap().insert("0".to_string());
+            in_flight.lock().unwrap().insert("0".to_string(), 0);
             let mut event_rx = h.event_rx;
 
             dispatch_prompt(
@@ -2884,7 +2898,10 @@ async fn dispatch_rename_session_rekeys_existing_and_ignores_missing() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::Reply);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+            let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
+            let in_flight_tabs = Arc::new(Mutex::new(HashMap::new()));
             let sid = acp::schema::v1::SessionId::new("sess-rekey");
             super::set_helper_owner_tab_id(Some("old-tab"));
             tab_to_session
@@ -2898,7 +2915,10 @@ async fn dispatch_rename_session_rekeys_existing_and_ignores_missing() {
                     old_tab_id: "old-tab".to_string(),
                     new_tab_id: "new-tab".to_string(),
                 },
+                &h.conn,
                 &tab_to_session,
+                &cancel_signals,
+                &in_flight_tabs,
             )
             .await;
             {
@@ -2918,7 +2938,10 @@ async fn dispatch_rename_session_rekeys_existing_and_ignores_missing() {
                     old_tab_id: "ghost".to_string(),
                     new_tab_id: "phantom".to_string(),
                 },
+                &h.conn,
                 &tab_to_session,
+                &cancel_signals,
+                &in_flight_tabs,
             )
             .await;
             let g = tab_to_session.lock().await;
@@ -2926,6 +2949,229 @@ async fn dispatch_rename_session_rekeys_existing_and_ignores_missing() {
             assert!(
                 g.contains_key("new-tab"),
                 "existing binding must survive the no-op"
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn dispatch_rename_session_rekeys_registered_cancellation_and_in_flight_owner() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::Reply);
+            let tab_to_session = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+            let (signal, cancelled) = oneshot::channel();
+            let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
+                "old-tab".to_string(),
+                PromptCancelEntry::Registered {
+                    prompt_id: 7,
+                    signal,
+                },
+            )])));
+            let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("old-tab".to_string(), 7)])));
+
+            dispatch_rename_session(
+                RenameSessionRequest {
+                    old_tab_id: "old-tab".to_string(),
+                    new_tab_id: "new-tab".to_string(),
+                },
+                &h.conn,
+                &tab_to_session,
+                &cancel_signals,
+                &in_flight_tabs,
+            )
+            .await;
+
+            assert_eq!(
+                in_flight_tabs.lock().unwrap().get("new-tab").copied(),
+                Some(7)
+            );
+            assert!(!in_flight_tabs.lock().unwrap().contains_key("old-tab"));
+            dispatch_cancel(
+                CancelRequest {
+                    tab_id: "new-tab".to_string(),
+                    prompt_id: 7,
+                    session_id: None,
+                },
+                &h.conn,
+                &cancel_signals,
+            );
+            assert!(
+                cancelled.await.is_ok(),
+                "cancel under the renamed tab id must signal the original prompt"
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn dispatch_rename_session_rekeys_pending_cancellation() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::Reply);
+            let tab_to_session = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+            let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
+                "old-tab".to_string(),
+                PromptCancelEntry::Pending { prompt_id: 9 },
+            )])));
+            let in_flight_tabs = Arc::new(Mutex::new(HashMap::new()));
+
+            dispatch_rename_session(
+                RenameSessionRequest {
+                    old_tab_id: "old-tab".to_string(),
+                    new_tab_id: "new-tab".to_string(),
+                },
+                &h.conn,
+                &tab_to_session,
+                &cancel_signals,
+                &in_flight_tabs,
+            )
+            .await;
+
+            let registry = cancel_signals.lock().unwrap();
+            assert!(!registry.contains_key("old-tab"));
+            assert_eq!(
+                registry.get("new-tab").map(PromptCancelEntry::prompt_id),
+                Some(9)
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn dispatch_rename_session_merges_queued_cancel_with_registered_prompt() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::Reply);
+            let sid = acp::schema::v1::SessionId::new("sess-rename-cancel");
+            let tab_to_session = Arc::new(tokio::sync::Mutex::new(HashMap::from([(
+                "old-tab".to_string(),
+                sid,
+            )])));
+            let (signal, cancelled) = oneshot::channel();
+            let cancel_signals = Arc::new(Mutex::new(HashMap::from([(
+                "old-tab".to_string(),
+                PromptCancelEntry::Registered {
+                    prompt_id: 11,
+                    signal,
+                },
+            )])));
+            let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([("old-tab".to_string(), 11)])));
+
+            dispatch_cancel(
+                CancelRequest {
+                    tab_id: "new-tab".to_string(),
+                    prompt_id: 11,
+                    session_id: Some("sess-rename-cancel".to_string()),
+                },
+                &h.conn,
+                &cancel_signals,
+            );
+            assert_eq!(h.seen_cancels.load(Ordering::Acquire), 0);
+
+            dispatch_rename_session(
+                RenameSessionRequest {
+                    old_tab_id: "old-tab".to_string(),
+                    new_tab_id: "new-tab".to_string(),
+                },
+                &h.conn,
+                &tab_to_session,
+                &cancel_signals,
+                &in_flight_tabs,
+            )
+            .await;
+
+            assert!(
+                cancelled.await.is_ok(),
+                "registered prompt must be signalled"
+            );
+            for _ in 0..10 {
+                if h.seen_cancels.load(Ordering::Acquire) == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+            assert_eq!(h.seen_cancels.load(Ordering::Acquire), 1);
+            assert!(cancel_signals.lock().unwrap().is_empty());
+            assert_eq!(
+                *in_flight_tabs.lock().unwrap(),
+                HashMap::from([("new-tab".to_string(), 11)])
+            );
+
+            drop(PromptDispatchCleanup {
+                tab_key: "old-tab".to_string(),
+                prompt_id: 11,
+                in_flight_tabs: Arc::clone(&in_flight_tabs),
+                cancel_signals: Arc::clone(&cancel_signals),
+            });
+            assert!(in_flight_tabs.lock().unwrap().is_empty());
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn dispatch_rename_session_preserves_newer_destination_identity() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::Reply);
+            let sid = acp::schema::v1::SessionId::new("sess-stale-rename");
+            let tab_to_session = Arc::new(tokio::sync::Mutex::new(HashMap::from([(
+                "old-tab".to_string(),
+                sid,
+            )])));
+            let (old_signal, old_cancelled) = oneshot::channel();
+            let cancel_signals = Arc::new(Mutex::new(HashMap::from([
+                (
+                    "old-tab".to_string(),
+                    PromptCancelEntry::Registered {
+                        prompt_id: 7,
+                        signal: old_signal,
+                    },
+                ),
+                (
+                    "new-tab".to_string(),
+                    PromptCancelEntry::Pending { prompt_id: 8 },
+                ),
+            ])));
+            let in_flight_tabs = Arc::new(Mutex::new(HashMap::from([
+                ("old-tab".to_string(), 7),
+                ("new-tab".to_string(), 8),
+            ])));
+
+            dispatch_rename_session(
+                RenameSessionRequest {
+                    old_tab_id: "old-tab".to_string(),
+                    new_tab_id: "new-tab".to_string(),
+                },
+                &h.conn,
+                &tab_to_session,
+                &cancel_signals,
+                &in_flight_tabs,
+            )
+            .await;
+
+            assert!(old_cancelled.await.is_ok(), "stale local prompt must stop");
+            tokio::task::yield_now().await;
+            assert_eq!(
+                h.seen_cancels.load(Ordering::Acquire),
+                0,
+                "a mismatched merge must not cancel the newer provider prompt"
+            );
+            assert_eq!(
+                cancel_signals
+                    .lock()
+                    .unwrap()
+                    .get("new-tab")
+                    .map(PromptCancelEntry::prompt_id),
+                Some(8)
+            );
+            assert_eq!(
+                *in_flight_tabs.lock().unwrap(),
+                HashMap::from([("new-tab".to_string(), 8)])
             );
         })
         .await;
@@ -2943,7 +3189,7 @@ async fn dispatch_cancel_fires_local_signal_and_removes_registry_entry() {
             let (tx, rx) = oneshot::channel::<()>();
             cancel_signals.lock().unwrap().insert(
                 "tab-cancel".to_string(),
-                PromptCancelEntry {
+                PromptCancelEntry::Registered {
                     prompt_id: 7,
                     signal: tx,
                 },
@@ -2969,7 +3215,7 @@ async fn dispatch_cancel_fires_local_signal_and_removes_registry_entry() {
             let (new_tx, mut new_rx) = oneshot::channel::<()>();
             cancel_signals.lock().unwrap().insert(
                 "tab-cancel".to_string(),
-                PromptCancelEntry {
+                PromptCancelEntry::Registered {
                     prompt_id: 8,
                     signal: new_tx,
                 },
@@ -2995,31 +3241,39 @@ async fn dispatch_cancel_fires_local_signal_and_removes_registry_entry() {
                     .lock()
                     .unwrap()
                     .get("tab-cancel")
-                    .map(|entry| entry.prompt_id),
+                    .map(PromptCancelEntry::prompt_id),
                 Some(8)
             );
             cancel_signals.lock().unwrap().remove("tab-cancel");
 
-            // Cancelling an unknown tab is a harmless no-op.
+            cancel_signals.lock().unwrap().insert(
+                "tab-pending".to_string(),
+                PromptCancelEntry::Pending { prompt_id: 10 },
+            );
             dispatch_cancel(
                 CancelRequest {
-                    tab_id: "ghost-tab".to_string(),
+                    tab_id: "tab-pending".to_string(),
                     prompt_id: 9,
-                    session_id: Some("ghost".to_string()),
+                    session_id: Some("sess-pending".to_string()),
                 },
                 &h.conn,
                 &cancel_signals,
             );
-            // Let the best-effort agent-notify subtask run.
-            for _ in 0..10 {
-                tokio::task::yield_now().await;
-            }
+            assert_eq!(
+                cancel_signals
+                    .lock()
+                    .unwrap()
+                    .get("tab-pending")
+                    .map(PromptCancelEntry::prompt_id),
+                Some(10),
+                "a stale cancel must not replace a newer pending prompt"
+            );
         })
         .await;
 }
 
 #[tokio::test]
-async fn first_turn_cancel_before_prompt_task_starts_prevents_dispatch() {
+async fn prompt_then_cancel_channels_latch_cancel_before_prompt_dispatch() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {
@@ -3033,9 +3287,29 @@ async fn first_turn_cancel_before_prompt_task_starts_prevents_dispatch() {
 
             let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
             let mut event_rx = h.event_rx;
+            let (prompt_tx, mut prompt_rx) = tokio::sync::mpsc::unbounded_channel();
+            let (cancel_tx, mut cancel_rx) = tokio::sync::mpsc::unbounded_channel();
 
+            prompt_tx
+                .send(test_prompt(1, "must never run", false))
+                .unwrap();
+            cancel_tx
+                .send(CancelRequest {
+                    tab_id: "0".to_string(),
+                    prompt_id: 1,
+                    session_id: Some("mock-session-1".to_string()),
+                })
+                .unwrap();
+
+            let cancel = tokio::select! {
+                biased;
+                req = cancel_rx.recv() => req.expect("cancel channel closed"),
+                _ = prompt_rx.recv() => panic!("production ordering must select cancel first"),
+            };
+            dispatch_cancel(cancel, &h.conn, &cancel_signals);
+            let prompt = prompt_rx.recv().await.expect("prompt channel closed");
             dispatch_prompt(
-                test_prompt(1, "must never run", false),
+                prompt,
                 &h.conn,
                 &tab_to_session,
                 &memo,
@@ -3051,21 +3325,18 @@ async fn first_turn_cancel_before_prompt_task_starts_prevents_dispatch() {
                 true,
                 &h.proposal_channels,
             );
-            dispatch_cancel(
-                CancelRequest {
-                    tab_id: "0".to_string(),
-                    prompt_id: 1,
-                    session_id: None,
-                },
-                &h.conn,
-                &cancel_signals,
-            );
 
             tokio::time::timeout(std::time::Duration::from_secs(5), async {
                 loop {
                     match event_rx.recv().await {
-                        Some(AppEvent::AgentMessageEnd { session_id }) => {
-                            assert_eq!(session_id, "mock-session-1");
+                        Some(AppEvent::PromptCancellationSettled {
+                            tab_id,
+                            prompt_id,
+                            session_id,
+                        }) => {
+                            assert_eq!(tab_id, "0");
+                            assert_eq!(prompt_id, 1);
+                            assert_eq!(session_id, None);
                             break;
                         }
                         Some(AppEvent::AgentMessageChunk { .. }) => {
@@ -3082,8 +3353,212 @@ async fn first_turn_cancel_before_prompt_task_starts_prevents_dispatch() {
                 h.seen_prompts.lock().unwrap().is_empty(),
                 "a latched cancel must prevent the old prompt from reaching the agent"
             );
+            assert_eq!(
+                h.seen_cancels.load(Ordering::SeqCst),
+                0,
+                "a pre-registration cancel must not notify an unstarted ACP session"
+            );
+            assert!(
+                tab_to_session.lock().await.is_empty(),
+                "a queued cancellation must not lazily create a session"
+            );
             assert!(in_flight.lock().unwrap().is_empty());
             assert!(cancel_signals.lock().unwrap().is_empty());
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn registered_cancel_settles_after_prompt_quiesces() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::DelayedReply);
+            h.conn
+                .initialize(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .await
+                .expect("initialize failed");
+
+            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let mut event_rx = h.event_rx;
+            let task = dispatch_prompt(
+                test_prompt(7, "wait for cancellation", false),
+                &h.conn,
+                &tab_to_session,
+                &memo,
+                &in_flight,
+                &cancel_signals,
+                &h.event_tx,
+                &h.shell_mgr,
+                &h.prompt_timing,
+                &h.client,
+                &PromptUsageIdentity::default(),
+                false,
+                false,
+                true,
+                &h.proposal_channels,
+            )
+            .expect("prompt must be registered");
+
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                while h.seen_prompts.lock().unwrap().is_empty() {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("prompt did not start");
+
+            dispatch_cancel(
+                CancelRequest {
+                    tab_id: "0".to_string(),
+                    prompt_id: 7,
+                    session_id: Some("mock-session-1".to_string()),
+                },
+                &h.conn,
+                &cancel_signals,
+            );
+
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                loop {
+                    match event_rx.recv().await {
+                        Some(AppEvent::PromptCancellationSettled {
+                            tab_id,
+                            prompt_id,
+                            session_id,
+                        }) => {
+                            assert_eq!(tab_id, "0");
+                            assert_eq!(prompt_id, 7);
+                            assert_eq!(session_id.as_deref(), Some("mock-session-1"));
+                            break;
+                        }
+                        Some(AppEvent::AgentMessageEnd { .. }) => {
+                            panic!("cancelled prompt must not emit AgentMessageEnd")
+                        }
+                        Some(_) => {}
+                        None => panic!("event channel closed before cancellation settled"),
+                    }
+                }
+            })
+            .await
+            .expect("registered cancellation did not settle");
+
+            task.await.expect("prompt task failed");
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                while h.seen_cancels.load(Ordering::SeqCst) != 1 {
+                    tokio::task::yield_now().await;
+                }
+            })
+            .await
+            .expect("session/cancel was not delivered");
+            assert!(in_flight.lock().unwrap().is_empty());
+            assert!(cancel_signals.lock().unwrap().is_empty());
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn stale_pending_cancel_does_not_cancel_newer_prompt() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::Reply);
+            h.conn
+                .initialize(acp::schema::v1::InitializeRequest::new(
+                    acp::schema::ProtocolVersion::LATEST,
+                ))
+                .await
+                .expect("initialize failed");
+
+            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            let mut event_rx = h.event_rx;
+            cancel_signals
+                .lock()
+                .unwrap()
+                .insert("0".to_string(), PromptCancelEntry::Pending { prompt_id: 1 });
+
+            dispatch_prompt(
+                test_prompt(2, "newer prompt must run", false),
+                &h.conn,
+                &tab_to_session,
+                &memo,
+                &in_flight,
+                &cancel_signals,
+                &h.event_tx,
+                &h.shell_mgr,
+                &h.prompt_timing,
+                &h.client,
+                &PromptUsageIdentity::default(),
+                false,
+                false,
+                true,
+                &h.proposal_channels,
+            );
+
+            tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                loop {
+                    if matches!(
+                        event_rx.recv().await,
+                        Some(AppEvent::AgentMessageEnd { .. })
+                    ) {
+                        break;
+                    }
+                }
+            })
+            .await
+            .expect("newer prompt did not complete");
+            let seen_prompts = h.seen_prompts.lock().unwrap();
+            assert_eq!(seen_prompts.len(), 1);
+            assert!(seen_prompts[0].contains("newer prompt must run"));
+            assert!(in_flight.lock().unwrap().is_empty());
+            assert!(cancel_signals.lock().unwrap().is_empty());
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn newer_pending_cancel_survives_stale_older_prompt() {
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async {
+            let h = connect_for_dispatch(MockBehavior::Reply);
+            let (tab_to_session, in_flight, cancel_signals, memo) = fresh_dispatch_state();
+            cancel_signals
+                .lock()
+                .unwrap()
+                .insert("0".to_string(), PromptCancelEntry::Pending { prompt_id: 2 });
+
+            let task = dispatch_prompt(
+                test_prompt(1, "stale prompt must not run", false),
+                &h.conn,
+                &tab_to_session,
+                &memo,
+                &in_flight,
+                &cancel_signals,
+                &h.event_tx,
+                &h.shell_mgr,
+                &h.prompt_timing,
+                &h.client,
+                &PromptUsageIdentity::default(),
+                false,
+                false,
+                true,
+                &h.proposal_channels,
+            );
+
+            assert!(task.is_none());
+            assert!(tab_to_session.lock().await.is_empty());
+            assert!(in_flight.lock().unwrap().is_empty());
+            assert!(h.seen_prompts.lock().unwrap().is_empty());
+            assert_eq!(
+                cancel_signals
+                    .lock()
+                    .unwrap()
+                    .get("0")
+                    .map(PromptCancelEntry::prompt_id),
+                Some(2)
+            );
         })
         .await;
 }
@@ -3108,7 +3583,7 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
             let (tx, rx) = oneshot::channel::<()>();
             cancel_signals.lock().unwrap().insert(
                 "t1".to_string(),
-                PromptCancelEntry {
+                PromptCancelEntry::Registered {
                     prompt_id: 1,
                     signal: tx,
                 },
@@ -3153,7 +3628,13 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
             .await
             .expect("drop must ask master to resolve and close the destroyed tab");
 
-            // No-op: dropping an unbound tab leaves the map empty, no panic.
+            // An unbound tab can still have a cancel latched ahead of prompt
+            // registration. Lifecycle operations must preserve that pending
+            // identity for the queued prompt to consume.
+            cancel_signals.lock().unwrap().insert(
+                "unbound".to_string(),
+                PromptCancelEntry::Pending { prompt_id: 3 },
+            );
             dispatch_drop_session(
                 DropSessionRequest {
                     tab_id: "unbound".to_string(),
@@ -3167,6 +3648,15 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
             )
             .await;
             assert!(tab_to_session.lock().await.is_empty());
+            assert_eq!(
+                cancel_signals
+                    .lock()
+                    .unwrap()
+                    .get("unbound")
+                    .map(PromptCancelEntry::prompt_id),
+                Some(3),
+                "drop must preserve a pending pre-registration cancel"
+            );
             tokio::time::timeout(std::time::Duration::from_secs(5), async {
                 loop {
                     if h.close_tab_requests.lock().unwrap().as_slice()
@@ -3188,7 +3678,7 @@ async fn dispatch_drop_session_closes_unbinds_and_fires_cancel_then_ignores_miss
             let (reset_tx, reset_rx) = oneshot::channel::<()>();
             cancel_signals.lock().unwrap().insert(
                 "reset-tab".to_string(),
-                PromptCancelEntry {
+                PromptCancelEntry::Registered {
                     prompt_id: 2,
                     signal: reset_tx,
                 },
@@ -3251,6 +3741,10 @@ async fn dispatch_new_session_creates_binds_and_emits_attached() {
             let h = connect_for_dispatch(MockBehavior::Reply);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
             let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
+            cancel_signals.lock().unwrap().insert(
+                "t1".to_string(),
+                PromptCancelEntry::Pending { prompt_id: 8 },
+            );
             let memo = TemplateMemo::default();
             let mut event_rx = h.event_rx;
 
@@ -3285,6 +3779,15 @@ async fn dispatch_new_session_creates_binds_and_emits_attached() {
                 tab_to_session.lock().await.get("t1").map(|s| s.to_string()),
                 Some("mock-session-1".to_string()),
                 "new session must be bound to the tab"
+            );
+            assert_eq!(
+                cancel_signals
+                    .lock()
+                    .unwrap()
+                    .get("t1")
+                    .map(PromptCancelEntry::prompt_id),
+                Some(8),
+                "new-session lifecycle must preserve queued cancellation"
             );
         })
         .await;
@@ -3361,7 +3864,7 @@ async fn dispatch_new_session_replaces_old_and_fires_its_cancel() {
             let (tx_old, rx_old) = oneshot::channel::<()>();
             cancel_signals.lock().unwrap().insert(
                 "t1".to_string(),
-                PromptCancelEntry {
+                PromptCancelEntry::Registered {
                     prompt_id: 1,
                     signal: tx_old,
                 },
@@ -3417,6 +3920,10 @@ async fn dispatch_load_session_binds_and_emits_attached() {
             let h = connect_for_dispatch(MockBehavior::Reply);
             let tab_to_session = std::sync::Arc::new(tokio::sync::Mutex::new(HashMap::new()));
             let cancel_signals = Arc::new(Mutex::new(HashMap::new()));
+            cancel_signals.lock().unwrap().insert(
+                "t1".to_string(),
+                PromptCancelEntry::Pending { prompt_id: 9 },
+            );
             let mut event_rx = h.event_rx;
 
             dispatch_load_session(
@@ -3450,6 +3957,15 @@ async fn dispatch_load_session_binds_and_emits_attached() {
                 tab_to_session.lock().await.get("t1").map(|s| s.to_string()),
                 Some("hist-sess-7".to_string()),
                 "loaded session must be bound to the tab"
+            );
+            assert_eq!(
+                cancel_signals
+                    .lock()
+                    .unwrap()
+                    .get("t1")
+                    .map(PromptCancelEntry::prompt_id),
+                Some(9),
+                "load-session lifecycle must preserve queued cancellation"
             );
         })
         .await;

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -2811,6 +2811,10 @@ async fn dispatch_prompt_new_session_failure_emits_error_and_releases_slot() {
                 in_flight.lock().unwrap().is_empty(),
                 "single-flight slot must be released on new_session failure"
             );
+            assert!(
+                cancel_signals.lock().unwrap().is_empty(),
+                "new_session failure must remove the prompt's cancel entry"
+            );
             assert!(tab_to_session.lock().await.is_empty());
             assert!(h.seen_prompts.lock().unwrap().is_empty());
         })

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -3369,7 +3369,7 @@ async fn prompt_then_cancel_channels_latch_cancel_before_prompt_dispatch() {
 }
 
 #[tokio::test]
-async fn registered_cancel_settles_after_prompt_quiesces() {
+async fn registered_cancel_settles_after_prompt_finishes() {
     let local = tokio::task::LocalSet::new();
     local
         .run_until(async {

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -469,6 +469,7 @@ fn session_attach_reconciles_latest_yolo_state() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: "new-yolo-session".into(),
+        prompt_id: None,
         available_models: Vec::new(),
         current_model_id: None,
     });
@@ -500,6 +501,7 @@ fn client_reconciled_session_attach_does_not_duplicate_native_yolo_rpc() {
     app.handle_event(AppEvent::SessionAttached {
         tab_id: DEFAULT_TAB_ID.into(),
         session_id: session_id.into(),
+        prompt_id: None,
         available_models: Vec::new(),
         current_model_id: None,
     });
@@ -581,6 +583,7 @@ fn slash_restart_resets_connection_and_clears_sessions() {
         app.restart_without_acp_pending,
         "a closed lifecycle receiver must leave the helper waiting for replacement-master readiness"
     );
+    app.handle_event(AppEvent::AgentTransportRetired);
 
     app.handle_event(AppEvent::WtEvent {
         method: "agent_master_restarted".into(),

--- a/tools/wta/src/slash_command_tests.rs
+++ b/tools/wta/src/slash_command_tests.rs
@@ -390,6 +390,43 @@ fn slash_stop_when_idle_notes_nothing_to_stop() {
 }
 
 #[test]
+fn slash_stop_while_cancelling_is_idempotent() {
+    let mut app = test_app();
+    let prompt = crate::protocol::acp::client::PromptSubmission::new("stop this".into(), None);
+    let cancellation = prompt.cancellation_token();
+    app.turn_submit_prompt_for_tab_with_cancellation(
+        DEFAULT_TAB_ID,
+        SubmittedPrompt {
+            id: prompt.id,
+            text: prompt.text,
+            submitted_at_unix_s: prompt.submitted_at_unix_s,
+            context: TurnContext::default(),
+            autofix: None,
+        },
+        cancellation,
+    );
+
+    run_slash(&mut app, "stop");
+    run_slash(&mut app, "stop");
+
+    assert!(app.current_tab().turn.is_cancelling());
+    assert_eq!(
+        app.current_tab()
+            .messages
+            .iter()
+            .filter(|message| matches!(
+                message,
+                ChatMessage::Notice {
+                    kind: NoticeKind::Success,
+                    ..
+                }
+            ))
+            .count(),
+        1
+    );
+}
+
+#[test]
 fn slash_new_when_idle_resets_session() {
     let (mut app, _new_session_rx) = test_app_with_new_session_rx();
     app.current_tab_mut().session_id = Some("sid-1".into());


### PR DESCRIPTION
## Summary

- give every prompt a cancellation token shared by App turn state and the ACP prompt task
- keep the turn in `Cancelling` until that exact producer quiesces, is cancelled before dispatch, or its transport generation is retired
- send provider `session/cancel` only after the prompt task resolves the real ACP session, while rejecting late output and interaction events from retired sessions
- preserve cancellation barriers across reset, reconnect, session load, tab rename, Autofix, permission, and MCP user-input flows

## Root cause

The UI previously treated a cancellation request as turn completion even though the helper and ACP producer could still be active. Because ACP output is session-scoped rather than WTA-prompt-scoped, admitting another prompt during that window could return busy and route output from the cancelled turn into the new turn.

The fix makes cancellation ownership prompt-scoped and treats producer quiescence or conclusive transport retirement as the admission boundary. Session lifecycle operations use alias-aware generations so delayed `/new`, load, reset, rename, and reconnect results cannot rebind stale state.

## Validation

- `cargo fmt --manifest-path tools/wta/Cargo.toml -- --check`
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- 2047 passed, 0 failed, 1 ignored
- `git diff --check`
