### PR TITLE
Fix agent pool generation ownership races

### DIFF
--- a/test/e2e/tests/Feature.AgentRestart.Tests.ps1
+++ b/test/e2e/tests/Feature.AgentRestart.Tests.ps1
@@ -15,7 +15,12 @@ BeforeDiscovery { $script:Ready = [bool]((Get-AppxPackage | Where-Object { $_.Na
 Describe 'Feature: agent restart' -Tag 'Feature' -Skip:(-not $script:Ready) {
     BeforeAll {
         Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
-        $script:app = Start-Terminal -Package (Get-ItTestPackage) -PassFre $true -Settings @{ acpAgent = 'copilot' }
+        $script:app = Start-Terminal -Package (Get-ItTestPackage) -PassFre $true -Settings @{
+            acpAgent = 'copilot'
+            # This suite tests restart/reconnect, not permission enforcement.
+            # Current Copilot CLI builds cannot submit ACP prompts with Yolo disabled.
+            'agentPane.yoloMode' = $true
+        }
         Open-AgentPane -App $script:app | Out-Null
         Wait-AgentReady -App $script:app -TimeoutSec 60 | Out-Null
     }

--- a/test/e2e/tests/Feature.SessionList.Tests.ps1
+++ b/test/e2e/tests/Feature.SessionList.Tests.ps1
@@ -8,7 +8,12 @@ BeforeDiscovery { $script:Ready = [bool]((Get-AppxPackage | Where-Object { $_.Na
 Describe 'Feature: session list + view switching + focus/restore' -Tag 'Feature' -Skip:(-not $script:Ready) {
     BeforeAll {
         Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
-        $script:app = Start-Terminal -Package (Get-ItTestPackage) -PassFre $true -Settings @{ acpAgent = 'copilot' }
+        $script:app = Start-Terminal -Package (Get-ItTestPackage) -PassFre $true -Settings @{
+            acpAgent = 'copilot'
+            # This suite tests session management, not permission enforcement.
+            # Current Copilot CLI builds cannot submit ACP prompts with Yolo disabled.
+            'agentPane.yoloMode' = $true
+        }
         Open-AgentPane -App $script:app | Out-Null
         Wait-AgentReady -App $script:app -TimeoutSec 60 | Out-Null
         # Seed a live session with a known marker so a row exists.
@@ -37,7 +42,10 @@ Describe 'Feature: session list + view switching + focus/restore' -Tag 'Feature'
         }
         It 'Session view shows rows with navigation hints' {
             Assert-AgentPaneText -App $script:app -Pattern 'to launch session|to navigate|Enter to launch' -TimeoutSec 8
-            @(Get-SessionRows -App $script:app).Count | Should -BeGreaterThan 0
+            $rowsRendered = Test-Until -TimeoutSec 8 -IntervalSec 0.5 -Condition {
+                @(Get-SessionRows -App $script:app).Count -gt 0
+            }
+            $rowsRendered | Should -BeTrue -Because 'the rendered session view must expose at least one parsed row'
         }
         It 'Session view refresh works (reopen renders the list again)' {
             Close-SessionList -App $script:app | Out-Null

--- a/test/e2e/tests/Feature.SharedAgentLifecycle.Tests.ps1
+++ b/test/e2e/tests/Feature.SharedAgentLifecycle.Tests.ps1
@@ -21,7 +21,12 @@ BeforeDiscovery {
 Describe 'Feature: shared agent CLI lifecycle' -Tag 'Feature' -Skip:(-not $script:Ready) {
     BeforeAll {
         Import-Module (Join-Path $PSScriptRoot '..\ItE2E\ItE2E.psd1') -Force
-        $script:app = Start-Terminal -Package Dev -PassFre $true -Settings @{ acpAgent = 'copilot' }
+        $script:app = Start-Terminal -Package Dev -PassFre $true -Settings @{
+            acpAgent = 'copilot'
+            # This suite tests shared-process lifecycle, not permission enforcement.
+            # Current Copilot CLI builds cannot submit ACP prompts with Yolo disabled.
+            'agentPane.yoloMode' = $true
+        }
 
         $script:GetMaster = {
             @(Get-CimInstance Win32_Process -Filter "Name='wta.exe'" -ErrorAction SilentlyContinue |

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -4712,6 +4712,101 @@ fn requested_model_is_explicit(agent_cmd: &str, agent_id: Option<&str>) -> bool 
 /// new agent serialize on the per-key `OnceCell`; helpers for different
 /// agents spawn in parallel because the outer map lock is held only
 /// long enough to get/insert the cell, never across the spawn.
+#[derive(Debug)]
+struct RetiredAgentCell;
+
+impl std::fmt::Display for RetiredAgentCell {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("agent-pool generation was retired")
+    }
+}
+
+impl std::error::Error for RetiredAgentCell {}
+
+async fn agent_cell_is_current(
+    state: &MasterStateInner,
+    key: &AgentCmdKey,
+    cell: &AgentCell,
+) -> bool {
+    state
+        .agents
+        .lock()
+        .await
+        .get(key)
+        .is_some_and(|current| Arc::ptr_eq(current, cell))
+}
+
+async fn remove_agent_cell_if_current(
+    state: &MasterStateInner,
+    key: &AgentCmdKey,
+    cell: &AgentCell,
+) -> bool {
+    let mut agents = state.agents.lock().await;
+    if agents
+        .get(key)
+        .is_some_and(|current| Arc::ptr_eq(current, cell))
+    {
+        agents.remove(key);
+        true
+    } else {
+        false
+    }
+}
+
+async fn acquire_agent_from_pool<F, Fut>(
+    state: &MasterStateInner,
+    key: &AgentCmdKey,
+    mut initialize: F,
+) -> Result<Arc<AgentCli>>
+where
+    F: FnMut(AgentCell) -> Fut,
+    Fut: Future<Output = Result<Arc<AgentCli>>>,
+{
+    loop {
+        let cell = {
+            let mut agents = state.agents.lock().await;
+            Arc::clone(
+                agents
+                    .entry(key.clone())
+                    .or_insert_with(|| Arc::new(tokio::sync::OnceCell::new())),
+            )
+        };
+
+        let initialized = cell
+            .get_or_try_init(|| async {
+                // A failed initializer retires its cell before waking waiters.
+                // Waiters that captured that cell must join the replacement
+                // generation instead of starting another process in the stale
+                // cell where the old process's reaper can still reach it.
+                if !agent_cell_is_current(state, key, &cell).await {
+                    return Err(anyhow!(RetiredAgentCell));
+                }
+
+                match initialize(Arc::clone(&cell)).await {
+                    Ok(agent) => Ok(agent),
+                    Err(error) => {
+                        remove_agent_cell_if_current(state, key, &cell).await;
+                        Err(error)
+                    }
+                }
+            })
+            .await;
+
+        match initialized {
+            Ok(agent) if agent_cell_is_current(state, key, &cell).await => {
+                return Ok(Arc::clone(agent));
+            }
+            Ok(agent) => {
+                // The process initialized after its generation was retired.
+                // Do not leave an untracked provider running outside the pool.
+                agent.conn.shutdown();
+            }
+            Err(error) if error.is::<RetiredAgentCell>() => {}
+            Err(error) => return Err(error),
+        }
+    }
+}
+
 async fn get_or_spawn_agent(
     state: &Arc<MasterStateInner>,
     agent_cmd: &str,
@@ -4721,21 +4816,12 @@ async fn get_or_spawn_agent(
     supplied_cloud_models: Vec<crate::app::AcpModelInfo>,
 ) -> Result<Arc<AgentCli>> {
     let key = agent_cmd_key_with_provider(agent_cmd, agent_id, source, &provider_binding);
-    let cell = {
-        let mut agents = state.agents.lock().await;
-        Arc::clone(
-            agents
-                .entry(key.clone())
-                .or_insert_with(|| Arc::new(tokio::sync::OnceCell::new())),
-        )
-    };
-    // On spawn/init failure the `OnceCell` stays uninitialized and
-    // `spawn_one_agent` kills its child, whose closing stdio ends the I/O
-    // task that then `reap_agent`s this key out of the map — so a later
-    // helper requesting the same agent gets a fresh cell and retries
-    // cleanly (no lingering dead slot, no leaked subprocess).
-    let agent = cell
-        .get_or_try_init(|| async {
+    let initialization_key = key.clone();
+    acquire_agent_from_pool(state, &key, move |cell| {
+        let key = initialization_key.clone();
+        let provider_binding = provider_binding.clone();
+        let supplied_cloud_models = supplied_cloud_models.clone();
+        async move {
             spawn_one_agent(
                 state,
                 &cell,
@@ -4747,9 +4833,9 @@ async fn get_or_spawn_agent(
                 supplied_cloud_models,
             )
             .await
-        })
-        .await?;
-    Ok(Arc::clone(agent))
+        }
+    })
+    .await
 }
 
 /// Spawn one agent CLI subprocess, wire master as its ACP client, run
@@ -5170,10 +5256,13 @@ async fn reap_agent(
 ) {
     let removed = {
         let mut agents = state.agents.lock().await;
-        if agents
+        let owns_generation = agents
             .get(key)
-            .is_some_and(|current| Arc::ptr_eq(current, cell))
-        {
+            .is_some_and(|current| Arc::ptr_eq(current, cell));
+        let owns_instance = cell
+            .get()
+            .is_none_or(|agent| agent.instance_id == instance_id);
+        if owns_generation && owns_instance {
             agents.remove(key);
             true
         } else {

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -79,6 +79,7 @@ pub(crate) struct HelperId(u64);
 type AgentCmdKey = String;
 type AgentInstanceId = uuid::Uuid;
 type AgentCell = Arc<OnceCell<Arc<AgentCli>>>;
+type WeakAgentCell = Weak<OnceCell<Arc<AgentCli>>>;
 
 struct CustomModelGeneration {
     config: crate::custom_model_provider::Config,
@@ -479,6 +480,11 @@ struct MasterStateInner {
     /// under the same command line never re-binds to a session it never had —
     /// such a resume falls back to a real `session/load` from disk.
     orphaned_sessions: Mutex<HashMap<AgentCmdKey, HashSet<acp::schema::v1::SessionId>>>,
+    /// Generations whose initializer was cancelled before its `OnceCell`
+    /// published a value. This uses a synchronous mutex so the initializer's
+    /// drop guard can tombstone the generation before `get_or_try_init` wakes
+    /// queued waiters.
+    retired_agent_cells: std::sync::Mutex<Vec<WeakAgentCell>>,
     /// Stable tab identity retained when a helper disconnect wins the race
     /// against the terminal's close-by-tab request. This lets a surviving
     /// helper physically close the now-orphaned ACP session milliseconds later.
@@ -4293,6 +4299,7 @@ async fn run_master_loop(config: MasterConfig, pipe_name: String) -> Result<()> 
         hook_owned: Mutex::new(HashSet::new()),
         born_bound: Mutex::new(HashSet::new()),
         orphaned_sessions: Mutex::new(HashMap::new()),
+        retired_agent_cells: std::sync::Mutex::new(Vec::new()),
         orphaned_tabs: Mutex::new(HashMap::new()),
     });
     {
@@ -4743,17 +4750,79 @@ impl std::fmt::Display for RetiredAgentCell {
 
 impl std::error::Error for RetiredAgentCell {}
 
+fn retired_agent_cells(state: &MasterStateInner) -> std::sync::MutexGuard<'_, Vec<WeakAgentCell>> {
+    state
+        .retired_agent_cells
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn agent_cell_is_retired(state: &MasterStateInner, cell: &AgentCell) -> bool {
+    let mut retired = retired_agent_cells(state);
+    retired.retain(|candidate| candidate.strong_count() > 0);
+    let cell = Arc::downgrade(cell);
+    retired
+        .iter()
+        .any(|candidate| Weak::ptr_eq(candidate, &cell))
+}
+
+fn retire_agent_cell(state: &MasterStateInner, cell: &AgentCell) {
+    let mut retired = retired_agent_cells(state);
+    retired.retain(|candidate| candidate.strong_count() > 0);
+    let cell = Arc::downgrade(cell);
+    if !retired
+        .iter()
+        .any(|candidate| Weak::ptr_eq(candidate, &cell))
+    {
+        retired.push(cell);
+    }
+}
+
+struct AgentInitializationRetirement<'a> {
+    state: &'a MasterStateInner,
+    cell: AgentCell,
+    armed: bool,
+}
+
+impl<'a> AgentInitializationRetirement<'a> {
+    fn new(state: &'a MasterStateInner, cell: AgentCell) -> Self {
+        Self {
+            state,
+            cell,
+            armed: true,
+        }
+    }
+
+    fn retire(&mut self) {
+        if self.armed {
+            retire_agent_cell(self.state, &self.cell);
+            self.armed = false;
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for AgentInitializationRetirement<'_> {
+    fn drop(&mut self) {
+        self.retire();
+    }
+}
+
 async fn agent_cell_is_current(
     state: &MasterStateInner,
     key: &AgentCmdKey,
     cell: &AgentCell,
 ) -> bool {
-    state
-        .agents
-        .lock()
-        .await
-        .get(key)
-        .is_some_and(|current| Arc::ptr_eq(current, cell))
+    !agent_cell_is_retired(state, cell)
+        && state
+            .agents
+            .lock()
+            .await
+            .get(key)
+            .is_some_and(|current| Arc::ptr_eq(current, cell))
 }
 
 async fn remove_agent_cell_if_current(
@@ -4785,6 +4854,12 @@ where
     loop {
         let cell = {
             let mut agents = state.agents.lock().await;
+            if agents
+                .get(key)
+                .is_some_and(|cell| agent_cell_is_retired(state, cell))
+            {
+                agents.remove(key);
+            }
             Arc::clone(
                 agents
                     .entry(key.clone())
@@ -4802,9 +4877,14 @@ where
                     return Err(anyhow!(RetiredAgentCell));
                 }
 
+                let mut retirement = AgentInitializationRetirement::new(state, Arc::clone(&cell));
                 match initialize(Arc::clone(&cell)).await {
-                    Ok(agent) => Ok(agent),
+                    Ok(agent) => {
+                        retirement.disarm();
+                        Ok(agent)
+                    }
                     Err(error) => {
+                        retirement.retire();
                         remove_agent_cell_if_current(state, key, &cell).await;
                         Err(error)
                     }

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -443,6 +443,8 @@ struct MasterStateInner {
     #[cfg(test)]
     disconnect_orphan_publication_pause: Mutex<Option<Arc<DisconnectOrphanPublicationPause>>>,
     #[cfg(test)]
+    reap_agent_orphan_cleanup_pause: Mutex<Option<Arc<ReapAgentOrphanCleanupPause>>>,
+    #[cfg(test)]
     deferred_retirement_cleanup_complete: tokio::sync::Notify,
     /// Session ids claimed by an *authoritative* producer — a native agent hook
     /// (arrives via `intellterm.wta/session_hook`) or an ACP agent-pane
@@ -472,10 +474,10 @@ struct MasterStateInner {
     /// has it (a re-load would be rejected "already loaded", or, if the
     /// orphan turn is still running, wedge behind it and hang the pane on
     /// "Resuming…"). Only recorded while the owning CLI *instance* is still
-    /// the live pool entry (checked via `Arc::ptr_eq`), and `reap_agent`
-    /// drops just that agent's set on CLI death, so a crashed-and-respawned
-    /// CLI under the same command line never re-binds to a session it never
-    /// had — such a resume falls back to a real `session/load` from disk.
+    /// the live pool entry (checked under the `agents` lock), and `reap_agent`
+    /// drops just that agent's set on CLI death, so a crashed-and-respawned CLI
+    /// under the same command line never re-binds to a session it never had —
+    /// such a resume falls back to a real `session/load` from disk.
     orphaned_sessions: Mutex<HashMap<AgentCmdKey, HashSet<acp::schema::v1::SessionId>>>,
     /// Stable tab identity retained when a helper disconnect wins the race
     /// against the terminal's close-by-tab request. This lets a surviving
@@ -495,6 +497,13 @@ struct MasterStateInner {
 struct DisconnectOrphanPublicationPause {
     routes_dropped: tokio::sync::Notify,
     resume_publication: tokio::sync::Notify,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct ReapAgentOrphanCleanupPause {
+    agent_removed: tokio::sync::Notify,
+    resume_cleanup: tokio::sync::Notify,
 }
 
 async fn session_lifecycle_gate(
@@ -553,6 +562,7 @@ async fn rollback_orphan_rebind(
     state: &MasterStateInner,
     helper_id: HelperId,
     agent_key: &AgentCmdKey,
+    expected_agent_instance_id: AgentInstanceId,
     session_id: &acp::schema::v1::SessionId,
     previous: Option<HelperRoute>,
 ) -> SwappedSessionRouteRollback {
@@ -565,13 +575,20 @@ async fn rollback_orphan_rebind(
         (rollback, !routes.contains_key(session_id))
     };
     if rollback == SwappedSessionRouteRollback::Restored && route_absent {
-        state
-            .orphaned_sessions
-            .lock()
-            .await
-            .entry(agent_key.clone())
-            .or_default()
-            .insert(session_id.clone());
+        let agents = state.agents.lock().await;
+        let expected_instance_is_current = agents
+            .get(agent_key)
+            .and_then(|cell| cell.get())
+            .is_some_and(|agent| agent.instance_id == expected_agent_instance_id);
+        if expected_instance_is_current {
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry(agent_key.clone())
+                .or_default()
+                .insert(session_id.clone());
+        }
     }
     rollback
 }
@@ -3475,6 +3492,7 @@ impl HelperHandler {
                             &self.state,
                             self.helper_id,
                             &agent.cmd_key,
+                            agent.instance_id,
                             &session_id,
                             previous_target_route,
                         )
@@ -4268,6 +4286,8 @@ async fn run_master_loop(config: MasterConfig, pipe_name: String) -> Result<()> 
         retirement_pending_timeout: SESSION_CLOSE_TIMEOUT,
         #[cfg(test)]
         disconnect_orphan_publication_pause: Mutex::new(None),
+        #[cfg(test)]
+        reap_agent_orphan_cleanup_pause: Mutex::new(None),
         #[cfg(test)]
         deferred_retirement_cleanup_complete: tokio::sync::Notify::new(),
         hook_owned: Mutex::new(HashSet::new()),
@@ -5254,6 +5274,8 @@ async fn reap_agent(
     cell: &AgentCell,
     instance_id: AgentInstanceId,
 ) {
+    #[cfg(test)]
+    let cleanup_pause = state.reap_agent_orphan_cleanup_pause.lock().await.clone();
     let removed = {
         let mut agents = state.agents.lock().await;
         let owns_generation = agents
@@ -5264,23 +5286,25 @@ async fn reap_agent(
             .is_none_or(|agent| agent.instance_id == instance_id);
         if owns_generation && owns_instance {
             agents.remove(key);
+            #[cfg(test)]
+            if let Some(pause) = cleanup_pause {
+                pause.agent_removed.notify_one();
+                pause.resume_cleanup.notified().await;
+            }
+            // Keep the key unavailable until all generation-owned state is
+            // gone. Pool publication takes `agents` first, so the consistent
+            // order is agents -> orphaned_sessions -> orphaned_tabs.
+            state.orphaned_sessions.lock().await.remove(key);
+            state
+                .orphaned_tabs
+                .lock()
+                .await
+                .retain(|_, (orphan_key, _, _)| orphan_key != key);
             true
         } else {
             false
         }
     };
-    if removed {
-        // Every session THIS CLI held died with it, so drop only this
-        // agent's orphan set — a post-respawn resume then forwards a real
-        // `session/load` (reloading from disk) instead of re-binding to a
-        // session the new CLI never had. Other agents' orphans are untouched.
-        state.orphaned_sessions.lock().await.remove(key);
-        state
-            .orphaned_tabs
-            .lock()
-            .await
-            .retain(|_, (orphan_key, _, _)| orphan_key != key);
-    }
     let capabilities_removed = state
         .session_mcp_capabilities
         .remove_owner(instance_id)

--- a/tools/wta/src/master/mod.rs
+++ b/tools/wta/src/master/mod.rs
@@ -5293,13 +5293,13 @@ async fn reap_agent(
             }
             // Keep the key unavailable until all generation-owned state is
             // gone. Pool publication takes `agents` first, so the consistent
-            // order is agents -> orphaned_sessions -> orphaned_tabs.
-            state.orphaned_sessions.lock().await.remove(key);
+            // order is agents -> orphaned_tabs -> orphaned_sessions.
             state
                 .orphaned_tabs
                 .lock()
                 .await
                 .retain(|_, (orphan_key, _, _)| orphan_key != key);
+            state.orphaned_sessions.lock().await.remove(key);
             true
         } else {
             false

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -7944,6 +7944,51 @@ async fn reap_agent_keeps_key_unavailable_through_orphan_cleanup() {
         .await;
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn reap_agent_matches_all_retirement_orphan_lock_order() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let key = "copilot --acp --stdio".to_string();
+            let dead_agent = unbound_test_agent(&key);
+            let dead_instance = dead_agent.instance_id;
+            let dead_cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(dead_cell.set(dead_agent).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(key.clone(), Arc::clone(&dead_cell));
+
+            let pause = Arc::new(ReapAgentOrphanCleanupPause::default());
+            *state.reap_agent_orphan_cleanup_pause.lock().await = Some(Arc::clone(&pause));
+            let orphaned_tabs = state.orphaned_tabs.lock().await;
+            let reaper = tokio::task::spawn_local({
+                let state = Arc::clone(&state);
+                let key = key.clone();
+                let dead_cell = Arc::clone(&dead_cell);
+                async move {
+                    reap_agent(&state, &key, &dead_cell, dead_instance).await;
+                }
+            });
+
+            pause.agent_removed.notified().await;
+            pause.resume_cleanup.notify_one();
+            tokio::task::yield_now().await;
+
+            tokio::time::timeout(
+                std::time::Duration::from_secs(1),
+                state.orphaned_sessions.lock(),
+            )
+            .await
+            .expect("reaper must wait for orphaned_tabs without holding orphaned_sessions");
+
+            drop(orphaned_tabs);
+            reaper.await.expect("reaper task should complete");
+        })
+        .await;
+}
+
 /// A stale reaper must revoke its dead CLI instance's capabilities without
 /// disturbing the replacement CLI that now occupies the same pool key.
 #[tokio::test]

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -1047,6 +1047,7 @@ async fn failed_pool_generation_wakes_waiters_into_a_fresh_cell() {
 
             let state = make_state();
             let key = "model:failed-generation-retry".to_string();
+            let failed_instance = AgentInstanceId::new_v4();
             let replacement = unbound_test_agent(&key);
             let first_started = Arc::new(tokio::sync::Notify::new());
             let release_first = Arc::new(tokio::sync::Notify::new());
@@ -1118,6 +1119,19 @@ async fn failed_pool_generation_wakes_waiters_into_a_fresh_cell() {
                     .get(&key)
                     .is_some_and(|cell| Arc::ptr_eq(cell, &retry_cell)),
                 "the replacement generation must remain published"
+            );
+
+            // Complete the original race: the failed provider's I/O/child
+            // reaper can arrive after the waiter publishes its replacement.
+            reap_agent(&state, &key, &first_cell, failed_instance).await;
+            assert!(
+                state
+                    .agents
+                    .lock()
+                    .await
+                    .get(&key)
+                    .is_some_and(|cell| Arc::ptr_eq(cell, &retry_cell)),
+                "the failed generation's delayed reaper must preserve its replacement"
             );
         })
         .await;

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -1377,6 +1377,7 @@ fn make_state_with_retirement_pending_timeout(
         retirement_completion_tx: Mutex::new(None),
         retirement_pending_timeout,
         disconnect_orphan_publication_pause: Mutex::new(None),
+        reap_agent_orphan_cleanup_pause: Mutex::new(None),
         deferred_retirement_cleanup_complete: tokio::sync::Notify::new(),
         hook_owned: Mutex::new(HashSet::new()),
         born_bound: Mutex::new(HashSet::new()),
@@ -7525,6 +7526,92 @@ async fn orphan_rebind_close_failure_does_not_mark_target_owned_by_another_helpe
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn late_old_generation_orphan_rollback_is_not_published_or_consumed() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let key = "late-orphan-rollback-agent".to_string();
+            let helper_id = HelperId(34);
+            let session_id = SessionId::new("late-orphan-rollback-session");
+            let (notif_tx, _notif_rx) = mpsc::channel(NOTIF_CHANNEL_CAPACITY);
+
+            let dead_agent = unbound_test_agent(&key);
+            let dead_instance_id = dead_agent.instance_id;
+            let dead_cell = empty_agent_cell();
+            assert!(dead_cell.set(dead_agent).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(key.clone(), Arc::clone(&dead_cell));
+            bind_session_route(
+                &state,
+                session_id.clone(),
+                HelperRoute {
+                    helper_id,
+                    agent_instance_id: dead_instance_id,
+                    notif_tx,
+                    forwarder: Some(agent_link_to_noop_client()),
+                    consecutive_drops: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+                },
+            )
+            .await;
+
+            let lifecycle_gate = session_lifecycle_gate(&state, &session_id).await;
+            let lifecycle_guard = lifecycle_gate.lock().await;
+            let rollback = tokio::task::spawn_local({
+                let state = Arc::clone(&state);
+                let key = key.clone();
+                let session_id = session_id.clone();
+                async move {
+                    rollback_orphan_rebind(
+                        &state,
+                        helper_id,
+                        &key,
+                        dead_instance_id,
+                        &session_id,
+                        None,
+                    )
+                    .await
+                }
+            });
+
+            reap_agent(&state, &key, &dead_cell, dead_instance_id).await;
+            let replacement = unbound_test_agent(&key);
+            let replacement_cell = empty_agent_cell();
+            assert!(replacement_cell.set(replacement).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(key.clone(), replacement_cell);
+
+            drop(lifecycle_guard);
+            assert_eq!(
+                rollback.await.expect("late rollback should complete"),
+                SwappedSessionRouteRollback::Restored
+            );
+            assert!(!state
+                .session_to_helper
+                .lock()
+                .await
+                .contains_key(&session_id));
+
+            let consumed = state
+                .orphaned_sessions
+                .lock()
+                .await
+                .get_mut(&key)
+                .is_some_and(|sessions| sessions.remove(&session_id));
+            assert!(
+                !consumed,
+                "a late rollback from the dead generation must not publish a stale orphan"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn load_reserves_time_to_close_loaded_target_after_predecessor_timeout() {
     tokio::task::LocalSet::new()
         .run_until(async {
@@ -7754,6 +7841,104 @@ async fn reap_agent_drops_only_its_own_orphans() {
             assert!(
                 orphaned_tabs.contains_key("tab-b"),
                 "reaping one agent must preserve another agent's tab fallback"
+            );
+        })
+        .await;
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn reap_agent_keeps_key_unavailable_through_orphan_cleanup() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let key = "copilot --acp --stdio".to_string();
+            let dead_agent = unbound_test_agent(&key);
+            let dead_instance = dead_agent.instance_id;
+            let dead_cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(dead_cell.set(dead_agent).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(key.clone(), Arc::clone(&dead_cell));
+            state
+                .orphaned_sessions
+                .lock()
+                .await
+                .entry(key.clone())
+                .or_default()
+                .insert(SessionId::new("dead-session"));
+            state.orphaned_tabs.lock().await.insert(
+                "dead-tab".to_string(),
+                (key.clone(), HelperId(1), SessionId::new("dead-session")),
+            );
+
+            let pause = Arc::new(ReapAgentOrphanCleanupPause::default());
+            *state.reap_agent_orphan_cleanup_pause.lock().await = Some(Arc::clone(&pause));
+            let reaper = tokio::task::spawn_local({
+                let state = Arc::clone(&state);
+                let key = key.clone();
+                let dead_cell = Arc::clone(&dead_cell);
+                async move {
+                    reap_agent(&state, &key, &dead_cell, dead_instance).await;
+                }
+            });
+
+            pause.agent_removed.notified().await;
+            assert!(
+                state.agents.try_lock().is_err(),
+                "a replacement generation must not publish before orphan cleanup completes"
+            );
+            pause.resume_cleanup.notify_one();
+            reaper.await.expect("reaper task should complete");
+
+            let replacement = unbound_test_agent(&key);
+            let acquired = acquire_agent_from_pool(&state, &key, {
+                let state = Arc::clone(&state);
+                let key = key.clone();
+                let replacement = Arc::clone(&replacement);
+                move |_| {
+                    let state = Arc::clone(&state);
+                    let key = key.clone();
+                    let replacement = Arc::clone(&replacement);
+                    async move {
+                        state
+                            .orphaned_sessions
+                            .lock()
+                            .await
+                            .entry(key.clone())
+                            .or_default()
+                            .insert(SessionId::new("replacement-session"));
+                        state.orphaned_tabs.lock().await.insert(
+                            "replacement-tab".to_string(),
+                            (key, HelperId(2), SessionId::new("replacement-session")),
+                        );
+                        Ok(replacement)
+                    }
+                }
+            })
+            .await
+            .expect("replacement generation should publish after cleanup");
+
+            assert!(Arc::ptr_eq(&acquired, &replacement));
+            assert!(
+                state
+                    .orphaned_sessions
+                    .lock()
+                    .await
+                    .get(&key)
+                    .is_some_and(|sessions| {
+                        sessions.contains(&SessionId::new("replacement-session"))
+                    }),
+                "the old reaper must not erase replacement orphan sessions"
+            );
+            assert!(
+                state
+                    .orphaned_tabs
+                    .lock()
+                    .await
+                    .contains_key("replacement-tab"),
+                "the old reaper must not erase replacement orphan tabs"
             );
         })
         .await;
@@ -9421,6 +9606,7 @@ fn make_state_with_wt(wt: Arc<dyn crate::shell::wt_channel::WtChannel>) -> Arc<M
         retirement_completion_tx: Mutex::new(None),
         retirement_pending_timeout: SESSION_CLOSE_TIMEOUT,
         disconnect_orphan_publication_pause: Mutex::new(None),
+        reap_agent_orphan_cleanup_pause: Mutex::new(None),
         deferred_retirement_cleanup_complete: tokio::sync::Notify::new(),
         hook_owned: Mutex::new(HashSet::new()),
         born_bound: Mutex::new(HashSet::new()),

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -1039,6 +1039,90 @@ async fn concurrent_helper_initialization_publishes_only_the_winning_agent() {
         .await;
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn failed_pool_generation_wakes_waiters_into_a_fresh_cell() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            use std::sync::atomic::{AtomicUsize, Ordering};
+
+            let state = make_state();
+            let key = "model:failed-generation-retry".to_string();
+            let replacement = unbound_test_agent(&key);
+            let first_started = Arc::new(tokio::sync::Notify::new());
+            let release_first = Arc::new(tokio::sync::Notify::new());
+            let first_cell = Arc::new(Mutex::new(None::<AgentCell>));
+            let retry_cell = Arc::new(Mutex::new(None::<AgentCell>));
+            let retry_initializations = Arc::new(AtomicUsize::new(0));
+
+            let failed = acquire_agent_from_pool(&state, &key, {
+                let first_started = Arc::clone(&first_started);
+                let release_first = Arc::clone(&release_first);
+                let first_cell = Arc::clone(&first_cell);
+                move |cell| {
+                    let first_started = Arc::clone(&first_started);
+                    let release_first = Arc::clone(&release_first);
+                    let first_cell = Arc::clone(&first_cell);
+                    async move {
+                        *first_cell.lock().await = Some(cell);
+                        first_started.notify_one();
+                        release_first.notified().await;
+                        Err(anyhow!("expected initialization failure"))
+                    }
+                }
+            });
+            let retried = acquire_agent_from_pool(&state, &key, {
+                let replacement = Arc::clone(&replacement);
+                let retry_cell = Arc::clone(&retry_cell);
+                let retry_initializations = Arc::clone(&retry_initializations);
+                move |cell| {
+                    let replacement = Arc::clone(&replacement);
+                    let retry_cell = Arc::clone(&retry_cell);
+                    let retry_initializations = Arc::clone(&retry_initializations);
+                    async move {
+                        retry_initializations.fetch_add(1, Ordering::SeqCst);
+                        *retry_cell.lock().await = Some(cell);
+                        Ok(replacement)
+                    }
+                }
+            });
+            let release = async {
+                first_started.notified().await;
+                release_first.notify_one();
+            };
+
+            let (failed, retried, ()) = tokio::join!(biased; failed, retried, release);
+            assert!(failed.is_err());
+            let retried = retried.expect("waiting caller should initialize a fresh generation");
+            assert!(Arc::ptr_eq(&retried, &replacement));
+            assert_eq!(retry_initializations.load(Ordering::SeqCst), 1);
+
+            let first_cell = first_cell
+                .lock()
+                .await
+                .clone()
+                .expect("failed initializer should capture its cell");
+            let retry_cell = retry_cell
+                .lock()
+                .await
+                .clone()
+                .expect("retry initializer should capture its cell");
+            assert!(
+                !Arc::ptr_eq(&first_cell, &retry_cell),
+                "a failed generation must never be initialized again"
+            );
+            assert!(
+                state
+                    .agents
+                    .lock()
+                    .await
+                    .get(&key)
+                    .is_some_and(|cell| Arc::ptr_eq(cell, &retry_cell)),
+                "the replacement generation must remain published"
+            );
+        })
+        .await;
+}
+
 #[test]
 fn id_is_case_insensitive() {
     let (cmd, id) = resolve(Some(&allow_set(&["gemini"])), Some("GeMiNi"), None);
@@ -7593,65 +7677,72 @@ fn is_already_loaded_error_matches_message_and_data() {
 
 /// `reap_agent` must drop only the dead agent's orphan sessions, leaving
 /// a co-resident agent's (e.g. Gemini next to Copilot) orphans intact.
-#[tokio::test]
+#[tokio::test(flavor = "current_thread")]
 async fn reap_agent_drops_only_its_own_orphans() {
-    let state = make_state();
-    let key_a = "copilot --acp --stdio".to_string();
-    let key_b = "gemini --acp".to_string();
-    {
-        let mut orphans = state.orphaned_sessions.lock().await;
-        orphans
-            .entry(key_a.clone())
-            .or_default()
-            .insert(SessionId::new("a-sess"));
-        orphans
-            .entry(key_b.clone())
-            .or_default()
-            .insert(SessionId::new("b-sess"));
-    }
-    state.orphaned_tabs.lock().await.insert(
-        "tab-a".to_string(),
-        (key_a.clone(), HelperId(1), SessionId::new("a-sess")),
-    );
-    state.orphaned_tabs.lock().await.insert(
-        "tab-b".to_string(),
-        (key_b.clone(), HelperId(2), SessionId::new("b-sess")),
-    );
-    // reap only acts when the key is a live pool entry.
-    let cell = {
-        let mut agents = state.agents.lock().await;
-        let cell = Arc::new(tokio::sync::OnceCell::new());
-        agents.insert(key_a.clone(), Arc::clone(&cell));
-        cell
-    };
-    let stale_cell = Arc::new(tokio::sync::OnceCell::new());
-    reap_agent(&state, &key_a, &stale_cell, AgentInstanceId::new_v4()).await;
-    assert!(
-        state.agents.lock().await.contains_key(&key_a),
-        "a stale reaper must not remove a replacement pool entry"
-    );
-    reap_agent(&state, &key_a, &cell, AgentInstanceId::new_v4()).await;
-    let orphans = state.orphaned_sessions.lock().await;
-    assert!(
-        !orphans.contains_key(&key_a),
-        "reaped agent's orphan set must be dropped"
-    );
-    assert!(
-        orphans
-            .get(&key_b)
-            .is_some_and(|s| s.contains(&SessionId::new("b-sess"))),
-        "a co-resident agent's orphans must be untouched"
-    );
-    drop(orphans);
-    let orphaned_tabs = state.orphaned_tabs.lock().await;
-    assert!(
-        !orphaned_tabs.contains_key("tab-a"),
-        "reaping an agent must remove its stale tab fallback"
-    );
-    assert!(
-        orphaned_tabs.contains_key("tab-b"),
-        "reaping one agent must preserve another agent's tab fallback"
-    );
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let key_a = "copilot --acp --stdio".to_string();
+            let key_b = "gemini --acp".to_string();
+            {
+                let mut orphans = state.orphaned_sessions.lock().await;
+                orphans
+                    .entry(key_a.clone())
+                    .or_default()
+                    .insert(SessionId::new("a-sess"));
+                orphans
+                    .entry(key_b.clone())
+                    .or_default()
+                    .insert(SessionId::new("b-sess"));
+            }
+            state.orphaned_tabs.lock().await.insert(
+                "tab-a".to_string(),
+                (key_a.clone(), HelperId(1), SessionId::new("a-sess")),
+            );
+            state.orphaned_tabs.lock().await.insert(
+                "tab-b".to_string(),
+                (key_b.clone(), HelperId(2), SessionId::new("b-sess")),
+            );
+            let agent = unbound_test_agent(&key_a);
+            let instance_id = agent.instance_id;
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(agent).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(key_a.clone(), Arc::clone(&cell));
+
+            let stale_cell = Arc::new(tokio::sync::OnceCell::new());
+            reap_agent(&state, &key_a, &stale_cell, AgentInstanceId::new_v4()).await;
+            assert!(
+                state.agents.lock().await.contains_key(&key_a),
+                "a stale reaper must not remove a replacement pool entry"
+            );
+            reap_agent(&state, &key_a, &cell, instance_id).await;
+            let orphans = state.orphaned_sessions.lock().await;
+            assert!(
+                !orphans.contains_key(&key_a),
+                "reaped agent's orphan set must be dropped"
+            );
+            assert!(
+                orphans
+                    .get(&key_b)
+                    .is_some_and(|s| s.contains(&SessionId::new("b-sess"))),
+                "a co-resident agent's orphans must be untouched"
+            );
+            drop(orphans);
+            let orphaned_tabs = state.orphaned_tabs.lock().await;
+            assert!(
+                !orphaned_tabs.contains_key("tab-a"),
+                "reaping an agent must remove its stale tab fallback"
+            );
+            assert!(
+                orphaned_tabs.contains_key("tab-b"),
+                "reaping one agent must preserve another agent's tab fallback"
+            );
+        })
+        .await;
 }
 
 /// A stale reaper must revoke its dead CLI instance's capabilities without
@@ -7705,6 +7796,81 @@ async fn stale_reaper_revokes_only_dead_agent_capabilities() {
         1,
         "the replacement instance's capabilities must remain valid"
     );
+}
+
+#[tokio::test]
+async fn prepublication_reaper_retires_its_empty_generation() {
+    let state = make_state();
+    let key = "copilot --acp --stdio".to_string();
+    let cell = Arc::new(tokio::sync::OnceCell::new());
+    state
+        .agents
+        .lock()
+        .await
+        .insert(key.clone(), Arc::clone(&cell));
+
+    reap_agent(&state, &key, &cell, AgentInstanceId::new_v4()).await;
+
+    assert!(
+        !state.agents.lock().await.contains_key(&key),
+        "an I/O failure before publication must retire the empty generation"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn stale_reaper_cannot_remove_replacement_published_in_same_cell() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let key = "copilot --acp --stdio".to_string();
+            let dead_instance = AgentInstanceId::new_v4();
+            let replacement = unbound_test_agent(&key);
+            let replacement_instance = replacement.instance_id;
+            let cell = Arc::new(tokio::sync::OnceCell::new());
+            assert!(cell.set(Arc::clone(&replacement)).is_ok());
+            state
+                .agents
+                .lock()
+                .await
+                .insert(key.clone(), Arc::clone(&cell));
+            state
+                .session_mcp_capabilities
+                .prepare(dead_instance, None)
+                .await;
+            state
+                .session_mcp_capabilities
+                .prepare(replacement_instance, None)
+                .await;
+
+            reap_agent(&state, &key, &cell, dead_instance).await;
+
+            assert!(
+                state
+                    .agents
+                    .lock()
+                    .await
+                    .get(&key)
+                    .is_some_and(|current| Arc::ptr_eq(current, &cell)),
+                "the dead process must not remove a replacement in the same cell"
+            );
+            assert_eq!(
+                state
+                    .session_mcp_capabilities
+                    .remove_owner(dead_instance)
+                    .await,
+                0,
+                "the dead process's capabilities must be revoked"
+            );
+            assert_eq!(
+                state
+                    .session_mcp_capabilities
+                    .remove_owner(replacement_instance)
+                    .await,
+                1,
+                "the replacement process's capabilities must remain valid"
+            );
+        })
+        .await;
 }
 
 /// Regression for the reentrant-permission deadlock: a `prompt` in flight

--- a/tools/wta/src/master/tests.rs
+++ b/tools/wta/src/master/tests.rs
@@ -1137,6 +1137,106 @@ async fn failed_pool_generation_wakes_waiters_into_a_fresh_cell() {
         .await;
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn cancelled_pool_initializer_wakes_waiters_into_a_fresh_cell() {
+    tokio::task::LocalSet::new()
+        .run_until(async {
+            let state = make_state();
+            let key = "model:cancelled-generation-retry".to_string();
+            let cancelled_instance = AgentInstanceId::new_v4();
+            let replacement = unbound_test_agent(&key);
+            let first_started = Arc::new(tokio::sync::Notify::new());
+            let waiter_started = Arc::new(tokio::sync::Notify::new());
+            let first_cell = Arc::new(Mutex::new(None::<AgentCell>));
+            let retry_cell = Arc::new(Mutex::new(None::<AgentCell>));
+
+            let cancelled = tokio::task::spawn_local({
+                let state = Arc::clone(&state);
+                let key = key.clone();
+                let first_started = Arc::clone(&first_started);
+                let first_cell = Arc::clone(&first_cell);
+                async move {
+                    acquire_agent_from_pool(&state, &key, move |cell| {
+                        let first_started = Arc::clone(&first_started);
+                        let first_cell = Arc::clone(&first_cell);
+                        async move {
+                            *first_cell.lock().await = Some(cell);
+                            first_started.notify_one();
+                            std::future::pending::<Result<Arc<AgentCli>>>().await
+                        }
+                    })
+                    .await
+                }
+            });
+            first_started.notified().await;
+
+            let retried = tokio::task::spawn_local({
+                let state = Arc::clone(&state);
+                let key = key.clone();
+                let replacement = Arc::clone(&replacement);
+                let retry_cell = Arc::clone(&retry_cell);
+                let waiter_started = Arc::clone(&waiter_started);
+                async move {
+                    waiter_started.notify_one();
+                    acquire_agent_from_pool(&state, &key, move |cell| {
+                        let replacement = Arc::clone(&replacement);
+                        let retry_cell = Arc::clone(&retry_cell);
+                        async move {
+                            *retry_cell.lock().await = Some(cell);
+                            Ok(replacement)
+                        }
+                    })
+                    .await
+                }
+            });
+            waiter_started.notified().await;
+            assert!(
+                !retried.is_finished(),
+                "the waiter must be queued behind the first initializer"
+            );
+
+            cancelled.abort();
+            let cancellation = match cancelled.await {
+                Ok(_) => panic!("the first initializer should be cancelled"),
+                Err(error) => error,
+            };
+            assert!(cancellation.is_cancelled());
+
+            let retried = retried
+                .await
+                .expect("waiting task should complete")
+                .expect("waiting caller should initialize a fresh generation");
+            assert!(Arc::ptr_eq(&retried, &replacement));
+
+            let first_cell = first_cell
+                .lock()
+                .await
+                .clone()
+                .expect("cancelled initializer should capture its cell");
+            let retry_cell = retry_cell
+                .lock()
+                .await
+                .clone()
+                .expect("retry initializer should capture its cell");
+            assert!(
+                !Arc::ptr_eq(&first_cell, &retry_cell),
+                "a cancelled generation must never be initialized again"
+            );
+
+            reap_agent(&state, &key, &first_cell, cancelled_instance).await;
+            assert!(
+                state
+                    .agents
+                    .lock()
+                    .await
+                    .get(&key)
+                    .is_some_and(|cell| Arc::ptr_eq(cell, &retry_cell)),
+                "the cancelled generation's delayed reaper must preserve its replacement"
+            );
+        })
+        .await;
+}
+
 #[test]
 fn id_is_case_insensitive() {
     let (cmd, id) = resolve(Some(&allow_set(&["gemini"])), Some("GeMiNi"), None);
@@ -1382,6 +1482,7 @@ fn make_state_with_retirement_pending_timeout(
         hook_owned: Mutex::new(HashSet::new()),
         born_bound: Mutex::new(HashSet::new()),
         orphaned_sessions: Mutex::new(HashMap::new()),
+        retired_agent_cells: std::sync::Mutex::new(Vec::new()),
         orphaned_tabs: Mutex::new(HashMap::new()),
     })
 }
@@ -9656,6 +9757,7 @@ fn make_state_with_wt(wt: Arc<dyn crate::shell::wt_channel::WtChannel>) -> Arc<M
         hook_owned: Mutex::new(HashSet::new()),
         born_bound: Mutex::new(HashSet::new()),
         orphaned_sessions: Mutex::new(HashMap::new()),
+        retired_agent_cells: std::sync::Mutex::new(Vec::new()),
         orphaned_tabs: Mutex::new(HashMap::new()),
     })
 }


### PR DESCRIPTION
## Summary

- retire a failed agent-pool generation before waiting callers retry
- force callers holding a retired cell to acquire a fresh generation
- require reapers to match both the pool cell and provider process instance
- retire an empty generation when ACP I/O exits before publication
- preserve replacement instances and their session MCP capabilities

## Race reproduction

The regression test deterministically coordinates the original failure without timing sleeps:

1. initializer A starts in a new pool cell
2. caller B captures that cell and waits
3. A fails, retiring the generation
4. B retries and publishes into a fresh cell
5. A's delayed reaper runs
6. the test verifies B's replacement remains published

The related tests also cover pre-publication I/O exit and a stale reaper targeting a different instance in the same cell.

## Tests

- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml`
- 2,012 passed, 1 ignored

Closes #846