### PR TITLE
Hide vertical tabs setting until stabilized

### DIFF
--- a/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
+++ b/src/cascadia/TerminalSettingsEditor/GlobalAppearance.xaml
@@ -106,7 +106,7 @@
                       Style="{StaticResource ComboBoxSettingStyle}" />
         </local:SettingContainer>
 
-        <!--  Tab Layout (horizontal vs vertical)  -->
+        <!--  TODO: Re-enable the tab layout setting after vertical tabs stabilize.
         <local:SettingContainer x:Name="TabLayout"
                                 x:Uid="Globals_TabLayout">
             <ComboBox AutomationProperties.AccessibilityView="Content"
@@ -115,6 +115,7 @@
                       SelectedItem="{x:Bind ViewModel.CurrentTabLayout, Mode=TwoWay}"
                       Style="{StaticResource ComboBoxSettingStyle}" />
         </local:SettingContainer>
+        -->
 
         <!--  Disable Animations  -->
         <!--  NOTE: the UID is "DisablePaneAnimationsReversed" not "DisablePaneAnimations". See GH#9124 for more details.  -->


### PR DESCRIPTION
## Summary
- hide the tab layout selector from the Appearance settings page
- leave the underlying vertical tabs implementation and setting unchanged
- add a TODO to restore the selector after vertical tabs stabilize

## Validation
- built the Debug configuration successfully
- deployed and launched Intelligent Terminal