### PR TITLE
[Performance] Remove WTA helper pane self-discovery

### DIFF
--- a/tools/wta/src/helper/runtime.rs
+++ b/tools/wta/src/helper/runtime.rs
@@ -129,12 +129,6 @@ pub(super) async fn run_default_tui_over_pipe(
     };
     let shell_mgr = Arc::new(shell_mgr);
 
-    let pane_identity = if wt_connected {
-        discover_pane_identity(&shell_mgr).await
-    } else {
-        None
-    };
-
     // Connection failures to wta-master (pipe connect give-up, ACP initialize
     // timeout/failure) are logged at their source (target=helper) and again in
     // `run_acp_tui_mode`'s exit branch, which `process::exit`s rather than
@@ -144,7 +138,6 @@ pub(super) async fn run_default_tui_over_pipe(
         shell_mgr,
         wt_connected,
         debug_rx,
-        pane_identity,
         wt_event_rx,
         wt_protocol_channel,
         pipe_name,
@@ -161,6 +154,13 @@ async fn resolve_app_source_cwd(
         return Some(cwd);
     }
     crate::agent_source::resolve_source_cwd(source, legacy_environment_cwd.as_deref()).await
+}
+
+fn normalize_spawn_identity(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 #[cfg(test)]
@@ -214,55 +214,24 @@ mod cwd_tests {
     }
 }
 
-/// Discover our own pane identity by matching our PID against WT's pane list.
-async fn discover_pane_identity(shell_mgr: &ShellManager) -> Option<(String, String, String)> {
-    let our_pid = std::process::id();
+#[cfg(test)]
+mod identity_tests {
+    use super::normalize_spawn_identity;
 
-    // WT IDs may arrive as JSON strings or numbers (COM returns numeric) — accept both.
-    fn id_str(v: Option<&serde_json::Value>) -> Option<String> {
-        match v {
-            Some(serde_json::Value::String(s)) => Some(s.clone()),
-            Some(serde_json::Value::Number(n)) => Some(n.to_string()),
-            _ => None,
-        }
+    #[test]
+    fn spawn_identity_trims_valid_values() {
+        assert_eq!(
+            normalize_spawn_identity(Some("  {pane-session-id}  ")).as_deref(),
+            Some("{pane-session-id}")
+        );
     }
 
-    let windows = shell_mgr.wt_list_windows().await.ok()?;
-    let windows_arr = windows.get("windows")?.as_array()?;
-
-    for win in windows_arr {
-        let window_id = match id_str(win.get("window_id")) {
-            Some(w) => w,
-            None => continue,
-        };
-        let tabs = shell_mgr.wt_list_tabs(&window_id).await.ok()?;
-        let tabs_arr = tabs.get("tabs")?.as_array()?;
-
-        for tab in tabs_arr {
-            let tab_id_str = match id_str(tab.get("tab_id")) {
-                Some(t) => t,
-                None => continue,
-            };
-            let panes = shell_mgr
-                .wt_list_panes(&tab_id_str, Some(&window_id))
-                .await
-                .ok()?;
-            let panes_arr = panes.get("panes")?.as_array()?;
-
-            for pane in panes_arr {
-                if let Some(pid) = pane.get("pid").and_then(|v| v.as_u64()) {
-                    if pid == our_pid as u64 {
-                        let pane_id = match id_str(pane.get("session_id")) {
-                            Some(p) => p,
-                            None => continue,
-                        };
-                        return Some((pane_id, tab_id_str.clone(), window_id.to_string()));
-                    }
-                }
-            }
-        }
+    #[test]
+    fn spawn_identity_rejects_missing_or_empty_values() {
+        assert_eq!(normalize_spawn_identity(None), None);
+        assert_eq!(normalize_spawn_identity(Some("")), None);
+        assert_eq!(normalize_spawn_identity(Some(" \t\r\n ")), None);
     }
-    None
 }
 
 struct TuiRestoreGuard {
@@ -302,7 +271,6 @@ async fn run_acp_tui_mode(
     shell_mgr: Arc<ShellManager>,
     wt_connected: bool,
     debug_rx: tokio::sync::mpsc::UnboundedReceiver<app::DebugMessage>,
-    pane_identity: Option<(String, String, String)>,
     wt_event_rx: Option<tokio::sync::mpsc::UnboundedReceiver<serde_json::Value>>,
     wt_protocol_channel: Option<Arc<CliChannel>>,
     connect_master_pipe: String,
@@ -329,7 +297,6 @@ async fn run_acp_tui_mode(
         shell_mgr,
         wt_connected,
         debug_rx,
-        pane_identity,
         wt_event_rx,
         wt_protocol_channel,
         connect_master_pipe,
@@ -401,7 +368,6 @@ async fn run_acp_app(
     shell_mgr: Arc<ShellManager>,
     wt_connected: bool,
     mut debug_rx: tokio::sync::mpsc::UnboundedReceiver<app::DebugMessage>,
-    pane_identity: Option<(String, String, String)>,
     wt_event_rx: Option<tokio::sync::mpsc::UnboundedReceiver<serde_json::Value>>,
     wt_protocol_channel: Option<Arc<CliChannel>>,
     connect_master_pipe: String,
@@ -1228,30 +1194,21 @@ async fn run_acp_app(
             // its `session/list` snapshot. See
             // doc/specs/per-cli-history-filtering.md.
 
-            if let Some((pane_id, _tab_id, window_id)) = pane_identity {
-                app_state.pane_id = Some(pane_id);
-                // discover_pane_identity returns the legacy unstable tab
-                // index, not the GUID — ignore it. The stable owner-tab GUID
-                // is passed by WT via --owner-tab-id (see below) and seeded
-                // directly into app_state.tab_id.
-                app_state.window_id = Some(window_id);
-            }
-            else if let Some(pane_id) = std::env::var("WT_SESSION")
-                .ok()
-                .map(|value| value.trim().to_string())
-                .filter(|value| !value.is_empty())
-            {
+            // ConptyConnection supplies the helper's pane identity directly.
+            // Window and stable tab identity come from the owner arguments
+            // below, so no Terminal-wide pane enumeration is required.
+            let wt_session = std::env::var("WT_SESSION").ok();
+            if let Some(pane_id) = normalize_spawn_identity(wt_session.as_deref()) {
                 tracing::info!(
                     target: "tab_session",
                     pane_id = %pane_id,
-                    "seeded app_state.pane_id from WT_SESSION fallback"
+                    "seeded app_state.pane_id from WT_SESSION"
                 );
                 app_state.pane_id = Some(pane_id);
             }
 
             // WT knows the owning window authoritatively when it creates the
-            // helper. Prefer that seed over best-effort PID discovery so
-            // outbound per-window events work from the first render.
+            // helper, so outbound per-window events work from the first render.
             if let Some(owner_window_id) = config
                 .owner_window_id
                 .as_deref()


### PR DESCRIPTION
## Summary of the Pull Request

Remove the WTA helper's Terminal-wide pane self-discovery from its startup path. The helper now uses the pane, tab, and window identities already supplied when Terminal launches it.

## References and Relevant Issues

Performance follow-up based on the agent pane startup latency investigation.

Closes #837

## Detailed Description of the Pull Request / Additional comments

Every helper previously enumerated all Terminal windows, every tab in each window, and every pane in each tab to find its own PID. Each query launches a separate `wtcli.exe` process and activates the Terminal COM server, so startup cost grew with the number of open tabs.

The discovered values were redundant:

- Pane identity is already available through `WT_SESSION`.
- Stable tab identity is already supplied through `--owner-tab-id`.
- Window identity is already supplied through `--owner-window-id`.

This change removes the enumeration and the intermediate identity plumbing. It keeps non-pane launch behavior unchanged when those values are unavailable and adds focused coverage for spawn identity normalization.

## Performance Results

### Method

- x64 Debug package built from `main` at `fbe0b12ec501b5db1a90962ad7e1bbd0c7d3597b`.
- Baseline WTA SHA-256: `C6EBC8E625E8755F4A2EF21C9BB54EC4245A667516CB74E9750DDF3E71EC8DE0`.
- Candidate WTA at `ee8bcf6e293936f5335690a7b3eb879ceead4cb4`.
- Candidate WTA SHA-256: `D265D2B84F1CDF292A9E336727F43434C9CAB426F1047C0FDB52992920BD7A8C`.
- The Terminal package and settings were held fixed; only `wta.exe` was swapped.
- Each sample used fresh Terminal/WTA processes. Baseline and candidate order alternated between pairs to reduce ordering, cache, Defender, and machine-load bias.
- Direct discovery metric: `Connected to WT COM protocol` to `start_reader: starting`.
- End-to-end helper startup proxy: `Connected to WT COM protocol` to `master pipe connected`.
- Provider initialization and first-token latency are excluded because they are dominated by provider and network behavior.

### One-window, one-tab startup

Ten alternating A/B pairs:

| Metric | `main` baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| COM to master connection, p50 | 503.40 ms | 221.69 ms | **56.0% faster** |
| COM to master connection, mean | 511.54 ms | 247.23 ms | **51.7% faster** |
| COM to master connection, p95 | 570.49 ms | 358.37 ms | **37.2% faster** |
| Discovery stage, p50 | 328.95 ms | 3.10 ms | **99.1% faster** |
| Observed `wtcli.exe` starts, median | 9.5 | 6.0 | **3.5 fewer** |

The candidate was faster in all 10 paired comparisons. The median paired saving was 278.84 ms, or 56.6%.

The process count is a best-effort 25 ms sampler and includes fixed listener/startup processes, so it may miss very short-lived processes. The source-level change removes the topology queries themselves: one `list-windows`, one `list-tabs` per window, and one `list-panes` per tab.

### Five-tab burst

Five alternating A/B pairs created four additional tabs through the WT protocol and measured the fifth helper:

| Metric for fifth helper | `main` baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| Discovery stage, p50 | 1485.26 ms | 323.87 ms | **78.2% faster** |
| Discovery stage, range | 1426.04-1786.56 ms | 113.70-350.25 ms | Lower and tighter |
| COM to master connection, p50 | 2632.19 ms | 1396.55 ms | **46.9% faster** |

The five-tab run intentionally creates realistic helper/ACP contention. That downstream contention makes the COM-to-master metric noisier; the discovery-stage metric is the direct measurement of the code removed by this PR.

These are Debug-build results and should be interpreted as a controlled relative comparison rather than absolute Release latency.

## Validation Steps Performed

- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- Result: 2009 passed, 0 failed, 1 ignored

## PR Checklist
- [x] Closes #837
- [x] Tests added/passed
- [ ] Documentation updated
- [ ] Schema updated (if necessary)
