### PR TITLE
Settings polish: keep Add New as the final custom endpoint row

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/AIAgents.cpp
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.cpp
@@ -52,13 +52,9 @@ namespace winrt::Microsoft::Terminal::Settings::Editor::implementation
         const auto customModelsHeader = RS_(L"AIAgents_CustomModels/Header");
         const auto customModelsCaption = RS_(L"AIAgents_CustomModels/HelpText");
         const auto customModelsLearnMore = RS_(L"AIAgents_CustomModelsLearnMore");
-        EmptyCustomModelsHeaderText().Text(customModelsHeader);
-        EmptyCustomModelsCaptionPrefix().Text(customModelsCaption);
-        EmptyCustomModelsCaptionLink().Text(customModelsLearnMore);
         CustomModelsHeaderText().Text(customModelsHeader);
         CustomModelsCaptionPrefix().Text(customModelsCaption);
         CustomModelsCaptionLink().Text(customModelsLearnMore);
-        Automation::AutomationProperties::SetName(EmptyCustomModelProviders(), customModelsHeader);
         Automation::AutomationProperties::SetName(CustomModelProvidersExpander(), customModelsHeader);
 
         // Auto-error-detection caption + inline "supported shells" hyperlink.

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -268,7 +268,16 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border Padding="0,8,0,16">
+                    <Border Padding="0,8,0,16"
+                            Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.IsAddingCustomModelProvider), Mode=OneWay}">
+                        <Button x:Uid="AIAgents_CustomProviderAdd"
+                                HorizontalAlignment="Right"
+                                Click="{x:Bind ViewModel.AddCustomModelProvider}"
+                                Style="{StaticResource AccentButtonStyle}" />
+                    </Border>
+
+                    <Border Padding="0,8,0,16"
+                            Visibility="{x:Bind ViewModel.IsAddingCustomModelProvider, Mode=OneWay}">
                         <StackPanel Spacing="12">
                             <TextBlock x:Uid="AIAgents_CustomProviderAddHeader"
                                        FontWeight="SemiBold"
@@ -319,6 +328,8 @@
                                             IsEnabled="{x:Bind ViewModel.CanSaveCustomModelProvider, Mode=OneWay}"
                                             Click="{x:Bind ViewModel.SaveCustomModelProvider}"
                                             Style="{StaticResource AccentButtonStyle}" />
+                                    <Button x:Uid="AIAgents_CustomProviderCancel"
+                                            Click="{x:Bind ViewModel.CancelCustomModelProvider}" />
                                 </StackPanel>
                             </StackPanel>
                         </StackPanel>

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -195,18 +195,19 @@
                            HorizontalContentAlignment="Stretch"
                            IsExpanded="{x:Bind ViewModel.IsCustomModelProvidersExpanded, Mode=TwoWay}">
                 <muxc:Expander.Header>
-                    <StackPanel MinHeight="64"
-                                VerticalAlignment="Center">
-                        <TextBlock x:Name="CustomModelsHeaderText"
-                                   Style="{StaticResource SettingsPageItemHeaderStyle}" />
-                        <TextBlock Style="{StaticResource CaptionTextBlockStyle}"
-                                   TextWrapping="Wrap">
-                            <Run x:Name="CustomModelsCaptionPrefix"
-                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}" /><Hyperlink NavigateUri="https://github.com/microsoft/intelligent-terminal#custom-providers-byok">
-                                <Run x:Name="CustomModelsCaptionLink" />
-                            </Hyperlink>
-                        </TextBlock>
-                    </StackPanel>
+                    <Grid MinHeight="64">
+                        <StackPanel VerticalAlignment="Center">
+                            <TextBlock x:Name="CustomModelsHeaderText"
+                                       Style="{StaticResource SettingsPageItemHeaderStyle}" />
+                            <TextBlock Style="{StaticResource CaptionTextBlockStyle}"
+                                       TextWrapping="Wrap">
+                                <Run x:Name="CustomModelsCaptionPrefix"
+                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}" /><Hyperlink NavigateUri="https://github.com/microsoft/intelligent-terminal#custom-providers-byok">
+                                    <Run x:Name="CustomModelsCaptionLink" />
+                                </Hyperlink>
+                            </TextBlock>
+                        </StackPanel>
+                    </Grid>
                 </muxc:Expander.Header>
                 <StackPanel>
                     <TextBlock Margin="0,12,0,0"
@@ -217,7 +218,9 @@
                     <ItemsControl ItemsSource="{x:Bind ViewModel.CustomModelProviders, Mode=OneWay}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="local:CustomModelProviderEntry">
-                                <Border Padding="0,4">
+                                <Border Padding="0,4"
+                                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                                        BorderThickness="0,0,0,1">
                                     <Grid>
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height="Auto" />

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -218,8 +218,8 @@
                     <ItemsControl ItemsSource="{x:Bind ViewModel.CustomModelProviders, Mode=OneWay}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="local:CustomModelProviderEntry">
-                                <Border MinHeight="48"
-                                        Padding="0,4"
+                                <Border MinHeight="64"
+                                        Padding="0,8"
                                         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                                         BorderThickness="0,0,0,1">
                                     <Grid>
@@ -269,8 +269,8 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border MinHeight="48"
-                            Padding="0,4"
+                    <Border MinHeight="64"
+                            Padding="0,8"
                             Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.IsAddingCustomModelProvider), Mode=OneWay}">
                         <Grid>
                             <Button x:Uid="AIAgents_CustomProviderAdd"

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -220,13 +220,12 @@
                     <ItemsControl ItemsSource="{x:Bind ViewModel.CustomModelProviders, Mode=OneWay}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="local:CustomModelProviderEntry">
-                                <Border MinHeight="64"
-                                        Padding="0,8"
+                                <Border Padding="0,4"
                                         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                                         BorderThickness="0,0,0,1">
                                     <Grid>
                                         <Grid.RowDefinitions>
-                                            <RowDefinition Height="*" />
+                                            <RowDefinition Height="Auto" />
                                             <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
                                         <Grid.ColumnDefinitions>
@@ -271,16 +270,12 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border MinHeight="64"
-                            Padding="0,8"
+                    <Border Padding="0,4"
                             Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.IsAddingCustomModelProvider), Mode=OneWay}">
-                        <Grid>
-                            <Button x:Uid="AIAgents_CustomProviderAdd"
-                                    HorizontalAlignment="Right"
-                                    VerticalAlignment="Center"
-                                    Click="{x:Bind ViewModel.AddCustomModelProvider}"
-                                    Style="{StaticResource AccentButtonStyle}" />
-                        </Grid>
+                        <Button x:Uid="AIAgents_CustomProviderAdd"
+                                HorizontalAlignment="Right"
+                                Click="{x:Bind ViewModel.AddCustomModelProvider}"
+                                Style="{StaticResource AccentButtonStyle}" />
                     </Border>
 
                     <Border Padding="0,8,0,16"

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -218,7 +218,8 @@
                     <ItemsControl ItemsSource="{x:Bind ViewModel.CustomModelProviders, Mode=OneWay}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="local:CustomModelProviderEntry">
-                                <Border Padding="0,4"
+                                <Border MinHeight="48"
+                                        Padding="0,4"
                                         BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
                                         BorderThickness="0,0,0,1">
                                     <Grid>
@@ -268,10 +269,12 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border Padding="0,8,0,16"
+                    <Border MinHeight="48"
+                            Padding="0,4"
                             Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.IsAddingCustomModelProvider), Mode=OneWay}">
                         <Button x:Uid="AIAgents_CustomProviderAdd"
                                 HorizontalAlignment="Right"
+                                VerticalAlignment="Center"
                                 Click="{x:Bind ViewModel.AddCustomModelProvider}"
                                 Style="{StaticResource AccentButtonStyle}" />
                     </Border>

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -209,7 +209,9 @@
                         </StackPanel>
                     </Grid>
                 </muxc:Expander.Header>
-                <StackPanel>
+                <!--  Offset WinUI's default vertical Expander content padding so each
+                      provider and Add New occupy one visually centered row.  -->
+                <StackPanel Margin="0,-16,0,-16">
                     <TextBlock Margin="0,12,0,0"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Text="{x:Bind ViewModel.CustomModelProviderUnsupportedMessage, Mode=OneWay}"

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -224,7 +224,7 @@
                                         BorderThickness="0,0,0,1">
                                     <Grid>
                                         <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="*" />
                                             <RowDefinition Height="Auto" />
                                         </Grid.RowDefinitions>
                                         <Grid.ColumnDefinitions>
@@ -272,11 +272,13 @@
                     <Border MinHeight="48"
                             Padding="0,4"
                             Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.IsAddingCustomModelProvider), Mode=OneWay}">
-                        <Button x:Uid="AIAgents_CustomProviderAdd"
-                                HorizontalAlignment="Right"
-                                VerticalAlignment="Center"
-                                Click="{x:Bind ViewModel.AddCustomModelProvider}"
-                                Style="{StaticResource AccentButtonStyle}" />
+                        <Grid>
+                            <Button x:Uid="AIAgents_CustomProviderAdd"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Center"
+                                    Click="{x:Bind ViewModel.AddCustomModelProvider}"
+                                    Style="{StaticResource AccentButtonStyle}" />
+                        </Grid>
                     </Border>
 
                     <Border Padding="0,8,0,16"

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -189,74 +189,24 @@
                 </Grid>
             </local:SettingContainer>
 
-            <Grid x:Name="EmptyCustomModelProviders"
-                  Margin="0,4,0,0"
-                  Padding="16,0,8,0"
-                  HorizontalAlignment="Stretch"
-                  Background="{ThemeResource ExpanderHeaderBackground}"
-                  BorderBrush="{ThemeResource ExpanderHeaderBorderBrush}"
-                  BorderThickness="{ThemeResource ExpanderHeaderBorderThickness}"
-                  CornerRadius="{ThemeResource ControlCornerRadius}"
-                  MaxWidth="1000"
-                  MinHeight="64"
-                  MinWidth="{ThemeResource FlyoutThemeMinWidth}"
-                  Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.ShowCustomModelProvidersExpander), Mode=OneWay}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*" />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <StackPanel Grid.Column="0"
-                            Padding="0,12,0,12"
-                            VerticalAlignment="Center">
-                    <TextBlock x:Name="EmptyCustomModelsHeaderText"
-                               Style="{StaticResource SettingsPageItemHeaderStyle}" />
-                    <TextBlock Style="{StaticResource CaptionTextBlockStyle}"
-                               TextWrapping="Wrap">
-                        <Run x:Name="EmptyCustomModelsCaptionPrefix"
-                             Foreground="{ThemeResource TextFillColorSecondaryBrush}" /><Hyperlink NavigateUri="https://github.com/microsoft/intelligent-terminal#custom-providers-byok">
-                            <Run x:Name="EmptyCustomModelsCaptionLink" />
-                        </Hyperlink>
-                    </TextBlock>
-                </StackPanel>
-                <Button Grid.Column="1"
-                        x:Uid="AIAgents_CustomProviderAdd"
-                        Margin="0,12,0,12"
-                        HorizontalAlignment="Right"
-                        VerticalAlignment="Center"
-                        Click="{x:Bind ViewModel.AddCustomModelProvider}"
-                        Style="{StaticResource AccentButtonStyle}" />
-            </Grid>
-
             <muxc:Expander x:Name="CustomModelProvidersExpander"
                            Margin="0,4,0,0"
                            HorizontalAlignment="Stretch"
                            HorizontalContentAlignment="Stretch"
-                           IsExpanded="{x:Bind ViewModel.IsCustomModelProvidersExpanded, Mode=TwoWay}"
-                           Visibility="{x:Bind ViewModel.ShowCustomModelProvidersExpander, Mode=OneWay}">
+                           IsExpanded="{x:Bind ViewModel.IsCustomModelProvidersExpanded, Mode=TwoWay}">
                 <muxc:Expander.Header>
-                    <Grid MinHeight="64">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
-                        <StackPanel Grid.Column="0"
-                                    VerticalAlignment="Center">
-                            <TextBlock x:Name="CustomModelsHeaderText"
-                                       Style="{StaticResource SettingsPageItemHeaderStyle}" />
-                            <TextBlock Style="{StaticResource CaptionTextBlockStyle}"
-                                       TextWrapping="Wrap">
-                                <Run x:Name="CustomModelsCaptionPrefix"
-                                     Foreground="{ThemeResource TextFillColorSecondaryBrush}" /><Hyperlink NavigateUri="https://github.com/microsoft/intelligent-terminal#custom-providers-byok">
-                                    <Run x:Name="CustomModelsCaptionLink" />
-                                </Hyperlink>
-                            </TextBlock>
-                        </StackPanel>
-                        <Button Grid.Column="1"
-                                x:Uid="AIAgents_CustomProviderAdd"
-                                VerticalAlignment="Center"
-                                Click="{x:Bind ViewModel.AddCustomModelProvider}"
-                                Style="{StaticResource AccentButtonStyle}" />
-                    </Grid>
+                    <StackPanel MinHeight="64"
+                                VerticalAlignment="Center">
+                        <TextBlock x:Name="CustomModelsHeaderText"
+                                   Style="{StaticResource SettingsPageItemHeaderStyle}" />
+                        <TextBlock Style="{StaticResource CaptionTextBlockStyle}"
+                                   TextWrapping="Wrap">
+                            <Run x:Name="CustomModelsCaptionPrefix"
+                                 Foreground="{ThemeResource TextFillColorSecondaryBrush}" /><Hyperlink NavigateUri="https://github.com/microsoft/intelligent-terminal#custom-providers-byok">
+                                <Run x:Name="CustomModelsCaptionLink" />
+                            </Hyperlink>
+                        </TextBlock>
+                    </StackPanel>
                 </muxc:Expander.Header>
                 <StackPanel>
                     <TextBlock Margin="0,12,0,0"
@@ -315,8 +265,7 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
 
-                    <Border Padding="0,8,0,16"
-                            Visibility="{x:Bind ViewModel.IsAddingCustomModelProvider, Mode=OneWay}">
+                    <Border Padding="0,8,0,16">
                         <StackPanel Spacing="12">
                             <TextBlock x:Uid="AIAgents_CustomProviderAddHeader"
                                        FontWeight="SemiBold"
@@ -367,8 +316,6 @@
                                             IsEnabled="{x:Bind ViewModel.CanSaveCustomModelProvider, Mode=OneWay}"
                                             Click="{x:Bind ViewModel.SaveCustomModelProvider}"
                                             Style="{StaticResource AccentButtonStyle}" />
-                                    <Button x:Uid="AIAgents_CustomProviderCancel"
-                                            Click="{x:Bind ViewModel.CancelCustomModelProvider}" />
                                 </StackPanel>
                             </StackPanel>
                         </StackPanel>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -3008,7 +3008,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Neu hinzufügen</value>
+    <value>Endpunkt hinzufügen</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -3007,13 +3007,21 @@
     <value>Leer lassen, wenn Ihr Endpunkt keine Authentifizierung erfordert. In der Windows-Anmeldeinformationsverwaltung gespeichert.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>Neu hinzufügen</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Hinzufügen und auswählen</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Dadurch wird das Modell hinzugefügt und als aktuelles Modell ausgewählt</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>Abbrechen</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -3007,10 +3007,6 @@
     <value>Leer lassen, wenn Ihr Endpunkt keine Authentifizierung erfordert. In der Windows-Anmeldeinformationsverwaltung gespeichert.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Endpunkt hinzufügen</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Hinzufügen und auswählen</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3018,10 +3014,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Dadurch wird das Modell hinzugefügt und als aktuelles Modell ausgewählt</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>Abbrechen</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -3007,11 +3007,11 @@
     <value>Leer lassen, wenn Ihr Endpunkt keine Authentifizierung erfordert. In der Windows-Anmeldeinformationsverwaltung gespeichert.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>Neu hinzufügen</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Hinzufügen und auswählen</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -3119,10 +3119,6 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Leave blank if your endpoint does not need auth. Stored in Windows Credential Manager.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Add endpoint</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Add and Select</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3130,10 +3126,6 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>This will add the model and select it as the current model</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>Cancel</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -3119,13 +3119,21 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Leave blank if your endpoint does not need auth. Stored in Windows Credential Manager.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>Add New</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Add and Select</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>This will add the model and select it as the current model</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -3119,11 +3119,11 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <value>Leave blank if your endpoint does not need auth. Stored in Windows Credential Manager.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>Add New</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Add and Select</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -3007,11 +3007,11 @@
     <value>Déjelo en blanco si su punto de conexión no necesita autenticación. Se almacena en el Administrador de credenciales de Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>Agregar nuevo</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Agregar y seleccionar</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -3008,7 +3008,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Agregar nuevo</value>
+    <value>Agregar punto de conexión</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -3007,13 +3007,21 @@
     <value>Déjelo en blanco si su punto de conexión no necesita autenticación. Se almacena en el Administrador de credenciales de Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>Agregar nuevo</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Agregar y seleccionar</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Esto agregará el modelo y lo seleccionará como el modelo actual</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>Cancelar</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -3007,10 +3007,6 @@
     <value>Déjelo en blanco si su punto de conexión no necesita autenticación. Se almacena en el Administrador de credenciales de Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Agregar punto de conexión</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Agregar y seleccionar</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3018,10 +3014,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Esto agregará el modelo y lo seleccionará como el modelo actual</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>Cancelar</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -3009,7 +3009,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Ajouter nouveau</value>
+    <value>Ajouter un point de terminaison</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -3008,11 +3008,11 @@
     <value>Laissez vide si votre point de terminaison ne nécessite pas d’authentification. Stocké dans le Gestionnaire d’informations d’identification Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>Ajouter nouveau</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Ajouter et sélectionner</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -3008,13 +3008,21 @@
     <value>Laissez vide si votre point de terminaison ne nécessite pas d’authentification. Stocké dans le Gestionnaire d’informations d’identification Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>Ajouter nouveau</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Ajouter et sélectionner</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Cela ajoutera le modèle et le sélectionnera comme modèle actuel</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>Annuler</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -3008,10 +3008,6 @@
     <value>Laissez vide si votre point de terminaison ne nécessite pas d’authentification. Stocké dans le Gestionnaire d’informations d’identification Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Ajouter un point de terminaison</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Ajouter et sélectionner</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3019,10 +3015,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Cela ajoutera le modèle et le sélectionnera comme modèle actuel</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>Annuler</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -3008,7 +3008,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Aggiungi nuovo</value>
+    <value>Aggiungi endpoint</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -3007,13 +3007,21 @@
     <value>Lascia vuoto se il tuo endpoint non richiede autenticazione. Salvata in Gestione credenziali di Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>Aggiungi nuovo</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Aggiungi e seleziona</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Questo aggiungerà il modello e lo selezionerà come modello corrente</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>Annulla</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -3007,10 +3007,6 @@
     <value>Lascia vuoto se il tuo endpoint non richiede autenticazione. Salvata in Gestione credenziali di Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Aggiungi endpoint</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Aggiungi e seleziona</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3018,10 +3014,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Questo aggiungerà il modello e lo selezionerà come modello corrente</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>Annulla</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -3007,11 +3007,11 @@
     <value>Lascia vuoto se il tuo endpoint non richiede autenticazione. Salvata in Gestione credenziali di Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>Aggiungi nuovo</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Aggiungi e seleziona</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -3007,11 +3007,11 @@
     <value>エンドポイントで認証が不要な場合は空白のままにします。Windows 資格情報マネージャーに保存されます。</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>新規追加</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>追加して選択</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -3008,7 +3008,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>新規追加</value>
+    <value>エンドポイントの追加</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -3007,13 +3007,21 @@
     <value>エンドポイントで認証が不要な場合は空白のままにします。Windows 資格情報マネージャーに保存されます。</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>新規追加</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>追加して選択</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>これによりモデルが追加され、現在のモデルとして選択されます</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>キャンセル</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -3007,10 +3007,6 @@
     <value>エンドポイントで認証が不要な場合は空白のままにします。Windows 資格情報マネージャーに保存されます。</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>エンドポイントの追加</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>追加して選択</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3018,10 +3014,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>これによりモデルが追加され、現在のモデルとして選択されます</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>キャンセル</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -3067,13 +3067,21 @@
     <value>엔드포인트에 인증이 필요하지 않은 경우 비워 둡니다. Windows 자격 증명 관리자에 저장됩니다.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>새로 추가</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>추가 및 선택</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>이렇게 하면 모델이 추가되고 현재 모델로 선택됩니다</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>취소</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -3067,11 +3067,11 @@
     <value>엔드포인트에 인증이 필요하지 않은 경우 비워 둡니다. Windows 자격 증명 관리자에 저장됩니다.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>새로 추가</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>추가 및 선택</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -3067,10 +3067,6 @@
     <value>엔드포인트에 인증이 필요하지 않은 경우 비워 둡니다. Windows 자격 증명 관리자에 저장됩니다.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>엔드포인트 추가</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>추가 및 선택</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3078,10 +3074,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>이렇게 하면 모델이 추가되고 현재 모델로 선택됩니다</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>취소</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -3068,7 +3068,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>새로 추가</value>
+    <value>엔드포인트 추가</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -3050,13 +3050,21 @@
     <value>Deixe em branco se seu ponto de extremidade não precisar de autenticação. Armazenado no Gerenciador de Credenciais do Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>Adicionar novo</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Adicionar e selecionar</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Isso adicionará o modelo e o selecionará como o modelo atual</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>Cancelar</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -3050,10 +3050,6 @@
     <value>Deixe em branco se seu ponto de extremidade não precisar de autenticação. Armazenado no Gerenciador de Credenciais do Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Adicionar ponto de extremidade</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Adicionar e selecionar</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3061,10 +3057,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Isso adicionará o modelo e o selecionará como o modelo atual</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>Cancelar</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -3051,7 +3051,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Adicionar novo</value>
+    <value>Adicionar ponto de extremidade</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -3050,11 +3050,11 @@
     <value>Deixe em branco se seu ponto de extremidade não precisar de autenticação. Armazenado no Gerenciador de Credenciais do Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>Adicionar novo</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Adicionar e selecionar</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -2998,11 +2998,11 @@
     <value>Leave blank if your endpoint does not need auth. Stored in Windows Credential Manager.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>Add New</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Add and Select</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -2998,13 +2998,21 @@
     <value>Leave blank if your endpoint does not need auth. Stored in Windows Credential Manager.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>Add New</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Add and Select</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>This will add the model and select it as the current model</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -2998,10 +2998,6 @@
     <value>Leave blank if your endpoint does not need auth. Stored in Windows Credential Manager.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Add endpoint</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Add and Select</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3009,10 +3005,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>This will add the model and select it as the current model</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>Cancel</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -2998,11 +2998,11 @@
     <value>Leave blank if your endpoint does not need auth. Stored in Windows Credential Manager.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>Add New</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Add and Select</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -2998,13 +2998,21 @@
     <value>Leave blank if your endpoint does not need auth. Stored in Windows Credential Manager.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>Add New</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Add and Select</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>This will add the model and select it as the current model</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -2998,10 +2998,6 @@
     <value>Leave blank if your endpoint does not need auth. Stored in Windows Credential Manager.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Add endpoint</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Add and Select</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3009,10 +3005,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>This will add the model and select it as the current model</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>Cancel</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -2998,11 +2998,11 @@
     <value>Leave blank if your endpoint does not need auth. Stored in Windows Credential Manager.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>Add New</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Add and Select</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -2998,13 +2998,21 @@
     <value>Leave blank if your endpoint does not need auth. Stored in Windows Credential Manager.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>Add New</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Add and Select</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>This will add the model and select it as the current model</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>Cancel</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -2998,10 +2998,6 @@
     <value>Leave blank if your endpoint does not need auth. Stored in Windows Credential Manager.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Add endpoint</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Add and Select</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3009,10 +3005,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>This will add the model and select it as the current model</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>Cancel</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -3050,10 +3050,6 @@
     <value>Оставьте пустым, если конечная точка не требует проверки подлинности. Сохраняется в диспетчере учетных данных Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Добавить конечную точку</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Добавить и выбрать</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3061,10 +3057,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Это действие добавит модель и выберет ее в качестве текущей модели</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>Отменить</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -3050,13 +3050,21 @@
     <value>Оставьте пустым, если конечная точка не требует проверки подлинности. Сохраняется в диспетчере учетных данных Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>Добавить нового поставщика</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Добавить и выбрать</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Это действие добавит модель и выберет ее в качестве текущей модели</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>Отменить</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -3050,11 +3050,11 @@
     <value>Оставьте пустым, если конечная точка не требует проверки подлинности. Сохраняется в диспетчере учетных данных Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>Добавить нового поставщика</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Добавить и выбрать</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -3051,7 +3051,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Добавить нового поставщика</value>
+    <value>Добавить конечную точку</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -3065,13 +3065,21 @@
     <value>Оставите празно ако вашој крајњој тачки није потребна аутентификација. Чува се у Windows менаџеру акредитива.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>Додај новог добављача</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Додај и изабери</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Ово ће додати модел и изабрати га као текући модел</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>Откажи</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -3065,11 +3065,11 @@
     <value>Оставите празно ако вашој крајњој тачки није потребна аутентификација. Чува се у Windows менаџеру акредитива.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>Додај новог добављача</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Додај и изабери</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -3065,10 +3065,6 @@
     <value>Оставите празно ако вашој крајњој тачки није потребна аутентификација. Чува се у Windows менаџеру акредитива.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Додај крајњу тачку</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Додај и изабери</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3076,10 +3072,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Ово ће додати модел и изабрати га као текући модел</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>Откажи</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -3066,7 +3066,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Додај новог добављача</value>
+    <value>Додај крајњу тачку</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -2711,10 +2711,6 @@
     <value>Залиште порожнім, якщо кінцева точка не потребує автентифікації. Зберігається в Диспетчері облікових даних Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Додати кінцеву точку</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Додати й вибрати</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -2722,10 +2718,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Це додасть модель і вибере її як поточну модель</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>Скасувати</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -2711,11 +2711,11 @@
     <value>Залиште порожнім, якщо кінцева точка не потребує автентифікації. Зберігається в Диспетчері облікових даних Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>Додати новий</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Додати й вибрати</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -2711,13 +2711,21 @@
     <value>Залиште порожнім, якщо кінцева точка не потребує автентифікації. Зберігається в Диспетчері облікових даних Windows.</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>Додати новий</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>Додати й вибрати</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>Це додасть модель і вибере її як поточну модель</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>Скасувати</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -2712,7 +2712,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Додати новий</value>
+    <value>Додати кінцеву точку</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -3067,11 +3067,11 @@
     <value>如果终结点不需要身份验证，请留空。存储在 Windows 凭据管理器中。</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>新增</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>添加并选择</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -3068,7 +3068,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>新增</value>
+    <value>添加终结点</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -3067,13 +3067,21 @@
     <value>如果终结点不需要身份验证，请留空。存储在 Windows 凭据管理器中。</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>新增</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>添加并选择</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>这将添加该模型并将其选择为当前模型</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>取消</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -3067,10 +3067,6 @@
     <value>如果终结点不需要身份验证，请留空。存储在 Windows 凭据管理器中。</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>添加终结点</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>添加并选择</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3078,10 +3074,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>这将添加该模型并将其选择为当前模型</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>取消</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -3007,11 +3007,11 @@
     <value>如果您的端點不需要驗證，請保留空白。儲存於 Windows 認證管理員。</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
     <value>新增</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
-<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>新增並選取</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -3008,7 +3008,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>新增</value>
+    <value>新增端點</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -3007,13 +3007,21 @@
     <value>如果您的端點不需要驗證，請保留空白。儲存於 Windows 認證管理員。</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
+    <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
+    <value>新增</value>
+    <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
+  </data>
+<data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>新增並選取</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
   </data>
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>這將會新增模型並將其選取為目前模型</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
+  </data>
+  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
+    <value>取消</value>
+    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -3007,10 +3007,6 @@
     <value>如果您的端點不需要驗證，請保留空白。儲存於 Windows 認證管理員。</value>
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
-  <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>新增端點</value>
-    <comment>Button that starts adding a custom model provider endpoint.</comment>
-  </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
     <value>新增並選取</value>
     <comment>Button that adds a custom provider model and selects it as the current model.</comment>
@@ -3018,10 +3014,6 @@
   <data name="AIAgents_CustomProviderSaveHint.Text" xml:space="preserve">
     <value>這將會新增模型並將其選取為目前模型</value>
     <comment>Supporting text beside the button that adds and selects a custom provider model.</comment>
-  </data>
-  <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
-    <value>取消</value>
-    <comment>Button that cancels adding a provider.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>


### PR DESCRIPTION
## Summary
- keep the custom endpoint section as one consistent expander, including when no endpoints have been saved
- preserve each saved model/endpoint as a removable row
- show `Add New` as the final row and reveal the Base URL, Model ID, and API key fields only after it is selected
- restore the final row after `Add and Select` or `Cancel`
- vertically center the expander header and separate saved endpoint rows from the add flow

<img width="768" height="122" alt="image" src="https://github.com/user-attachments/assets/11d7f6f5-12bf-4cce-9e2b-6cedd4b5d66b" />
<img width="767" height="167" alt="image" src="https://github.com/user-attachments/assets/b78faad6-c6c3-4abc-a96b-6c0271dbcbf7" />
<img width="769" height="509" alt="image" src="https://github.com/user-attachments/assets/2f053e6f-4cb0-4550-a03c-23195ed2c6cd" />

## Validation
- built `TerminalSettingsEditor` with the project-local Debug `bx` command
- validated XAML and resource XML, UTF-8 BOM preservation, localized Add New and Cancel resources, and diff formatting

Related to #789 and #792.