### PR TITLE
Settings polish: refine the Agent settings layout

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -439,9 +439,10 @@
                                     x:Uid="AIAgents_YoloMode">
                 <StackPanel>
                     <ToggleSwitch AutomationProperties.AutomationId="AgentPaneYoloModeToggle"
+                                  AutomationProperties.AccessibilityView="Content"
+                                  MinWidth="0"
                                   IsOn="{x:Bind ViewModel.AgentPaneYoloMode, Mode=TwoWay}"
-                                  IsEnabled="{x:Bind mtu:Converters.InvertBoolean(ViewModel.IsYoloModePolicyLocked), Mode=OneWay}"
-                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                                  IsEnabled="{x:Bind mtu:Converters.InvertBoolean(ViewModel.IsYoloModePolicyLocked), Mode=OneWay}" />
                     <TextBlock x:Uid="AIAgents_PolicyLocked"
                                Visibility="{x:Bind ViewModel.IsYoloModePolicyLocked, Mode=OneWay}"
                                Opacity="0.6"

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -381,42 +381,6 @@
                           Style="{StaticResource ComboBoxSettingStyle}" />
             </local:SettingContainer>
 
-            <!--  Global Yolo preference: asks supported providers to enable
-                their advertised ACP session mode. High-risk toggle, so it
-                is disabled outright (IsYoloModePolicyLocked) when the
-                AllowYoloMode GPO policy blocks it.  -->
-            <local:SettingContainer x:Name="AgentPaneYoloMode"
-                                    x:Uid="AIAgents_YoloMode">
-                <StackPanel>
-                    <ToggleSwitch AutomationProperties.AutomationId="AgentPaneYoloModeToggle"
-                                  IsOn="{x:Bind ViewModel.AgentPaneYoloMode, Mode=TwoWay}"
-                                  IsEnabled="{x:Bind mtu:Converters.InvertBoolean(ViewModel.IsYoloModePolicyLocked), Mode=OneWay}"
-                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
-                    <TextBlock x:Uid="AIAgents_PolicyLocked"
-                               Visibility="{x:Bind ViewModel.IsYoloModePolicyLocked, Mode=OneWay}"
-                               Opacity="0.6"
-                               Margin="0,4,0,0" />
-                </StackPanel>
-            </local:SettingContainer>
-            <muxc:InfoBar x:Uid="AIAgents_YoloOpenCodeWarning"
-                          AutomationProperties.AutomationId="OpenCodeYoloCompatibilityInfoBar"
-                          HorizontalAlignment="Stretch"
-                          IsClosable="False"
-                          IsOpen="{x:Bind ViewModel.ShowOpenCodeYoloWarning, Mode=OneWay}"
-                          Margin="0,4,0,0"
-                          MaxWidth="1000"
-                          Severity="Warning"
-                          Visibility="{x:Bind ViewModel.ShowOpenCodeYoloWarning, Mode=OneWay}" />
-            <muxc:InfoBar x:Uid="AIAgents_YoloGeminiInfo"
-                          AutomationProperties.AutomationId="GeminiYoloCompatibilityInfoBar"
-                          HorizontalAlignment="Stretch"
-                          IsClosable="False"
-                          IsOpen="{x:Bind ViewModel.ShowGeminiYoloInfo, Mode=OneWay}"
-                          Margin="0,4,0,0"
-                          MaxWidth="1000"
-                          Severity="Informational"
-                          Visibility="{x:Bind ViewModel.ShowGeminiYoloInfo, Mode=OneWay}" />
-
             <local:SettingContainer x:Name="AutoErrorHandling"
                                     Style="{StaticResource AutoErrorHandlingSettingContainerStyle}">
                 <local:SettingContainer.Header>
@@ -466,6 +430,42 @@
                               AutomationProperties.AccessibilityView="Content"
                               IsOn="{x:Bind ViewModel.ShowTokenUsageAndCost, Mode=TwoWay}" />
             </local:SettingContainer>
+
+            <!--  Global Yolo preference: asks supported providers to enable
+                their advertised ACP session mode. High-risk toggle, so it
+                is disabled outright (IsYoloModePolicyLocked) when the
+                AllowYoloMode GPO policy blocks it.  -->
+            <local:SettingContainer x:Name="AgentPaneYoloMode"
+                                    x:Uid="AIAgents_YoloMode">
+                <StackPanel>
+                    <ToggleSwitch AutomationProperties.AutomationId="AgentPaneYoloModeToggle"
+                                  IsOn="{x:Bind ViewModel.AgentPaneYoloMode, Mode=TwoWay}"
+                                  IsEnabled="{x:Bind mtu:Converters.InvertBoolean(ViewModel.IsYoloModePolicyLocked), Mode=OneWay}"
+                                  Style="{StaticResource ToggleSwitchInExpanderStyle}" />
+                    <TextBlock x:Uid="AIAgents_PolicyLocked"
+                               Visibility="{x:Bind ViewModel.IsYoloModePolicyLocked, Mode=OneWay}"
+                               Opacity="0.6"
+                               Margin="0,4,0,0" />
+                </StackPanel>
+            </local:SettingContainer>
+            <muxc:InfoBar x:Uid="AIAgents_YoloOpenCodeWarning"
+                          AutomationProperties.AutomationId="OpenCodeYoloCompatibilityInfoBar"
+                          HorizontalAlignment="Stretch"
+                          IsClosable="False"
+                          IsOpen="{x:Bind ViewModel.ShowOpenCodeYoloWarning, Mode=OneWay}"
+                          Margin="0,4,0,0"
+                          MaxWidth="1000"
+                          Severity="Warning"
+                          Visibility="{x:Bind ViewModel.ShowOpenCodeYoloWarning, Mode=OneWay}" />
+            <muxc:InfoBar x:Uid="AIAgents_YoloGeminiInfo"
+                          AutomationProperties.AutomationId="GeminiYoloCompatibilityInfoBar"
+                          HorizontalAlignment="Stretch"
+                          IsClosable="False"
+                          IsOpen="{x:Bind ViewModel.ShowGeminiYoloInfo, Mode=OneWay}"
+                          Margin="0,4,0,0"
+                          MaxWidth="1000"
+                          Severity="Informational"
+                          Visibility="{x:Bind ViewModel.ShowGeminiYoloInfo, Mode=OneWay}" />
 
             <!--  ═══ Command palette group ═══  -->
             <TextBlock x:Uid="AIAgents_DelegateGroupHeader"

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -304,10 +304,17 @@
 
                     <Border Padding="0,4"
                             Visibility="{x:Bind mtu:Converters.InvertedBooleanToVisibility(ViewModel.IsAddingCustomModelProvider), Mode=OneWay}">
-                        <Button x:Uid="AIAgents_CustomProviderAdd"
-                                HorizontalAlignment="Right"
-                                Click="{x:Bind ViewModel.AddCustomModelProvider}"
-                                Style="{StaticResource AccentButtonStyle}" />
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Button Grid.Column="1"
+                                    x:Uid="AIAgents_CustomProviderAdd"
+                                    Click="{x:Bind ViewModel.AddCustomModelProvider}"
+                                    MinWidth="120"
+                                    Style="{StaticResource AccentButtonStyle}" />
+                        </Grid>
                     </Border>
 
                     <Border Padding="0,8,0,16"

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -287,7 +287,7 @@
                                                 x:Uid="AIAgents_CustomProviderRemove"
                                                 VerticalAlignment="Center"
                                                 Click="{x:Bind Remove}"
-                                                Width="120" />
+                                                Width="{StaticResource StandardBoxMinWidth}" />
                                         <muxc:InfoBar Grid.Row="1"
                                                       Grid.ColumnSpan="2"
                                                       Margin="0,12,0,0"
@@ -312,7 +312,7 @@
                             <Button Grid.Column="1"
                                     x:Uid="AIAgents_CustomProviderAdd"
                                     Click="{x:Bind ViewModel.AddCustomModelProvider}"
-                                    Width="120"
+                                    Width="{StaticResource StandardBoxMinWidth}"
                                     Style="{StaticResource AccentButtonStyle}" />
                         </Grid>
                     </Border>

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -287,7 +287,7 @@
                                                 x:Uid="AIAgents_CustomProviderRemove"
                                                 VerticalAlignment="Center"
                                                 Click="{x:Bind Remove}"
-                                                MinWidth="120" />
+                                                Width="120" />
                                         <muxc:InfoBar Grid.Row="1"
                                                       Grid.ColumnSpan="2"
                                                       Margin="0,12,0,0"
@@ -312,7 +312,7 @@
                             <Button Grid.Column="1"
                                     x:Uid="AIAgents_CustomProviderAdd"
                                     Click="{x:Bind ViewModel.AddCustomModelProvider}"
-                                    MinWidth="120"
+                                    Width="120"
                                     Style="{StaticResource AccentButtonStyle}" />
                         </Grid>
                     </Border>

--- a/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
+++ b/src/cascadia/TerminalSettingsEditor/AIAgents.xaml
@@ -287,7 +287,7 @@
                                                 x:Uid="AIAgents_CustomProviderRemove"
                                                 VerticalAlignment="Center"
                                                 Click="{x:Bind Remove}"
-                                                Width="{StaticResource StandardBoxMinWidth}" />
+                                                Width="120" />
                                         <muxc:InfoBar Grid.Row="1"
                                                       Grid.ColumnSpan="2"
                                                       Margin="0,12,0,0"
@@ -312,7 +312,7 @@
                             <Button Grid.Column="1"
                                     x:Uid="AIAgents_CustomProviderAdd"
                                     Click="{x:Bind ViewModel.AddCustomModelProvider}"
-                                    Width="{StaticResource StandardBoxMinWidth}"
+                                    Width="120"
                                     Style="{StaticResource AccentButtonStyle}" />
                         </Grid>
                     </Border>

--- a/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/de-DE/Resources.resw
@@ -2977,7 +2977,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>Abbrechen</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/en-US/Resources.resw
@@ -3053,7 +3053,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Add New</value>
+    <value>Add endpoint</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
@@ -3066,7 +3066,7 @@ In this context, "agent" refers to an AI agent (e.g. Copilot, Claude, Gemini), n
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>Cancel</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/es-ES/Resources.resw
@@ -2977,7 +2977,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>Cancelar</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/fr-FR/Resources.resw
@@ -2978,7 +2978,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>Annuler</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/it-IT/Resources.resw
@@ -2977,7 +2977,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>Annulla</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ja-JP/Resources.resw
@@ -2977,7 +2977,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>キャンセル</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ko-KR/Resources.resw
@@ -3022,7 +3022,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>취소</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/pt-BR/Resources.resw
@@ -3009,7 +3009,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>Cancelar</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploc/Resources.resw
@@ -2959,7 +2959,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Add New</value>
+    <value>Add endpoint</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
@@ -2972,7 +2972,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>Cancel</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-ploca/Resources.resw
@@ -2959,7 +2959,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Add New</value>
+    <value>Add endpoint</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
@@ -2972,7 +2972,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>Cancel</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/qps-plocm/Resources.resw
@@ -2959,7 +2959,7 @@
     <comment>{Locked="API"} Hint below the optional custom provider credential input. Use the established localized product name for Windows Credential Manager.</comment>
   </data>
   <data name="AIAgents_CustomProviderAdd.Content" xml:space="preserve">
-    <value>Add New</value>
+    <value>Add endpoint</value>
     <comment>Button in the final custom provider row that reveals the fields for adding another endpoint.</comment>
   </data>
   <data name="AIAgents_CustomProviderSave.Content" xml:space="preserve">
@@ -2972,7 +2972,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>Cancel</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/ru-RU/Resources.resw
@@ -3009,7 +3009,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>Отменить</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/sr-Cyrl-RS/Resources.resw
@@ -3024,7 +3024,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>Откажи</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/uk-UA/Resources.resw
@@ -2681,7 +2681,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>Скасувати</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-CN/Resources.resw
@@ -3022,7 +3022,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>取消</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>

--- a/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
+++ b/src/cascadia/TerminalSettingsEditor/Resources/zh-TW/Resources.resw
@@ -2977,7 +2977,7 @@
   </data>
   <data name="AIAgents_CustomProviderCancel.Content" xml:space="preserve">
     <value>取消</value>
-    <comment>Button that cancels adding a provider and restores the Add New row.</comment>
+    <comment>Button that cancels adding a provider and restores the Add endpoint row.</comment>
   </data>
   <data name="AIAgents_BYOKModelDisplayName" xml:space="preserve">
     <value>{} (BYOK)</value>


### PR DESCRIPTION
## Summary
- Reorder the Agent settings page to show Agent, Model, custom model, Pane position, Error detection, Sessions, and Token usage in sequence.
- Align the Yolo mode toggle with the Sessions and Token usage controls.
- Align the custom model Add endpoint and Remove actions in an equal-width right-side column.
- Rename the custom model action from Add New to Add endpoint.
- Keep all other copy, bindings, and behavior unchanged.

## Testing
- Built TerminalControl, TerminalSettingsEditor, and CascadiaPackage projects.

Closes #789