### PR TITLE
Show accurate agent connection stages

### DIFF
--- a/tools/wta/README.md
+++ b/tools/wta/README.md
@@ -253,6 +253,20 @@ the CLI helpers directly with the packaged `wta` app execution alias.
 5. Interact with the agent -- watch requests/responses flow in real time
 6. Use `wta list-panes`, `wta capture-pane` etc. in another pane for debugging
 
+While connecting, the chat activity row shows WTA's current operation: preparing
+the agent connection, connecting to the local coordinator, initializing the
+connection, refreshing user authentication after login (when supported), reading
+the coordinator's session registry snapshot, creating a session, or setting its
+model (when requested). Initialization and creation include local preparation
+and registration, not just waiting on the agent. `/restart` first shows
+"Restarting agent" while old sessions retire. These are local operation
+boundaries, not agent-reported progress: they do not expose internal MCP or
+model-catalog loading, and reading the registry does not fetch agent history.
+A queued session restore shows the actual connection stage first, followed by
+short resume context; once connected, it shows only "Resuming session" until
+the load completes. The pane does not become connected earlier, and these labels
+do not reduce startup time.
+
 ### Adding a new WT protocol method
 
 1. Declare the method in `src/cascadia/TerminalProtocol/TerminalProtocol.idl`

--- a/tools/wta/locales/af-ZA.yml
+++ b/tools/wta/locales/af-ZA.yml
@@ -124,8 +124,25 @@ agents.status.idle: "Ledig"
 layout.welcome_hint: "  (Ctrl+Shift+. om agentpaneel te wys/verberg • Ctrl+Shift+/ om agentsessie te wys/verberg)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Verbindingstoestand ────────────────────────────────────────────────────────
-connection.starting: "Agent word begin..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Berei agentverbinding voor..."
 connection.reconnecting: "Herkoppel tans..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Herbegin agent..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Koppel tans aan plaaslike koördineerder..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inisialiseer agentverbinding..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Staaf tans die gebruiker by die agent..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Lees sessielys..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Skep agentsessie..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Stel sessiemodel: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (hervat %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Koppel tans aan agent…"
 connection.lost: "Verbinding met die agent is verloor. Tik /restart om weer te koppel."  # {Locked="/restart"}
 

--- a/tools/wta/locales/am-ET.yml
+++ b/tools/wta/locales/am-ET.yml
@@ -124,8 +124,25 @@ agents.status.idle: "Idle"
 layout.welcome_hint: "(Ctrl+Shift+. የኤጅንት ገጽታ ማሳየት/መደበቅ • Ctrl+Shift+/ የኤጅንት ክፍለጥ ማሳየት/መደበቅ)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "ኤጅንት በመጀመር..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "የኤጅንት ግንኙነትን በማዘጋጀት ላይ..."
 connection.reconnecting: "እንደገና በመጋኘት..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "ኤጅንቱን እንደገና በማስጀመር ላይ..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "ከአካባቢያዊ አስተባባሪ ጋር በመገናኘት ላይ..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "የኤጅንት ግንኙነትን በማስጀመር ላይ..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "የተጠቃሚውን ማንነት ከኤጅንቱ ጋር በማረጋገጥ ላይ..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "የክፍለ ጊዜ ዝርዝርን በማንበብ ላይ..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "የኤጅንት ክፍለ ጊዜ በመፍጠር ላይ..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "የክፍለ ጊዜ ሞዴል በማቀናበር ላይ፦ %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} እንደገና በመቀጠል ላይ)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "ከኤጅንት ጋር በመገናኘት ላይ…"
 connection.lost: "ከኤጅንት ጋር ያለው ግንኙነት ጠፍቷል። እንደገና ለመገናኘት /restart ብለው ይተይቡ።"  # {Locked="/restart"}
 

--- a/tools/wta/locales/ar-SA.yml
+++ b/tools/wta/locales/ar-SA.yml
@@ -137,8 +137,25 @@ agents.status.idle: "خامل"
 layout.welcome_hint: "  (Ctrl+Shift+. لإظهار/إخفاء لوحة عامل الذكاء الاصطناعي • Ctrl+Shift+/ لإظهار/إخفاء جلسة عامل الذكاء الاصطناعي)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── حالة الاتصال ────────────────────────────────────────────────────────
-connection.starting: "جارٍ تشغيل عامل الذكاء الاصطناعي..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "جارٍ إعداد الاتصال بوكيل الذكاء الاصطناعي..."
 connection.reconnecting: "جارٍ إعادة الاتصال..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "جارٍ إعادة تشغيل وكيل الذكاء الاصطناعي..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "جارٍ الاتصال بالمنسق المحلي..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "جارٍ تهيئة الاتصال بوكيل الذكاء الاصطناعي..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "جارٍ مصادقة المستخدم لدى وكيل الذكاء الاصطناعي..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "جارٍ قراءة قائمة الجلسات..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "جارٍ إنشاء جلسة وكيل الذكاء الاصطناعي..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "جارٍ تعيين نموذج الجلسة: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (جارٍ استئناف %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "جارٍ الاتصال بعامل الذكاء الاصطناعي…"
 connection.lost: "فُقد الاتصال بعامل الذكاء الاصطناعي. اكتب /restart لإعادة الاتصال."  # {Locked="/restart"}
 

--- a/tools/wta/locales/as-IN.yml
+++ b/tools/wta/locales/as-IN.yml
@@ -137,8 +137,25 @@ agents.status.idle: "নিষ্ক্ৰিয়"
 layout.welcome_hint: "  (Ctrl+Shift+. এজেণ্ট পেন দেখুৱাওক/লুকুৱাওক • Ctrl+Shift+/ এজেণ্ট ছেশ্বন দেখুৱাওক/লুকুৱাওক)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── সংযোগ স্থিতি ────────────────────────────────────────────────────────
-connection.starting: "এজেণ্ট আৰম্ভ হৈ আছে..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "এজেণ্টৰ সংযোগ প্ৰস্তুত কৰা হৈছে..."
 connection.reconnecting: "পুনৰ সংযোগ হৈ আছে..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "এজেণ্ট পুনৰ আৰম্ভ কৰা হৈছে..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "স্থানীয় সমন্বয়কৰ সৈতে সংযোগ কৰা হৈছে..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "এজেণ্টৰ সংযোগ আৰম্ভ কৰা হৈছে..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "এজেণ্টৰ সৈতে ব্যৱহাৰকাৰীৰ প্ৰমাণীকৰণ কৰা হৈছে..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "অধিবেশনৰ তালিকা পঢ়া হৈছে..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "এজেণ্টৰ অধিবেশন সৃষ্টি কৰা হৈছে..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "অধিবেশনৰ মডেল নিৰ্ধাৰণ কৰা হৈছে: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} পুনৰ চলাই থকা হৈছে)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "এজেণ্টলৈ সংযোগ হৈ আছে…"
 connection.lost: "এজেণ্টৰ সৈতে সংযোগ হেৰাই গ'ল। পুনৰ সংযোগ কৰিবলৈ /restart টাইপ কৰক।"  # {Locked="/restart"}
 

--- a/tools/wta/locales/az-Latn-AZ.yml
+++ b/tools/wta/locales/az-Latn-AZ.yml
@@ -137,8 +137,25 @@ agents.status.idle: "Boş"
 layout.welcome_hint: "  (Ctrl+Shift+. agent panelini göstər/gizlə • Ctrl+Shift+/ agent sessiyasını göstər/gizlə)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Agent başladılır..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Agent bağlantısı hazırlanır..."
 connection.reconnecting: "Yenidən qoşulur..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Agent yenidən başladılır..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Yerli koordinatora qoşulur..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Agent bağlantısı ilkin sazlanır..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Agentdə istifadəçinin kimliyi doğrulanır..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Sessiya siyahısı oxunur..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Agent sessiyası yaradılır..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Sessiya modeli təyin edilir: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} davam etdirilir)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Agentə qoşulur…"
 connection.lost: "Agentlə bağlantı itdi. Yenidən qoşulmaq üçün /restart yazın."  # {Locked="/restart"}
 

--- a/tools/wta/locales/bg-BG.yml
+++ b/tools/wta/locales/bg-BG.yml
@@ -133,8 +133,25 @@ agents.status.idle: "Неактивен"
 layout.welcome_hint: "  (Ctrl+Shift+. показване/скриване на панела на агента • Ctrl+Shift+/ показване/скриване на сесията на агента)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Стартиране на агента..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Подготовка на връзката с агента..."
 connection.reconnecting: "Повторно свързване..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Рестартиране на агента..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Свързване с локалния координатор..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Инициализиране на връзката с агента..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Удостоверяване на потребителя пред агента..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Четене на списъка със сесии..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Създаване на сесия на агента..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Задаване на модел за сесията: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (възобновяване на %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Свързване с агента…"
 connection.lost: "Връзката с агента беше загубена. Въведете /restart, за да се свържете отново."  # {Locked="/restart"}
 

--- a/tools/wta/locales/bn-IN.yml
+++ b/tools/wta/locales/bn-IN.yml
@@ -137,8 +137,25 @@ agents.status.idle: "নিষ্ক্রিয়"
 layout.welcome_hint: "  (Ctrl+Shift+. এজেন্ট পেন দেখান/লুকান • Ctrl+Shift+/ এজেন্ট সেশন দেখান/লুকান)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── সংযোগ অবস্থা ────────────────────────────────────────────────────────
-connection.starting: "এজেন্ট চালু হচ্ছে..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "এজেন্টের সংযোগ প্রস্তুত করা হচ্ছে..."
 connection.reconnecting: "পুনরায় সংযোগ হচ্ছে..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "এজেন্ট পুনরায় চালু করা হচ্ছে..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "স্থানীয় সমন্বয়কারীর সঙ্গে সংযোগ করা হচ্ছে..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "এজেন্টের সংযোগের প্রারম্ভিকীকরণ করা হচ্ছে..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "এজেন্টের কাছে ব্যবহারকারীর পরিচয় যাচাই করা হচ্ছে..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "সেশনের তালিকা পড়া হচ্ছে..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "এজেন্টের সেশন তৈরি করা হচ্ছে..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "সেশনের মডেল সেট করা হচ্ছে: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} পুনরায় চালিয়ে যাওয়া হচ্ছে)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "এজেন্টের সাথে সংযোগ হচ্ছে…"
 connection.lost: "এজেন্টের সাথে সংযোগ হারিয়ে গেছে। পুনরায় সংযোগ করতে /restart টাইপ করুন।"  # {Locked="/restart"}
 

--- a/tools/wta/locales/bs-Latn-BA.yml
+++ b/tools/wta/locales/bs-Latn-BA.yml
@@ -133,8 +133,25 @@ agents.status.idle: "Neaktivan"
 layout.welcome_hint: "  (Ctrl+Shift+. za prikaz/skrivanje panela agenta • Ctrl+Shift+/ za prikaz/skrivanje sesije agenta)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Pokretanje agenta..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Priprema veze s agentom..."
 connection.reconnecting: "Ponovno povezivanje..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Ponovno pokretanje agenta..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Povezivanje s lokalnim koordinatorom..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inicijalizacija veze s agentom..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Autentifikacija korisnika kod agenta..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Čitanje liste sesija..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Kreiranje sesije agenta..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Postavljanje modela sesije: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (nastavljanje %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Povezivanje s agentom…"
 connection.lost: "Veza s agentom je izgubljena. Upišite /restart za ponovno povezivanje."  # {Locked="/restart"}
 

--- a/tools/wta/locales/ca-ES.yml
+++ b/tools/wta/locales/ca-ES.yml
@@ -124,8 +124,25 @@ agents.status.idle: "Inactiu"
 layout.welcome_hint: "  (Ctrl+Shift+. per mostrar/amagar el tauler d'agent • Ctrl+Shift+/ per mostrar/amagar la sessió d'agent)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Estat de la connexió ────────────────────────────────────────────────────────
-connection.starting: "S'està iniciant l'agent..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "S'està preparant la connexió amb l'agent..."
 connection.reconnecting: "S'està reconnectant..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "S'està reiniciant l'agent..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "S'està connectant amb el coordinador local..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "S'està inicialitzant la connexió amb l'agent..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "S'està autenticant l'usuari davant de l'agent..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "S'està llegint la llista de sessions..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "S'està creant la sessió de l'agent..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "S'està establint el model de la sessió: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (s'està reprenent %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "S'està connectant a l'agent…"
 connection.lost: "S'ha perdut la connexió amb l'agent. Escriviu /restart per tornar-vos a connectar."  # {Locked="/restart"}
 

--- a/tools/wta/locales/ca-Es-VALENCIA.yml
+++ b/tools/wta/locales/ca-Es-VALENCIA.yml
@@ -124,8 +124,25 @@ agents.status.idle: "Inactiu"
 layout.welcome_hint: "  (Ctrl+Shift+. per a mostrar/amagar el panell d'agent • Ctrl+Shift+/ per a mostrar/amagar la sessió d'agent)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Estat de la connexió ────────────────────────────────────────────────────────
-connection.starting: "S'està iniciant l'agent..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "S'està preparant la connexió amb l'agent..."
 connection.reconnecting: "S'està reconnectant..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "S'està reiniciant l'agent..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "S'està connectant amb el coordinador local..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "S'està inicialitzant la connexió amb l'agent..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "S'està autenticant l'usuari davant de l'agent..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "S'està llegint la llista de sessions..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "S'està creant la sessió de l'agent..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "S'està establint el model de la sessió: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (s'està reprenent %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "S'està connectant a l'agent…"
 connection.lost: "S'ha perdut la connexió amb l'agent. Escriviu /restart per tornar-vos a connectar."  # {Locked="/restart"}
 

--- a/tools/wta/locales/cs-CZ.yml
+++ b/tools/wta/locales/cs-CZ.yml
@@ -133,8 +133,25 @@ agents.status.idle: "Nečinný"
 layout.welcome_hint: "  (Ctrl+Shift+. zobrazit/skrýt panel agenta • Ctrl+Shift+/ zobrazit/skrýt relaci agenta)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Spouštění agenta..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Příprava připojení k agentovi..."
 connection.reconnecting: "Opětovné připojování..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Restartování agenta..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Připojování k místnímu koordinátoru..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inicializace připojení k agentovi..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Ověřování uživatele u agenta..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Čtení seznamu relací..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Vytváření relace agenta..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Nastavování modelu relace: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (obnovování %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Připojování k agentovi…"
 connection.lost: "Připojení k agentovi bylo ztraceno. Zadáním /restart se znovu připojíte."  # {Locked="/restart"}
 

--- a/tools/wta/locales/cy-GB.yml
+++ b/tools/wta/locales/cy-GB.yml
@@ -124,8 +124,25 @@ agents.status.idle: "Segur"
 layout.welcome_hint: "  (Ctrl+Shift+. i ddangos/cuddio'r paen asiant • Ctrl+Shift+/ i ddangos/cuddio'r sesiwn asiant)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Cyflwr cysylltiad ────────────────────────────────────────────────────────
-connection.starting: "Yn cychwyn yr asiant..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Yn paratoi'r cysylltiad â'r asiant..."
 connection.reconnecting: "Yn ailgysylltu..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Yn ailgychwyn yr asiant..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Yn cysylltu â'r cydlynydd lleol..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Yn ymgychwyn y cysylltiad â'r asiant..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Yn dilysu'r defnyddiwr gyda'r asiant..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Yn darllen y rhestr sesiynau..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Yn creu sesiwn yr asiant..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Yn gosod model y sesiwn: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (yn ailddechrau %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Yn cysylltu â'r asiant…"
 connection.lost: "Collwyd y cysylltiad â'r asiant. Teipiwch /restart i ailgysylltu."  # {Locked="/restart"}
 

--- a/tools/wta/locales/da-DK.yml
+++ b/tools/wta/locales/da-DK.yml
@@ -124,8 +124,25 @@ agents.status.idle: "Inaktiv"
 layout.welcome_hint: "  (Ctrl+Shift+. for at vise/skjule agentpanelet • Ctrl+Shift+/ for at vise/skjule agentsessionen)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Starter agenten..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Forbereder forbindelsen til agenten..."
 connection.reconnecting: "Genopretter forbindelse..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Genstarter agenten..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Opretter forbindelse til den lokale koordinator..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Initialiserer forbindelsen til agenten..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Godkender brugeren hos agenten..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Læser sessionslisten..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Opretter agentsession..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Indstiller sessionsmodel: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (genoptager %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Opretter forbindelse til agenten…"
 connection.lost: "Forbindelsen til agenten gik tabt. Skriv /restart for at oprette forbindelse igen."  # {Locked="/restart"}
 

--- a/tools/wta/locales/de-DE.yml
+++ b/tools/wta/locales/de-DE.yml
@@ -124,8 +124,25 @@ agents.status.idle: "Inaktiv"
 layout.welcome_hint: "  (Ctrl+Shift+. zum Ein-/Ausblenden des Agentbereichs • Ctrl+Shift+/ zum Ein-/Ausblenden der Agentsitzung)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Verbindungsstatus ────────────────────────────────────────────────────────────
-connection.starting: "Agent wird gestartet..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Verbindung mit dem Agenten wird vorbereitet..."
 connection.reconnecting: "Verbindung wird wiederhergestellt..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Agent wird neu gestartet..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Verbindung mit dem lokalen Koordinator wird hergestellt..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Verbindung mit dem Agenten wird initialisiert..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Benutzer wird beim Agenten authentifiziert..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Sitzungsliste wird gelesen..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Agentsitzung wird erstellt..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Sitzungsmodell wird festgelegt: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (Fortsetzen von %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Verbindung mit dem Agenten wird hergestellt…"
 connection.lost: "Die Verbindung mit dem Agenten wurde getrennt. Geben Sie /restart ein, um die Verbindung wiederherzustellen."  # {Locked="/restart"}
 

--- a/tools/wta/locales/el-GR.yml
+++ b/tools/wta/locales/el-GR.yml
@@ -124,8 +124,25 @@ agents.status.idle: "Αδρανής"
 layout.welcome_hint: "  (Ctrl+Shift+. για εμφάνιση/απόκρυψη πλαισίου παράγοντα • Ctrl+Shift+/ για εμφάνιση/απόκρυψη συνεδρίας παράγοντα)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Εκκίνηση παράγοντα..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Προετοιμασία σύνδεσης με τον πράκτορα τεχνητής νοημοσύνης..."
 connection.reconnecting: "Επανασύνδεση..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Επανεκκίνηση του πράκτορα τεχνητής νοημοσύνης..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Σύνδεση με τον τοπικό συντονιστή..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Αρχικοποίηση σύνδεσης με τον πράκτορα τεχνητής νοημοσύνης..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Έλεγχος ταυτότητας χρήστη στον πράκτορα τεχνητής νοημοσύνης..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Ανάγνωση της λίστας συνεδριών..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Δημιουργία συνεδρίας του πράκτορα τεχνητής νοημοσύνης..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Ορισμός μοντέλου συνεδρίας: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (συνέχιση %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Σύνδεση με τον παράγοντα…"
 connection.lost: "Η σύνδεση με τον παράγοντα χάθηκε. Πληκτρολογήστε /restart για επανασύνδεση."  # {Locked="/restart"}
 

--- a/tools/wta/locales/en-GB.yml
+++ b/tools/wta/locales/en-GB.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Idle"
 layout.welcome_hint: "  (Ctrl+Shift+. to show/hide agent pane • Ctrl+Shift+/ to show/hide agent session)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Starting agent..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Preparing agent connection..."
 connection.reconnecting: "Reconnecting..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Restarting agent..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Connecting to local coordinator..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Initialising agent connection..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Authenticating with agent..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Reading session list..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Creating agent session..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Setting session model: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (resuming %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Connecting to agent…"
 connection.lost: "Connection to the agent was lost. Type /restart to reconnect."  # {Locked="/restart"}
 

--- a/tools/wta/locales/en-US.yml
+++ b/tools/wta/locales/en-US.yml
@@ -196,10 +196,26 @@ agents.status.idle: "Idle"
 layout.welcome_hint: "  (Ctrl+Shift+. to show/hide agent pane • Ctrl+Shift+/ to show/hide agent session)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-# Status text shown while launching the agent process
-connection.starting: "Starting agent..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Preparing agent connection..."
 # Status text shown while re-establishing agent connection
 connection.reconnecting: "Reconnecting..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Restarting agent..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Connecting to local coordinator..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Initializing agent connection..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Authenticating with agent..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Reading session list..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Creating agent session..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Setting session model: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (resuming %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 # Animated activity line shown in the chat while the helper is still
 # establishing its connection to the agent (pipe connect → ACP init → session).
 # First agent launch can pull the npx adapter, so this can sit for tens of

--- a/tools/wta/locales/es-ES.yml
+++ b/tools/wta/locales/es-ES.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inactivo"
 layout.welcome_hint: "  (Ctrl+Shift+. para mostrar/ocultar el panel del agente • Ctrl+Shift+/ para mostrar/ocultar la sesión del agente)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Estado de conexión ────────────────────────────────────────────────────────────
-connection.starting: "Iniciando agente..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Preparando la conexión con el agente..."
 connection.reconnecting: "Reconectando..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Reiniciando el agente..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Conectando con el coordinador local..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inicializando la conexión con el agente..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Autenticando al usuario ante el agente..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Leyendo la lista de sesiones..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Creando la sesión del agente..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Estableciendo el modelo de la sesión: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (reanudando %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Conectando con el agente…"
 connection.lost: "Se perdió la conexión con el agente. Escribe /restart para volver a conectar."  # {Locked="/restart"}
 

--- a/tools/wta/locales/es-MX.yml
+++ b/tools/wta/locales/es-MX.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inactivo"
 layout.welcome_hint: "  (Ctrl+Shift+. para mostrar/ocultar el panel del agente • Ctrl+Shift+/ para mostrar/ocultar la sesión del agente)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Estado de conexión ────────────────────────────────────────────────────────────
-connection.starting: "Iniciando agente..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Preparando la conexión con el agente..."
 connection.reconnecting: "Reconectando..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Reiniciando el agente..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Conectando con el coordinador local..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inicializando la conexión con el agente..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Autenticando al usuario ante el agente..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Leyendo la lista de sesiones..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Creando la sesión del agente..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Estableciendo el modelo de la sesión: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (reanudando %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Conectando con el agente…"
 connection.lost: "Se perdió la conexión con el agente. Escribe /restart para volver a conectar."  # {Locked="/restart"}
 

--- a/tools/wta/locales/et-EE.yml
+++ b/tools/wta/locales/et-EE.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Jõude"
 layout.welcome_hint: "  (Ctrl+Shift+. agendipaneeli kuvamiseks/peitmiseks • Ctrl+Shift+/ agendiseansi kuvamiseks/peitmiseks)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Agendi käivitamine..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Agendiühenduse ettevalmistamine..."
 connection.reconnecting: "Taasühendamine..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Agendi taaskäivitamine..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Ühendamine kohaliku koordinaatoriga..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Agendiühenduse algväärtustamine..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Kasutaja autentimine agendi juures..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Seansiloendi lugemine..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Agendiseansi loomine..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Seansimudeli määramine: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} jätkamine)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Agendiga ühenduse loomine…"
 connection.lost: "Ühendus agendiga katkes. Uuesti ühendamiseks tippige /restart."  # {Locked="/restart"}
 

--- a/tools/wta/locales/eu-ES.yml
+++ b/tools/wta/locales/eu-ES.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inaktibo"
 layout.welcome_hint: "  (Ctrl+Shift+. agente-panela erakusteko/ezkutatzeko • Ctrl+Shift+/ agente-saioa erakusteko/ezkutatzeko)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Konexio-egoera ────────────────────────────────────────────────────────
-connection.starting: "Agentea abiarazten..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Agentearekiko konexioa prestatzen..."
 connection.reconnecting: "Birkonektatzen..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Agentea berrabiarazten..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Koordinatzaile lokalera konektatzen..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Agentearekiko konexioa hasieratzen..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Erabiltzailea agentearekin autentifikatzen..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Saioen zerrenda irakurtzen..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Agentearen saioa sortzen..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Saioaren modeloa ezartzen: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} berrekitzen)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Agentearekin konektatzen…"
 connection.lost: "Agentearekiko konexioa galdu da. Idatzi /restart berriro konektatzeko."  # {Locked="/restart"}
 

--- a/tools/wta/locales/fa-IR.yml
+++ b/tools/wta/locales/fa-IR.yml
@@ -136,8 +136,25 @@ agents.status.idle: "بیکار"
 layout.welcome_hint: "  (Ctrl+Shift+. نمایش/پنهان کردن پنل عامل هوش مصنوعی • Ctrl+Shift+/ نمایش/پنهان کردن نشست عامل هوش مصنوعی)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── وضعیت اتصال ────────────────────────────────────────────────────────
-connection.starting: "در حال راه‌اندازی عامل هوش مصنوعی..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "در حال آماده‌سازی اتصال به عامل هوش مصنوعی..."
 connection.reconnecting: "در حال اتصال مجدد..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "در حال راه‌اندازی مجدد عامل هوش مصنوعی..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "در حال اتصال به هماهنگ‌کنندهٔ محلی..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "در حال مقداردهی اولیهٔ اتصال به عامل هوش مصنوعی..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "در حال احراز هویت کاربر نزد عامل هوش مصنوعی..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "در حال خواندن فهرست جلسه‌ها..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "در حال ایجاد جلسهٔ عامل هوش مصنوعی..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "در حال تنظیم مدل جلسه: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (در حال ازسرگیری %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "در حال اتصال به عامل هوش مصنوعی…"
 connection.lost: "اتصال به عامل هوش مصنوعی قطع شد. برای اتصال مجدد، /restart را تایپ کنید."  # {Locked="/restart"}
 

--- a/tools/wta/locales/fi-FI.yml
+++ b/tools/wta/locales/fi-FI.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Vapaa"
 layout.welcome_hint: "  (Ctrl+Shift+. näyttää/piilottaa agenttipaneelin • Ctrl+Shift+/ näyttää/piilottaa agenttiistunnon)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Käynnistetään agenttia..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Valmistellaan agenttiyhteyttä..."
 connection.reconnecting: "Yhdistetään uudelleen..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Käynnistetään agenttia uudelleen..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Yhdistetään paikalliseen koordinaattoriin..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Alustetaan agenttiyhteyttä..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Todennetaan käyttäjää agentille..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Luetaan istuntoluetteloa..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Luodaan agentin istuntoa..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Asetetaan istunnon mallia: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (jatketaan istuntoa %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Yhdistetään agenttiin…"
 connection.lost: "Yhteys agenttiin katkesi. Muodosta yhteys uudelleen kirjoittamalla /restart."  # {Locked="/restart"}
 

--- a/tools/wta/locales/fil-PH.yml
+++ b/tools/wta/locales/fil-PH.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Walang ginagawa"
 layout.welcome_hint: "  (Ctrl+Shift+. para ipakita/itago ang agent pane • Ctrl+Shift+/ para ipakita/itago ang agent session)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Sinisimulan ang agent..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Inihahanda ang koneksyon sa agent..."
 connection.reconnecting: "Kumokonekta muli..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Sinisimulang muli ang agent..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Kumokonekta sa lokal na coordinator..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Sinisimulan ang koneksyon sa agent..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Pinapatunayan ang pagkakakilanlan ng user sa agent..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Binabasa ang listahan ng mga session..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Gumagawa ng session ng agent..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Itinatakda ang modelo ng session: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (ipinagpapatuloy ang %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Kumokonekta sa agent…"
 connection.lost: "Nawala ang koneksyon sa agent. I-type ang /restart para kumonektang muli."  # {Locked="/restart"}
 

--- a/tools/wta/locales/fr-CA.yml
+++ b/tools/wta/locales/fr-CA.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inactif"
 layout.welcome_hint: "  (Ctrl+Shift+. pour afficher/masquer le volet de l'agent • Ctrl+Shift+/ pour afficher/masquer la session de l'agent)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── État de la connexion ────────────────────────────────────────────────────────────
-connection.starting: "Démarrage de l'agent..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Préparation de la connexion à l'agent..."
 connection.reconnecting: "Reconnexion..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Redémarrage de l'agent..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Connexion au coordonnateur local..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Initialisation de la connexion à l'agent..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Authentification auprès de l'agent..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Lecture de la liste des sessions..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Création de la session de l'agent..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Définition du modèle de la session : %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (reprise de %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Connexion à l'agent…"
 connection.lost: "La connexion à l'agent a été perdue. Tapez /restart pour vous reconnecter."  # {Locked="/restart"}
 

--- a/tools/wta/locales/fr-FR.yml
+++ b/tools/wta/locales/fr-FR.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inactif"
 layout.welcome_hint: "  (Ctrl+Shift+. pour afficher/masquer le volet de l'agent • Ctrl+Shift+/ pour afficher/masquer la session de l'agent)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── État de la connexion ────────────────────────────────────────────────────────────
-connection.starting: "Démarrage de l'agent..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Préparation de la connexion à l'agent..."
 connection.reconnecting: "Reconnexion..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Redémarrage de l'agent..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Connexion au coordinateur local..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Initialisation de la connexion à l'agent..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Authentification auprès de l'agent..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Lecture de la liste des sessions..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Création de la session de l'agent..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Définition du modèle de la session : %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (reprise de %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Connexion à l'agent…"
 connection.lost: "La connexion à l'agent a été perdue. Tapez /restart pour vous reconnecter."  # {Locked="/restart"}
 

--- a/tools/wta/locales/ga-IE.yml
+++ b/tools/wta/locales/ga-IE.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Díomhaoin"
 layout.welcome_hint: "  (Ctrl+Shift+. chun pána gníomhaire a thaispeáint/a cheilt • Ctrl+Shift+/ chun seisiún gníomhaire a thaispeáint/a cheilt)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Staid ceangail ────────────────────────────────────────────────────────
-connection.starting: "Gníomhaire á thosú..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Ceangal leis an ngníomhaire á ullmhú..."
 connection.reconnecting: "Ag athcheangal..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "An gníomhaire á atosú..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Ag ceangal leis an gcomhordaitheoir áitiúil..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Ceangal leis an ngníomhaire á thúsú..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "An t-úsáideoir á fhíordheimhniú leis an ngníomhaire..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Liosta na seisiún á léamh..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Seisiún an ghníomhaire á chruthú..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Samhail an tseisiúin á socrú: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (ag leanúint de %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Ag ceangal leis an ngníomhaire…"
 connection.lost: "Cailleadh an ceangal leis an ngníomhaire. Clóscríobh /restart chun athcheangal."  # {Locked="/restart"}
 

--- a/tools/wta/locales/gd-gb.yml
+++ b/tools/wta/locales/gd-gb.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Na thàmh"
 layout.welcome_hint: "  (Ctrl+Shift+. gus panail àidseant a shealltainn/fhalach • Ctrl+Shift+/ gus seisean àidseant a shealltainn/fhalach)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Staid ceangail ────────────────────────────────────────────────────────
-connection.starting: "A' tòiseachadh an àidseant..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Ag ullachadh a' cheangail ris an neach-gnìomha..."
 connection.reconnecting: "Ag ath-cheangal..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Ag ath-thòiseachadh an neach-gnìomha..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "A' ceangal ris a' cho-òrdanaiche ionadail..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "A' tòiseachadh a' cheangail ris an neach-gnìomha..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "A' dearbhadh an cleachdaiche leis an neach-gnìomha..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "A' leughadh liosta nan seiseanan..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "A' cruthachadh seisean an neach-gnìomha..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "A' suidheachadh modail an t-seisein: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (a' leantainn air %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "A' ceangal ris an àidseant…"
 connection.lost: "Chaidh an ceangal ris an àidseant a chall. Sgrìobh /restart gus ath-cheangal."  # {Locked="/restart"}
 

--- a/tools/wta/locales/gl-ES.yml
+++ b/tools/wta/locales/gl-ES.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inactivo"
 layout.welcome_hint: "  (Ctrl+Shift+. para mostrar/ocultar o panel de axente • Ctrl+Shift+/ para mostrar/ocultar a sesión de axente)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Estado da conexión ────────────────────────────────────────────────────────
-connection.starting: "Iniciando o axente..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Preparando a conexión co axente..."
 connection.reconnecting: "Reconectando..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Reiniciando o axente..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Conectando co coordinador local..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inicializando a conexión co axente..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Autenticando o usuario ante o axente..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Lendo a lista de sesións..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Creando a sesión do axente..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Establecendo o modelo da sesión: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (retomando %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Conectando co axente…"
 connection.lost: "Perdeuse a conexión co axente. Escribe /restart para volver conectar."  # {Locked="/restart"}
 

--- a/tools/wta/locales/gu-IN.yml
+++ b/tools/wta/locales/gu-IN.yml
@@ -136,8 +136,25 @@ agents.status.idle: "નિષ્ક્રિય"
 layout.welcome_hint: "  (Ctrl+Shift+. એજન્ટ પેન બતાવો/છુપાવો • Ctrl+Shift+/ એજન્ટ સત્ર બતાવો/છુપાવો)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── જોડાણ સ્થિતિ ────────────────────────────────────────────────────────
-connection.starting: "એજન્ટ શરૂ થઈ રહ્યો છે..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "એજન્ટ સાથેનું જોડાણ તૈયાર કરવામાં આવી રહ્યું છે..."
 connection.reconnecting: "ફરીથી જોડાઈ રહ્યું છે..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "એજન્ટ ફરી શરૂ કરવામાં આવી રહ્યો છે..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "સ્થાનિક સંયોજક સાથે જોડાઈ રહ્યું છે..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "એજન્ટ સાથેનું જોડાણ શરૂ કરવામાં આવી રહ્યું છે..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "એજન્ટ પાસે વપરાશકર્તાની ઓળખ પ્રમાણિત કરવામાં આવી રહી છે..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "સત્રોની સૂચિ વાંચવામાં આવી રહી છે..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "એજન્ટનું સત્ર બનાવવામાં આવી રહ્યું છે..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "સત્રનું મૉડલ સેટ કરવામાં આવી રહ્યું છે: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} ફરી ચાલુ)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "એજન્ટ સાથે કનેક્ટ થઈ રહ્યું છે…"
 connection.lost: "એજન્ટ સાથેનું કનેક્શન તૂટી ગયું. ફરીથી કનેક્ટ કરવા માટે /restart ટાઇપ કરો."  # {Locked="/restart"}
 

--- a/tools/wta/locales/he-IL.yml
+++ b/tools/wta/locales/he-IL.yml
@@ -136,8 +136,25 @@ agents.status.idle: "לא פעיל"
 layout.welcome_hint: "  (Ctrl+Shift+. להצגה/הסתרה של חלונית הסוכן • Ctrl+Shift+/ להצגה/הסתרה של הפעלת הסוכן)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── מצב חיבור ────────────────────────────────────────────────────────
-connection.starting: "מפעיל את הסוכן..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "מכין את החיבור לסוכן..."
 connection.reconnecting: "מתחבר מחדש..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "מפעיל מחדש את הסוכן..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "מתחבר למתאם המקומי..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "מאתחל את החיבור לסוכן..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "מאמת את זהות המשתמש מול הסוכן..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "קורא את רשימת ההפעלות..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "יוצר הפעלה של הסוכן..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "מגדיר את מודל ההפעלה: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (מחדש את %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "מתחבר לסוכן…"
 connection.lost: "החיבור לסוכן אבד. הקלד /restart כדי להתחבר מחדש."  # {Locked="/restart"}
 

--- a/tools/wta/locales/hi-IN.yml
+++ b/tools/wta/locales/hi-IN.yml
@@ -136,8 +136,25 @@ agents.status.idle: "निष्क्रिय"
 layout.welcome_hint: "  (Ctrl+Shift+. एजेंट पेन दिखाएँ/छिपाएँ • Ctrl+Shift+/ एजेंट सत्र दिखाएँ/छिपाएँ)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── कनेक्शन स्थिति ────────────────────────────────────────────────────────
-connection.starting: "एजेंट प्रारंभ हो रहा है..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "एजेंट कनेक्शन तैयार किया जा रहा है..."
 connection.reconnecting: "पुनः कनेक्ट हो रहा है..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "एजेंट पुनः प्रारंभ किया जा रहा है..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "स्थानीय समन्वयक से कनेक्ट हो रहा है..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "एजेंट कनेक्शन का आरंभीकरण किया जा रहा है..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "एजेंट के साथ उपयोगकर्ता का प्रमाणीकरण किया जा रहा है..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "सत्र सूची पढ़ी जा रही है..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "एजेंट सत्र बनाया जा रहा है..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "सत्र का मॉडल सेट किया जा रहा है: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} जारी रखते हुए)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "एजेंट से कनेक्ट हो रहा है…"
 connection.lost: "एजेंट से कनेक्शन टूट गया. फिर से कनेक्ट करने के लिए /restart टाइप करें."  # {Locked="/restart"}
 

--- a/tools/wta/locales/hr-HR.yml
+++ b/tools/wta/locales/hr-HR.yml
@@ -132,8 +132,25 @@ agents.status.idle: "Neaktivno"
 layout.welcome_hint: "  (Ctrl+Shift+. prikaži/sakrij okno agenta • Ctrl+Shift+/ prikaži/sakrij sesiju agenta)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Pokretanje agenta..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Priprema veze s agentom..."
 connection.reconnecting: "Ponovno povezivanje..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Ponovno pokretanje agenta..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Povezivanje s lokalnim koordinatorom..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inicijalizacija veze s agentom..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Provjera autentičnosti korisnika kod agenta..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Čitanje popisa sesija..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Stvaranje sesije agenta..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Postavljanje modela sesije: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (nastavljanje %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Povezivanje s agentom…"
 connection.lost: "Veza s agentom je izgubljena. Upišite /restart za ponovno povezivanje."  # {Locked="/restart"}
 

--- a/tools/wta/locales/hu-HU.yml
+++ b/tools/wta/locales/hu-HU.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Tétlen"
 layout.welcome_hint: "  (Ctrl+Shift+. ügynökpanel megjelenítése/elrejtése • Ctrl+Shift+/ ügynökmunkamenet megjelenítése/elrejtése)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Ügynök indítása..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Ügynökkapcsolat előkészítése..."
 connection.reconnecting: "Újrakapcsolódás..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Ügynök újraindítása..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Kapcsolódás a helyi koordinátorhoz..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Ügynökkapcsolat inicializálása..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Felhasználó hitelesítése az ügynöknél..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Munkamenetlista olvasása..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Ügynöki munkamenet létrehozása..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Munkamenet modelljének beállítása: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} folytatása)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Kapcsolódás az ügynökhöz…"
 connection.lost: "Megszakadt a kapcsolat az ügynökkel. Az újrakapcsolódáshoz írja be: /restart."  # {Locked="/restart"}
 

--- a/tools/wta/locales/hy-AM.yml
+++ b/tools/wta/locales/hy-AM.yml
@@ -148,10 +148,26 @@ agents.status.idle: "Անգործ"
 layout.welcome_hint: "  (Ctrl+Shift+. ագենտի վահանակը ցույց տալ/թաքցնել • Ctrl+Shift+/ ագենտի նիստը ցույց տալ/թաքցնել)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────────────────────
-# Status text shown while launching the agent process
-connection.starting: "Ագենտը գործարկվում է..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Գործակալի հետ կապի նախապատրաստում..."
 # Status text shown while re-establishing agent connection
 connection.reconnecting: "Վերմիանում..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Գործակալի վերագործարկում..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Միացում տեղային համակարգողին..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Գործակալի հետ կապի սկզբնավորում..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Օգտատիրոջ ինքնության հաստատում գործակալի մոտ..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Նիստերի ցանկի ընթերցում..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Գործակալի նիստի ստեղծում..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Նիստի մոդելի սահմանում՝ %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (վերսկսում՝ %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Միանում է ագենտին…"
 connection.lost: "Ագենտի հետ կապը կորել է։ Մուտքագրեք /restart՝ նորից միանալու համար։"  # {Locked="/restart"}
 

--- a/tools/wta/locales/id-ID.yml
+++ b/tools/wta/locales/id-ID.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Menganggur"
 layout.welcome_hint: "  (Ctrl+Shift+. untuk menampilkan/menyembunyikan panel agen AI • Ctrl+Shift+/ untuk menampilkan/menyembunyikan sesi agen AI)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Memulai agen AI..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Menyiapkan koneksi agen AI..."
 connection.reconnecting: "Menyambungkan kembali..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Memulai ulang agen AI..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Menyambungkan ke koordinator lokal..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Menginisialisasi koneksi agen AI..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Mengautentikasi pengguna dengan agen AI..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Membaca daftar sesi..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Membuat sesi agen AI..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Mengatur model sesi: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (melanjutkan %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Menyambungkan ke agen AI…"
 connection.lost: "Koneksi ke agen AI terputus. Ketik /restart untuk menyambungkan kembali."  # {Locked="/restart"}
 

--- a/tools/wta/locales/is-IS.yml
+++ b/tools/wta/locales/is-IS.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Aðgerðarlaus"
 layout.welcome_hint: "  (Ctrl+Shift+. til að sýna/fela agentspjald • Ctrl+Shift+/ til að sýna/fela agentlotu)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Ræsi agent..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Undirbý tengingu við agent..."
 connection.reconnecting: "Endurtengi..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Endurræsi agent..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Tengist staðbundinni samræmingarþjónustu..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Frumstilli tengingu við agent..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Auðkenni notanda hjá agent..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Les lotulista..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Bý til lotu fyrir agent..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Stilli líkan lotunnar: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (held áfram með %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Tengist agent…"
 connection.lost: "Tengingin við agent rofnaði. Sláðu inn /restart til að tengjast aftur."  # {Locked="/restart"}
 

--- a/tools/wta/locales/it-IT.yml
+++ b/tools/wta/locales/it-IT.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inattivo"
 layout.welcome_hint: "  (Ctrl+Shift+. per mostrare/nascondere il riquadro agente • Ctrl+Shift+/ per mostrare/nascondere la sessione dell'agente)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Stato della connessione ────────────────────────────────────────────────────────────
-connection.starting: "Avvio dell'agente..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Preparazione della connessione all'agente..."
 connection.reconnecting: "Riconnessione..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Riavvio dell'agente..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Connessione al coordinatore locale..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inizializzazione della connessione all'agente..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Autenticazione dell'utente presso l'agente..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Lettura dell'elenco delle sessioni..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Creazione della sessione dell'agente..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Impostazione del modello della sessione: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (ripresa di %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Connessione all'agente…"
 connection.lost: "La connessione all'agente è stata persa. Digita /restart per riconnetterti."  # {Locked="/restart"}
 

--- a/tools/wta/locales/ja-JP.yml
+++ b/tools/wta/locales/ja-JP.yml
@@ -119,8 +119,25 @@ agents.status.idle: "アイドル"
 layout.welcome_hint: "  (Ctrl+Shift+. エージェント ペインの表示/非表示 • Ctrl+Shift+/ エージェント セッションの表示/非表示)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── 接続状態 ────────────────────────────────────────────────────────────
-connection.starting: "エージェントを起動中..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "エージェントへの接続を準備中..."
 connection.reconnecting: "再接続中..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "エージェントを再起動中..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "ローカル コーディネーターに接続中..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "エージェントへの接続を初期化中..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "エージェントでユーザー認証中..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "セッション一覧を読み取り中..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "エージェント セッションを作成中..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "セッションのモデルを設定中: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} を再開中)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "エージェントに接続中…"
 connection.lost: "エージェントへの接続が失われました。再接続するには /restart と入力してください。"  # {Locked="/restart"}
 

--- a/tools/wta/locales/ka-GE.yml
+++ b/tools/wta/locales/ka-GE.yml
@@ -136,8 +136,25 @@ agents.status.idle: "უმოქმედო"
 layout.welcome_hint: "  (Ctrl+Shift+. აგენტის პანელის ჩვენება/დამალვა • Ctrl+Shift+/ აგენტის სესიის ჩვენება/დამალვა)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── კავშირის მდგომარეობა ────────────────────────────────────────────────────────
-connection.starting: "აგენტის გაშვება..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "აგენტთან კავშირის მომზადება..."
 connection.reconnecting: "ხელახლა დაკავშირება..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "აგენტის ხელახლა გაშვება..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "ლოკალურ კოორდინატორთან დაკავშირება..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "აგენტთან კავშირის ინიციალიზაცია..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "მომხმარებლის ავთენტიფიკაცია აგენტთან..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "სესიების სიის წაკითხვა..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "აგენტის სესიის შექმნა..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "სესიის მოდელის დაყენება: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id}-ის გაგრძელება)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "აგენტთან დაკავშირება მიმდინარეობს…"
 connection.lost: "აგენტთან კავშირი დაიკარგა. ხელახლა დასაკავშირებლად აკრიფეთ /restart."  # {Locked="/restart"}
 

--- a/tools/wta/locales/kk-KZ.yml
+++ b/tools/wta/locales/kk-KZ.yml
@@ -136,8 +136,25 @@ agents.status.idle: "Бос"
 layout.welcome_hint: "  (Ctrl+Shift+. агент панелін көрсету/жасыру • Ctrl+Shift+/ агент сеансын көрсету/жасыру)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Агент іске қосылуда..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Агентпен байланыс дайындалуда..."
 connection.reconnecting: "Қайта қосылуда..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Агент қайта іске қосылуда..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Жергілікті үйлестірушіге қосылуда..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Агентпен байланыс инициализациялануда..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Агентте пайдаланушының түпнұсқалығы расталуда..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Сеанстар тізімі оқылуда..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Агент сеансы жасалуда..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Сеанс моделі орнатылуда: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} жалғастырылуда)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Агентке қосылуда…"
 connection.lost: "Агентпен байланыс жоғалды. Қайта қосылу үшін /restart деп теріңіз."  # {Locked="/restart"}
 

--- a/tools/wta/locales/km-KH.yml
+++ b/tools/wta/locales/km-KH.yml
@@ -135,10 +135,26 @@ agents.status.idle: "ទំនេរ"
 layout.welcome_hint: "  (Ctrl+Shift+. បង្ហាញ/លាក់ផ្តាំង AI អេជេន្ត់ • Ctrl+Shift+/ បង្ហាញ/លាក់វគ្គ AI អេជេន្ត់)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────────────────────
-# Status text shown while launching the agent process
-connection.starting: "កំពុងចាប់ផ្តើម AI អេជេន្ត់..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "កំពុងរៀបចំការតភ្ជាប់ទៅភ្នាក់ងារ AI..."
 # Status text shown while re-establishing agent connection
 connection.reconnecting: "កំពុងតភ្ជាប់ឡើងវិញ..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "កំពុងចាប់ផ្តើមភ្នាក់ងារ AI ឡើងវិញ..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "កំពុងតភ្ជាប់ទៅកម្មវិធីសម្របសម្រួលក្នុងម៉ាស៊ីន..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "កំពុងកំណត់ដំបូងសម្រាប់ការតភ្ជាប់ទៅភ្នាក់ងារ AI..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "កំពុងផ្ទៀងផ្ទាត់អត្តសញ្ញាណអ្នកប្រើប្រាស់ជាមួយភ្នាក់ងារ AI..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "កំពុងអានបញ្ជីវគ្គ..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "កំពុងបង្កើតវគ្គរបស់ភ្នាក់ងារ AI..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "កំពុងកំណត់ម៉ូដែលសម្រាប់វគ្គ៖ %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (កំពុងបន្ត %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "កំពុងភ្ជាប់ទៅ AI អេជេន្ត់…"
 connection.lost: "ការតភ្ជាប់ទៅ AI អេជេន្ត់បានបាត់បង់។ វាយ /restart ដើម្បីភ្ជាប់ឡើងវិញ។"  # {Locked="/restart"}
 

--- a/tools/wta/locales/kn-IN.yml
+++ b/tools/wta/locales/kn-IN.yml
@@ -136,8 +136,25 @@ agents.status.idle: "ನಿಷ್ಕ್ರಿಯ"
 layout.welcome_hint: "  (Ctrl+Shift+. ಏಜೆಂಟ್ ಪೇನ್ ತೋರಿಸು/ಮರೆಮಾಡು • Ctrl+Shift+/ ಏಜೆಂಟ್ ಸೆಶನ್ ತೋರಿಸು/ಮರೆಮಾಡು)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── ಸಂಪರ್ಕ ಸ್ಥಿತಿ ────────────────────────────────────────────────────────
-connection.starting: "ಏಜೆಂಟ್ ಪ್ರಾರಂಭವಾಗುತ್ತಿದೆ..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "ಏಜೆಂಟ್ ಸಂಪರ್ಕವನ್ನು ಸಿದ್ಧಪಡಿಸಲಾಗುತ್ತಿದೆ..."
 connection.reconnecting: "ಮರುಸಂಪರ್ಕಗೊಳ್ಳುತ್ತಿದೆ..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "ಏಜೆಂಟ್ ಅನ್ನು ಮರುಪ್ರಾರಂಭಿಸಲಾಗುತ್ತಿದೆ..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "ಸ್ಥಳೀಯ ಸಂಯೋಜಕಕ್ಕೆ ಸಂಪರ್ಕಗೊಳ್ಳುತ್ತಿದೆ..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "ಏಜೆಂಟ್ ಸಂಪರ್ಕವನ್ನು ಆರಂಭಿಸಲಾಗುತ್ತಿದೆ..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "ಏಜೆಂಟ್‌ನೊಂದಿಗೆ ಬಳಕೆದಾರರ ಗುರುತನ್ನು ದೃಢೀಕರಿಸಲಾಗುತ್ತಿದೆ..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "ಸೆಶನ್‌ಗಳ ಪಟ್ಟಿಯನ್ನು ಓದಲಾಗುತ್ತಿದೆ..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "ಏಜೆಂಟ್ ಸೆಶನ್ ರಚಿಸಲಾಗುತ್ತಿದೆ..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "ಸೆಶನ್‌ನ ಮಾದರಿಯನ್ನು ಹೊಂದಿಸಲಾಗುತ್ತಿದೆ: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} ಮುಂದುವರಿಸಲಾಗುತ್ತಿದೆ)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "ಏಜೆಂಟ್‌ಗೆ ಸಂಪರ್ಕಗೊಳ್ಳುತ್ತಿದೆ…"
 connection.lost: "ಏಜೆಂಟ್‌ಗೆ ಸಂಪರ್ಕ ಕಳೆದುಹೋಯಿತು. ಮರುಸಂಪರ್ಕಿಸಲು /restart ಟೈಪ್ ಮಾಡಿ."  # {Locked="/restart"}
 

--- a/tools/wta/locales/ko-KR.yml
+++ b/tools/wta/locales/ko-KR.yml
@@ -119,8 +119,25 @@ agents.status.idle: "유휴"
 layout.welcome_hint: "  (Ctrl+Shift+. 에이전트 창 표시/숨기기 • Ctrl+Shift+/ 에이전트 세션 표시/숨기기)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── 연결 상태 ────────────────────────────────────────────────────────────
-connection.starting: "에이전트 시작 중..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "에이전트 연결 준비 중..."
 connection.reconnecting: "다시 연결 중..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "에이전트 다시 시작 중..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "로컬 코디네이터에 연결 중..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "에이전트 연결 초기화 중..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "에이전트에서 사용자 인증 중..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "세션 목록 읽는 중..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "에이전트 세션 생성 중..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "세션 모델 설정 중: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} 재개 중)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "에이전트에 연결 중…"
 connection.lost: "에이전트와의 연결이 끊어졌습니다. 다시 연결하려면 /restart 명령을 입력하세요."  # {Locked="/restart"}
 

--- a/tools/wta/locales/kok-IN.yml
+++ b/tools/wta/locales/kok-IN.yml
@@ -136,8 +136,25 @@ agents.status.idle: "निश्क्रिय"
 layout.welcome_hint: "  (Ctrl+Shift+. एजेंट पेन दाखयात/लिपयात • Ctrl+Shift+/ एजेंट सत्र दाखयात/लिपयात)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── कनेक्शन स्थिती ────────────────────────────────────────────────────────
-connection.starting: "एजेंट सुरू जाता..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "एजेंटाक जोडपाची तयारी करता..."
 connection.reconnecting: "परतून जोडता..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "एजेंट परत सुरू करता..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "थळाव्या समन्वयकाक जोडता..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "एजेंटा कडेन जोडणी सुरू करता..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "एजेंटा कडेन वापरप्याची वळख प्रमाणीत करता..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "सत्रांची वळेरी वाचता..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "एजेंटाचें सत्र तयार करता..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "सत्राचें मॉडेल सेट करता: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} फुडें चालू करता)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "एजेंटाक जोडटा…"
 connection.lost: "एजेंटाशी जोडणी तुटली. परतून जोडपाक /restart टायप करात."  # {Locked="/restart"}
 

--- a/tools/wta/locales/lb-LU.yml
+++ b/tools/wta/locales/lb-LU.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Onbeschäftegt"
 layout.welcome_hint: "  (Ctrl+Shift+. fir den Agent-Panell ze weisen/verstoppen • Ctrl+Shift+/ fir d'Agent-Sëtzung ze weisen/verstoppen)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Verbindungszoustand ────────────────────────────────────────────────────────
-connection.starting: "Agent gëtt gestart..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Verbindung mam Agent gëtt virbereet..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Agent gëtt nei gestart..."
 connection.reconnecting: "Gëtt nei verbonnen..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Verbindung mam lokale Koordinator gëtt hiergestallt..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Verbindung mam Agent gëtt initialiséiert..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Umeldung beim Agent gëtt authentifizéiert..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Sessiounslëscht gëtt gelies..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Agent-Sessioun gëtt erstallt..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Sessiounsmodell gëtt festgeluecht: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (Sessioun %{session_id} gëtt weidergefouert)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Verbindung mam Agent gëtt hiergestallt…"
 connection.lost: "D'Verbindung mam Agent ass verluer gaangen. Tippt /restart fir nei ze verbannen."  # {Locked="/restart"}
 

--- a/tools/wta/locales/lo-LA.yml
+++ b/tools/wta/locales/lo-LA.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Idle"
 layout.welcome_hint: "(Ctrl+Shift+. ສະແດງ/ເຊື່ອງແຜງ agent • Ctrl+Shift+/ ສະແດງ/ເຊື່ອງພາກສ່ວນ agent)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "ກຳລັງເລີ່ມ agent..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "ກຳລັງກະກຽມການເຊື່ອມຕໍ່ agent..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "ກຳລັງເລີ່ມ agent ໃໝ່..."
 connection.reconnecting: "ກຳລັງເຊື່ອມຕໍ່ໃໝ່..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "ກຳລັງເຊື່ອມຕໍ່ກັບຕົວປະສານງານໃນເຄື່ອງ..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "ກຳລັງກຳນົດຄ່າເບື້ອງຕົ້ນຂອງການເຊື່ອມຕໍ່ agent..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "ກຳລັງຢືນຢັນການເຂົ້າສູ່ລະບົບກັບ agent..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "ກຳລັງອ່ານລາຍການເຊດຊັນ..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "ກຳລັງສ້າງເຊດຊັນ agent..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "ກຳລັງຕັ້ງຄ່າໂມເດລເຊດຊັນ: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (ກຳລັງສືບຕໍ່ %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "ກຳລັງເຊື່ອມຕໍ່ຫາ agent…"
 connection.lost: "ການເຊື່ອມຕໍ່ຫາ agent ຂາດຫາຍໄປ. ພິມ /restart ເພື່ອເຊື່ອມຕໍ່ໃໝ່."  # {Locked="/restart"}
 

--- a/tools/wta/locales/lt-LT.yml
+++ b/tools/wta/locales/lt-LT.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Laukimo būsena"
 layout.welcome_hint: "  (Ctrl+Shift+. rodyti / slėpti agento skydelį • Ctrl+Shift+/ rodyti / slėpti agento seansą)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Paleidžiamas agentas..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Ruošiamas ryšys su agentu..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Agentas paleidžiamas iš naujo..."
 connection.reconnecting: "Jungiamasi iš naujo..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Jungiamasi prie vietinio koordinatoriaus..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inicijuojamas ryšys su agentu..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Tikrinama naudotojo tapatybė prisijungiant prie agento..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Skaitomas seansų sąrašas..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Kuriamas agento seansas..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Nustatomas seanso modelis: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (tęsiamas %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Jungiamasi prie agento…"
 connection.lost: "Ryšys su agentu nutrūko. Įveskite /restart, kad prisijungtumėte iš naujo."  # {Locked="/restart"}
 

--- a/tools/wta/locales/lv-LV.yml
+++ b/tools/wta/locales/lv-LV.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Dīkstāvē"
 layout.welcome_hint: "  (Ctrl+Shift+. lai rādītu/paslēptu aģenta paneli • Ctrl+Shift+/ lai rādītu/paslēptu aģenta sesiju)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Startē aģentu..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Sagatavo savienojumu ar aģentu..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Restartē aģentu..."
 connection.reconnecting: "Atkārtoti savienojas..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Veido savienojumu ar lokālo koordinatoru..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inicializē savienojumu ar aģentu..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Autentificē lietotāju pie aģenta..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Lasa sesiju sarakstu..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Izveido aģenta sesiju..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Iestata sesijas modeli: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (atsāk %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Savienojas ar aģentu…"
 connection.lost: "Savienojums ar aģentu tika zaudēts. Ierakstiet /restart, lai izveidotu savienojumu atkārtoti."  # {Locked="/restart"}
 

--- a/tools/wta/locales/mi-NZ.yml
+++ b/tools/wta/locales/mi-NZ.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Noho noa"
 layout.welcome_hint: "  (Ctrl+Shift+. ki te whakaatu/huna i te papa agent • Ctrl+Shift+/ ki te whakaatu/huna i te wahanga agent)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "E timata ana i te agent..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "E whakarite ana i te hononga ki te agent..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "E tīmata anō ana i te agent..."
 connection.reconnecting: "E hono ano ana..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "E hono ana ki te kaiwhakaruruku ā-rohe..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "E arawhiti ana i te hononga ki te agent..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "E whakamotuhēhē ana i te takiuru ki te agent..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "E pānui ana i te rārangi wātū..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "E waihanga ana i te wātū agent..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "E tautuhi ana i te tauira wātū: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (e haere tonu ana i %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "E hono ana ki te agent…"
 connection.lost: "Kua ngaro te hononga ki te agent. Patohia /restart kia hono anō."  # {Locked="/restart"}
 

--- a/tools/wta/locales/mk-MK.yml
+++ b/tools/wta/locales/mk-MK.yml
@@ -132,8 +132,25 @@ agents.status.idle: "Неактивен"
 layout.welcome_hint: "  (Ctrl+Shift+. прикажи/скриј панел на агентот • Ctrl+Shift+/ прикажи/скриј сесија на агентот)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Стартување на агентот..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Подготовка на врската со агентот..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Рестартирање на агентот..."
 connection.reconnecting: "Повторно поврзување..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Поврзување со локалниот координатор..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Иницијализација на врската со агентот..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Автентикација на корисникот кај агентот..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Читање на списокот со сесии..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Создавање сесија на агентот..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Поставување модел за сесијата: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (продолжување на %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Поврзување со агентот…"
 connection.lost: "Врската со агентот беше изгубена. Внесете /restart за повторно поврзување."  # {Locked="/restart"}
 

--- a/tools/wta/locales/ml-IN.yml
+++ b/tools/wta/locales/ml-IN.yml
@@ -136,8 +136,25 @@ agents.status.idle: "നിഷ്ക്രിയം"
 layout.welcome_hint: "  (Ctrl+Shift+. ഏജന്റ് പേന്‍ കാണിക്കുക/മറയ്ക്കുക • Ctrl+Shift+/ ഏജന്റ് സെഷന്‍ കാണിക്കുക/മറയ്ക്കുക)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── കണക്ഷന്‍ നില ────────────────────────────────────────────────────────
-connection.starting: "ഏജന്റ് ആരംഭിക്കുന്നു..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "ഏജന്റുമായുള്ള കണക്ഷൻ തയ്യാറാക്കുന്നു..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "ഏജന്റ് പുനരാരംഭിക്കുന്നു..."
 connection.reconnecting: "വീണ്ടും കണക്ട് ചെയ്യുന്നു..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "ലോക്കൽ കോർഡിനേറ്ററുമായി ബന്ധിപ്പിക്കുന്നു..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "ഏജന്റുമായുള്ള കണക്ഷന്റെ പ്രാരംഭ സജ്ജീകരണം നടത്തുന്നു..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "ഏജന്റിലേക്കുള്ള ലോഗിൻ പ്രാമാണീകരിക്കുന്നു..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "സെഷൻ പട്ടിക വായിക്കുന്നു..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "ഏജന്റ് സെഷൻ സൃഷ്ടിക്കുന്നു..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "സെഷൻ മോഡൽ സജ്ജമാക്കുന്നു: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} തുടരുന്നു)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "ഏജന്റുമായി കണക്റ്റ് ചെയ്യുന്നു…"
 connection.lost: "ഏജന്റുമായുള്ള കണക്ഷൻ നഷ്ടപ്പെട്ടു. വീണ്ടും കണക്റ്റ് ചെയ്യാൻ /restart ടൈപ്പ് ചെയ്യുക."  # {Locked="/restart"}
 

--- a/tools/wta/locales/mr-IN.yml
+++ b/tools/wta/locales/mr-IN.yml
@@ -136,8 +136,25 @@ agents.status.idle: "निष्क्रिय"
 layout.welcome_hint: "  (Ctrl+Shift+. एजंट पेन दाखवा/लपवा • Ctrl+Shift+/ एजंट सत्र दाखवा/लपवा)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── कनेक्शन स्थिती ────────────────────────────────────────────────────────
-connection.starting: "एजंट सुरू होत आहे..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "एजंट कनेक्शनची तयारी करत आहे..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "एजंट रीस्टार्ट करत आहे..."
 connection.reconnecting: "पुन्हा कनेक्ट होत आहे..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "स्थानिक समन्वयकाशी कनेक्ट होत आहे..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "एजंट कनेक्शनचे आरंभीकरण करत आहे..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "एजंटकडे वापरकर्त्याच्या लॉगिनचे प्रमाणीकरण करत आहे..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "सत्रांची यादी वाचत आहे..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "एजंट सत्र तयार करत आहे..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "सत्राचे मॉडेल सेट करत आहे: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} पुन्हा सुरू करत आहे)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "एजंटशी कनेक्ट होत आहे…"
 connection.lost: "एजंटशी कनेक्शन तुटले. पुन्हा कनेक्ट करण्यासाठी /restart टाइप करा."  # {Locked="/restart"}
 

--- a/tools/wta/locales/ms-MY.yml
+++ b/tools/wta/locales/ms-MY.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Menganggur"
 layout.welcome_hint: "  (Ctrl+Shift+. untuk tunjuk/sembunyikan anak tetingkap ejen AI • Ctrl+Shift+/ untuk tunjuk/sembunyikan sesi ejen AI)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Memulakan ejen AI..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Menyediakan sambungan ejen AI..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Memulakan semula ejen AI..."
 connection.reconnecting: "Menyambung semula..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Menyambung kepada penyelaras setempat..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Memulakan sambungan ejen AI..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Mengesahkan log masuk dengan ejen AI..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Membaca senarai sesi..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Mencipta sesi ejen AI..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Menetapkan model sesi: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (menyambung semula %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Menyambung kepada ejen AI…"
 connection.lost: "Sambungan kepada ejen AI terputus. Taip /restart untuk menyambung semula."  # {Locked="/restart"}
 

--- a/tools/wta/locales/mt-MT.yml
+++ b/tools/wta/locales/mt-MT.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inattiv"
 layout.welcome_hint: "  (Ctrl+Shift+. biex turi/taħbi l-pannell tal-aġent • Ctrl+Shift+/ biex turi/taħbi s-sessjoni tal-aġent)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Stat tal-konnessjoni ────────────────────────────────────────────────────────
-connection.starting: "L-aġent qed jibda..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Qed jipprepara l-konnessjoni mal-aġent..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Qed jerġa' jibda l-aġent..."
 connection.reconnecting: "Qed jerġa' jikkonnettja..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Qed jikkonnettja mal-koordinatur lokali..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Qed jinizjalizza l-konnessjoni mal-aġent..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Qed jawtentika l-utent mal-aġent..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Qed jaqra l-lista tas-sessjonijiet..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Qed joħloq sessjoni tal-aġent..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Qed jistabbilixxi l-mudell tas-sessjoni: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (qed ikompli %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Qed tikkonnettja mal-aġent…"
 connection.lost: "Il-konnessjoni mal-aġent intilfet. Ittajpja /restart biex terġa' tikkonnettja."  # {Locked="/restart"}
 

--- a/tools/wta/locales/nb-NO.yml
+++ b/tools/wta/locales/nb-NO.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inaktiv"
 layout.welcome_hint: "  (Ctrl+Shift+. for å vise/skjule agentpanelet • Ctrl+Shift+/ for å vise/skjule agentøkten)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Starter agenten..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Forbereder tilkobling til agenten..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Starter agenten på nytt..."
 connection.reconnecting: "Kobler til på nytt..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Kobler til den lokale koordinatoren..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Initialiserer tilkoblingen til agenten..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Autentiserer brukeren hos agenten..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Leser øktlisten..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Oppretter agentøkt..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Angir øktmodell: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (gjenopptar %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Kobler til agenten…"
 connection.lost: "Tilkoblingen til agenten gikk tapt. Skriv /restart for å koble til på nytt."  # {Locked="/restart"}
 

--- a/tools/wta/locales/ne-NP.yml
+++ b/tools/wta/locales/ne-NP.yml
@@ -136,8 +136,25 @@ agents.status.idle: "निष्क्रिय"
 layout.welcome_hint: "  (Ctrl+Shift+. एजेन्ट पेन देखाउनुहोस्/लुकाउनुहोस् • Ctrl+Shift+/ एजेन्ट सत्र देखाउनुहोस्/लुकाउनुहोस्)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── जडान स्थिति ────────────────────────────────────────────────────────
-connection.starting: "एजेन्ट सुरु हुँदैछ..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "एजेन्ट जडानको तयारी गर्दै..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "एजेन्ट पुनः सुरु गर्दै..."
 connection.reconnecting: "पुनः जडान हुँदैछ..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "स्थानीय समन्वयकसँग जडान गर्दै..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "एजेन्ट जडानको प्रारम्भिक सेटअप गर्दै..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "एजेन्टसँग प्रयोगकर्ताको लगइन प्रमाणीकरण गर्दै..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "सत्र सूची पढ्दै..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "एजेन्ट सत्र सिर्जना गर्दै..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "सत्रको मोडेल सेट गर्दै: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} सुचारु गर्दै)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "एजेन्टसँग जडान हुँदैछ…"
 connection.lost: "एजेन्टसँगको जडान हरायो। पुनः जडान गर्न /restart टाइप गर्नुहोस्।"  # {Locked="/restart"}
 

--- a/tools/wta/locales/nl-NL.yml
+++ b/tools/wta/locales/nl-NL.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inactief"
 layout.welcome_hint: "  (Ctrl+Shift+. om het agentdeelvenster te tonen/verbergen • Ctrl+Shift+/ om de agentsessie te tonen/verbergen)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Verbindingsstatus ────────────────────────────────────────────────────────────
-connection.starting: "Agent starten..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Verbinding met de agent voorbereiden..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Agent opnieuw starten..."
 connection.reconnecting: "Opnieuw verbinden..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Verbinding maken met de lokale coördinator..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Verbinding met de agent initialiseren..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Gebruiker bij de agent verifiëren..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Sessielijst lezen..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Agentsessie maken..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Sessiemodel instellen: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} hervatten)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Verbinding maken met agent…"
 connection.lost: "De verbinding met de agent is verbroken. Typ /restart om opnieuw verbinding te maken."  # {Locked="/restart"}
 

--- a/tools/wta/locales/nn-NO.yml
+++ b/tools/wta/locales/nn-NO.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inaktiv"
 layout.welcome_hint: "  (Ctrl+Shift+. for å vise/gøyme agentpanelet • Ctrl+Shift+/ for å vise/gøyme agentøkta)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Startar agenten..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Førebur tilkopling til agenten..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Startar agenten på nytt..."
 connection.reconnecting: "Koplar til på nytt..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Koplar til den lokale koordinatoren..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Initialiserer tilkoplinga til agenten..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Autentiserer brukaren hjå agenten..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Les øktlista..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Opprettar agentøkt..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Set øktmodell: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (tek opp att %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Koplar til agenten…"
 connection.lost: "Tilkoblinga til agenten gjekk tapt. Skriv /restart for å kople til på nytt."  # {Locked="/restart"}
 

--- a/tools/wta/locales/or-IN.yml
+++ b/tools/wta/locales/or-IN.yml
@@ -136,8 +136,25 @@ agents.status.idle: "ନିଷ୍କ୍ରିୟ"
 layout.welcome_hint: "  (Ctrl+Shift+. ଏଜେଣ୍ଟ ପେନ୍ ଦେଖାନ୍ତୁ/ଲୁଚାନ୍ତୁ • Ctrl+Shift+/ ଏଜେଣ୍ଟ ସେସନ୍ ଦେଖାନ୍ତୁ/ଲୁଚାନ୍ତୁ)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── ସଂଯୋଗ ସ୍ଥିତି ────────────────────────────────────────────────────────
-connection.starting: "ଏଜେଣ୍ଟ ଆରମ୍ଭ ହେଉଛି..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "ଏଜେଣ୍ଟ ସଂଯୋଗ ପାଇଁ ପ୍ରସ୍ତୁତି କରାଯାଉଛି..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "ଏଜେଣ୍ଟ ପୁନଃ ଆରମ୍ଭ କରାଯାଉଛି..."
 connection.reconnecting: "ପୁଣି ସଂଯୋଗ ହେଉଛି..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "ସ୍ଥାନୀୟ ସମନ୍ୱୟକ ସହ ସଂଯୋଗ କରାଯାଉଛି..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "ଏଜେଣ୍ଟ ସଂଯୋଗର ପ୍ରାରମ୍ଭିକରଣ କରାଯାଉଛି..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "ଏଜେଣ୍ଟ ସହ ବ୍ୟବହାରକାରୀଙ୍କ ଲଗଇନ୍ ପ୍ରମାଣୀକରଣ କରାଯାଉଛି..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "ସେସନ୍ ତାଲିକା ପଢ଼ାଯାଉଛି..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "ଏଜେଣ୍ଟ ସେସନ୍ ସୃଷ୍ଟି କରାଯାଉଛି..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "ସେସନ୍ ମଡେଲ୍ ସେଟ୍ କରାଯାଉଛି: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} ପୁଣି ଚାଲୁ କରାଯାଉଛି)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "ଏଜେଣ୍ଟ ସହ ସଂଯୋଗ ହେଉଛି…"
 connection.lost: "ଏଜେଣ୍ଟ ସହିତ ସଂଯୋଗ ହରାଇଗଲା। ପୁଣି ସଂଯୋଗ କରିବାକୁ /restart ଟାଇପ୍ କରନ୍ତୁ।"  # {Locked="/restart"}
 

--- a/tools/wta/locales/pa-IN.yml
+++ b/tools/wta/locales/pa-IN.yml
@@ -136,8 +136,25 @@ agents.status.idle: "ਵਿਹਲਾ"
 layout.welcome_hint: "  (Ctrl+Shift+. ਏਜੰਟ ਪੈਨ ਦਿਖਾਓ/ਲੁਕਾਓ • Ctrl+Shift+/ ਏਜੰਟ ਸੈਸ਼ਨ ਦਿਖਾਓ/ਲੁਕਾਓ)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── ਕਨੈਕਸ਼ਨ ਸਥਿਤੀ ────────────────────────────────────────────────────────
-connection.starting: "ਏਜੰਟ ਸ਼ੁਰੂ ਹੋ ਰਿਹਾ ਹੈ..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "ਏਜੰਟ ਕਨੈਕਸ਼ਨ ਦੀ ਤਿਆਰੀ ਕਰ ਰਿਹਾ ਹੈ..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "ਏਜੰਟ ਨੂੰ ਮੁੜ ਚਾਲੂ ਕਰ ਰਿਹਾ ਹੈ..."
 connection.reconnecting: "ਮੁੜ-ਕਨੈਕਟ ਹੋ ਰਿਹਾ ਹੈ..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "ਸਥਾਨਕ ਕੋਆਰਡੀਨੇਟਰ ਨਾਲ ਕਨੈਕਟ ਹੋ ਰਿਹਾ ਹੈ..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "ਏਜੰਟ ਕਨੈਕਸ਼ਨ ਦੀ ਸ਼ੁਰੂਆਤੀ ਸੰਰਚਨਾ ਕਰ ਰਿਹਾ ਹੈ..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "ਏਜੰਟ ਨਾਲ ਵਰਤੋਂਕਾਰ ਦਾ ਲਾਗਇਨ ਪ੍ਰਮਾਣਿਤ ਕਰ ਰਿਹਾ ਹੈ..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "ਸੈਸ਼ਨਾਂ ਦੀ ਸੂਚੀ ਪੜ੍ਹ ਰਿਹਾ ਹੈ..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "ਏਜੰਟ ਸੈਸ਼ਨ ਬਣਾ ਰਿਹਾ ਹੈ..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "ਸੈਸ਼ਨ ਦਾ ਮਾਡਲ ਸੈੱਟ ਕਰ ਰਿਹਾ ਹੈ: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} ਮੁੜ ਜਾਰੀ ਕਰ ਰਿਹਾ ਹੈ)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "ਏਜੰਟ ਨਾਲ ਕਨੈਕਟ ਹੋ ਰਿਹਾ ਹੈ…"
 connection.lost: "ਏਜੰਟ ਨਾਲ ਕਨੈਕਸ਼ਨ ਟੁੱਟ ਗਿਆ। ਮੁੜ ਕਨੈਕਟ ਕਰਨ ਲਈ /restart ਟਾਈਪ ਕਰੋ।"  # {Locked="/restart"}
 

--- a/tools/wta/locales/pl-PL.yml
+++ b/tools/wta/locales/pl-PL.yml
@@ -132,8 +132,25 @@ agents.status.idle: "Bezczynny"
 layout.welcome_hint: "  (Ctrl+Shift+. pokaż/ukryj panel agenta • Ctrl+Shift+/ pokaż/ukryj sesję agenta)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Uruchamianie agenta..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Przygotowywanie połączenia z agentem..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Ponowne uruchamianie agenta..."
 connection.reconnecting: "Ponowne łączenie..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Łączenie z lokalnym koordynatorem..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inicjowanie połączenia z agentem..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Uwierzytelnianie użytkownika u agenta..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Odczytywanie listy sesji..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Tworzenie sesji agenta..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Ustawianie modelu sesji: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (wznawianie %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Łączenie z agentem…"
 connection.lost: "Połączenie z agentem zostało utracone. Wpisz /restart, aby połączyć się ponownie."  # {Locked="/restart"}
 

--- a/tools/wta/locales/pt-BR.yml
+++ b/tools/wta/locales/pt-BR.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Ocioso"
 layout.welcome_hint: "  (Ctrl+Shift+. para mostrar/ocultar o painel do agente • Ctrl+Shift+/ para mostrar/ocultar a sessão do agente)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Estado da conexão ────────────────────────────────────────────────────────────
-connection.starting: "Iniciando agente..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Preparando a conexão com o agente..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Reiniciando o agente..."
 connection.reconnecting: "Reconectando..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Conectando ao coordenador local..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inicializando a conexão com o agente..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Autenticando o usuário com o agente..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Lendo a lista de sessões..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Criando a sessão do agente..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Definindo o modelo da sessão: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (retomando %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Conectando ao agente…"
 connection.lost: "A conexão com o agente foi perdida. Digite /restart para reconectar."  # {Locked="/restart"}
 

--- a/tools/wta/locales/pt-PT.yml
+++ b/tools/wta/locales/pt-PT.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inativo"
 layout.welcome_hint: "  (Ctrl+Shift+. para mostrar/ocultar o painel do agente • Ctrl+Shift+/ para mostrar/ocultar a sessão do agente)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Estado da ligação ────────────────────────────────────────────────────────────
-connection.starting: "A iniciar o agente..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "A preparar a ligação ao agente..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "A reiniciar o agente..."
 connection.reconnecting: "A restabelecer ligação..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "A estabelecer ligação ao coordenador local..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "A inicializar a ligação ao agente..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "A autenticar o utilizador junto do agente..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "A ler a lista de sessões..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "A criar a sessão do agente..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "A definir o modelo da sessão: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (a retomar %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "A estabelecer ligação ao agente…"
 connection.lost: "A ligação ao agente foi perdida. Escreva /restart para restabelecer a ligação."  # {Locked="/restart"}
 

--- a/tools/wta/locales/qps-ploc.yml
+++ b/tools/wta/locales/qps-ploc.yml
@@ -125,8 +125,25 @@ agents.status.idle: "[Îďĺé!!]"
 layout.welcome_hint: "[(Ctrl+Shift+. ţö śĥöŵ/ĥïďé åğéñţ ṗåñé • Ctrl+Shift+/ ţö śĥöŵ/ĥïďé åğéñţ śéśśïöñ)!!!! !!!! !!!! !!!!]"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "[Ŝţåŕţïñğ åğéñţ...!!]"
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "[Þŕéþåŕïñğ åğéñţ çöññéçţïöñ...!!!! !!!!]"
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "[Ŕéśţåŕţïñğ åğéñţ...!!!!]"
 connection.reconnecting: "[Ŕéçöññéçţïñğ...!!]"
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "[Çöññéçţïñğ ţö ĺöçåĺ çööŕđïñåţöŕ...!!!! !!!!]"
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "[Ïñïţïåĺïžïñğ åğéñţ çöññéçţïöñ...!!!! !!!!]"
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "[Åûţĥéñţïçåţïñğ ŵïţĥ åğéñţ...!!!! !!!!]"
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "[Ŕéåđïñğ śéśśïöñ ĺïśţ...!!!!]"
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "[Çŕéåţïñğ åğéñţ śéśśïöñ...!!!!]"
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "[Ŝéţţïñğ śéśśïöñ ḿöđéĺ: %{model}...!!!! !!!!]"  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (ŕéśûḿïñğ %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "[Çöññéçţïñğ ţö åğéñţ…!!]"
 connection.lost: "[Çöññéçţïöñ ţö ţĥé åğéñţ ŵåś ĺöśţ. Ţýṗé /restart ţö ŕéçöññéçţ.!!]"  # {Locked="/restart"}
 

--- a/tools/wta/locales/qps-ploca.yml
+++ b/tools/wta/locales/qps-ploca.yml
@@ -123,8 +123,25 @@ agents.status.idle: "[!!_Idle_!!]"
 layout.welcome_hint: "[!!_  (Ctrl+Shift+. to show/hide agent pane • Ctrl+Shift+/ to show/hide agent session)_!!]"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "[!!_Starting agent..._!!]"
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "[!!_Ｐｒｅｐａｒｉｎｇ ａｇｅｎｔ ｃｏｎｎｅｃｔｉｏｎ..._!!]"
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "[!!_Ｒｅｓｔａｒｔｉｎｇ ａｇｅｎｔ..._!!]"
 connection.reconnecting: "[!!_Reconnecting..._!!]"
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "[!!_Ｃｏｎｎｅｃｔｉｎｇ ｔｏ ｌｏｃａｌ ｃｏｏｒｄｉｎａｔｏｒ..._!!]"
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "[!!_Ｉｎｉｔｉａｌｉｚｉｎｇ ａｇｅｎｔ ｃｏｎｎｅｃｔｉｏｎ..._!!]"
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "[!!_Ａｕｔｈｅｎｔｉｃａｔｉｎｇ ｗｉｔｈ ａｇｅｎｔ..._!!]"
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "[!!_Ｒｅａｄｉｎｇ ｓｅｓｓｉｏｎ ｌｉｓｔ..._!!]"
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "[!!_Ｃｒｅａｔｉｎｇ ａｇｅｎｔ ｓｅｓｓｉｏｎ..._!!]"
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "[!!_Ｓｅｔｔｉｎｇ ｓｅｓｓｉｏｎ ｍｏｄｅｌ: %{model}..._!!]"  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (ｒｅｓｕｍｉｎｇ %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "[!!_Connecting to agent…_!!]"
 connection.lost: "[!!_Connection to the agent was lost. Type /restart to reconnect._!!]"  # {Locked="/restart"}
 

--- a/tools/wta/locales/qps-plocm.yml
+++ b/tools/wta/locales/qps-plocm.yml
@@ -123,8 +123,25 @@ agents.status.idle: "[!! Idl_e !!]"
 layout.welcome_hint: "[!!   (C_trl+Shift+. to show/hide agent pane • Ctrl+Shift+/ to show/hide agent session) !!]"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "[!! Sta_rting agent... !!]"
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "\u202e[!! Pre_paring agent connection... !!]\u202c"
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "\u202e[!! Res_tarting agent... !!]\u202c"
 connection.reconnecting: "[!! Rec_onnecting... !!]"
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "\u202e[!! Conn_ecting to local coordinator... !!]\u202c"
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "\u202e[!! Ini_tializing agent connection... !!]\u202c"
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "\u202e[!! Auth_enticating with agent... !!]\u202c"
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "\u202e[!! Rea_ding session list... !!]\u202c"
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "\u202e[!! Cre_ating agent session... !!]\u202c"
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "\u202e[!! Set_ting session model: \u202c%{model}\u202e... !!]\u202c"  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} \u202e(res_uming \u202c%{session_id}\u202e)\u202c"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "[!! Conn_ecting to agent… !!]"
 connection.lost: "[!! Conn_ection to the agent was lost. Type /restart to reconnect. !!]"  # {Locked="/restart"}
 

--- a/tools/wta/locales/quz-PE.yml
+++ b/tools/wta/locales/quz-PE.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Samachkan"
 layout.welcome_hint: "  (Ctrl+Shift+. agente k'itita rikuchiy/pakay • Ctrl+Shift+/ agente hunt'ata rikuchiy/pakay)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Agente qallarichkan..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Agenteman t'inkinata wakichispa..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Agenteta musuqmanta qallarichispa..."
 connection.reconnecting: "Watiqmanta t'inkichkan..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Kay computadorapi tinkuchiqman t'inkispa..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Agenteman t'inkinata qallarichispa..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Agentepi haykuqpa kikin kayninta chiqaqchaspa..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Sesión listata ñawirispa..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Agente sesiónta ruwaspa..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Sesión modelota churaspa: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} nisqata qatispa)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Agente-man t'inkichkan…"
 connection.lost: "Agente-man t'inkiy chinkarun. Watiqmanta t'inkinapaq /restart qillqay."  # {Locked="/restart"}
 

--- a/tools/wta/locales/ro-RO.yml
+++ b/tools/wta/locales/ro-RO.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inactiv"
 layout.welcome_hint: "  (Ctrl+Shift+. afișare/ascundere panou agent • Ctrl+Shift+/ afișare/ascundere sesiune agent)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Se pornește agentul..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Se pregătește conexiunea cu agentul..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Se repornește agentul..."
 connection.reconnecting: "Reconectare..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Conectare la coordonatorul local..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Se inițializează conexiunea cu agentul..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Se autentifică utilizatorul la agent..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Se citește lista de sesiuni..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Se creează sesiunea agentului..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Se setează modelul sesiunii: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (se reia %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Se conectează la agent…"
 connection.lost: "Conexiunea la agent s-a pierdut. Tastați /restart pentru reconectare."  # {Locked="/restart"}
 

--- a/tools/wta/locales/ru-RU.yml
+++ b/tools/wta/locales/ru-RU.yml
@@ -132,8 +132,25 @@ agents.status.idle: "Простаивает"
 layout.welcome_hint: "  (Ctrl+Shift+. — показать/скрыть панель агента • Ctrl+Shift+/ — показать/скрыть сеанс агента)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Состояние подключения ────────────────────────────────────────────────────────────
-connection.starting: "Запуск агента..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Подготовка подключения к агенту..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Перезапуск агента..."
 connection.reconnecting: "Переподключение..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Подключение к локальному координатору..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Инициализация подключения к агенту..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Аутентификация пользователя у агента..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Чтение списка сеансов..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Создание сеанса агента..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Установка модели сеанса: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (возобновление %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Подключение к агенту…"
 connection.lost: "Подключение к агенту потеряно. Введите /restart, чтобы подключиться снова."  # {Locked="/restart"}
 

--- a/tools/wta/locales/sk-SK.yml
+++ b/tools/wta/locales/sk-SK.yml
@@ -132,8 +132,25 @@ agents.status.idle: "Nečinný"
 layout.welcome_hint: "  (Ctrl+Shift+. zobraziť/skryť panel agenta • Ctrl+Shift+/ zobraziť/skryť reláciu agenta)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Spúšťanie agenta..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Príprava pripojenia k agentovi..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Reštartovanie agenta..."
 connection.reconnecting: "Opätovné pripájanie..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Pripájanie k lokálnemu koordinátorovi..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inicializácia pripojenia k agentovi..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Overovanie prihlásenia používateľa k agentovi..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Čítanie zoznamu relácií..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Vytváranie relácie agenta..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Nastavovanie modelu relácie: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (obnovovanie %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Pripájanie k agentovi…"
 connection.lost: "Pripojenie k agentovi sa stratilo. Zadaním /restart sa znova pripojíte."  # {Locked="/restart"}
 

--- a/tools/wta/locales/sl-SI.yml
+++ b/tools/wta/locales/sl-SI.yml
@@ -132,8 +132,25 @@ agents.status.idle: "Nedejavno"
 layout.welcome_hint: "  (Ctrl+Shift+. prikaži/skrij podokno agenta • Ctrl+Shift+/ prikaži/skrij sejo agenta)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Zaganjanje agenta..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Priprava povezave z agentom..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Ponovni zagon agenta..."
 connection.reconnecting: "Ponovna povezava..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Povezovanje z lokalnim koordinatorjem..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inicializacija povezave z agentom..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Preverjanje pristnosti uporabnika pri agentu..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Branje seznama sej..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Ustvarjanje seje agenta..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Nastavljanje modela seje: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (nadaljevanje %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Vzpostavljanje povezave z agentom…"
 connection.lost: "Povezava z agentom je bila izgubljena. Vnesite /restart za ponovno povezavo."  # {Locked="/restart"}
 

--- a/tools/wta/locales/sq-AL.yml
+++ b/tools/wta/locales/sq-AL.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Joaktiv"
 layout.welcome_hint: "  (Ctrl+Shift+. shfaq/fshih panelin e agjentit • Ctrl+Shift+/ shfaq/fshih seancën e agjentit)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Po niset agjenti..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Po përgatitet lidhja me agjentin..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Po riniset agjenti..."
 connection.reconnecting: "Po rilidhet..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Po lidhet me koordinatorin lokal..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Po inicializohet lidhja me agjentin..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Po vërtetohet hyrja e përdoruesit tek agjenti..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Po lexohet lista e sesioneve..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Po krijohet sesioni i agjentit..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Po caktohet modeli i sesionit: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (po rifillon %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Po lidhet me agjentin…"
 connection.lost: "Lidhja me agjentin u humb. Shkruani /restart për t'u rilidhur."  # {Locked="/restart"}
 

--- a/tools/wta/locales/sr-Cyrl-BA.yml
+++ b/tools/wta/locales/sr-Cyrl-BA.yml
@@ -132,8 +132,25 @@ agents.status.idle: "Неактиван"
 layout.welcome_hint: "  (Ctrl+Shift+. за приказ/скривање панела агента • Ctrl+Shift+/ за приказ/скривање сесије агента)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Покретање агента..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Припрема везе са агентом..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Поновно покретање агента..."
 connection.reconnecting: "Поновно повезивање..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Повезивање са локалним координатором..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Иницијализација везе са агентом..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Провјера пријаве корисника код агента..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Читање листе сесија..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Прављење сесије агента..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Постављање модела сесије: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (настављање %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Повезивање са агентом…"
 connection.lost: "Веза са агентом је изгубљена. Унесите /restart да бисте се поново повезали."  # {Locked="/restart"}
 

--- a/tools/wta/locales/sr-Cyrl-RS.yml
+++ b/tools/wta/locales/sr-Cyrl-RS.yml
@@ -132,8 +132,25 @@ agents.status.idle: "Неактиван"
 layout.welcome_hint: "  (Ctrl+Shift+. за приказ/скривање панела агента • Ctrl+Shift+/ за приказ/скривање сесије агента)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Покретање агента..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Припрема везе са агентом..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Поновно покретање агента..."
 connection.reconnecting: "Поновно повезивање..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Повезивање са локалним координатором..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Иницијализација везе са агентом..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Провера пријаве корисника код агента..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Читање листе сесија..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Прављење сесије агента..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Постављање модела сесије: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (настављање %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Повезивање са агентом…"
 connection.lost: "Веза са агентом је изгубљена. Унесите /restart да бисте се поново повезали."  # {Locked="/restart"}
 

--- a/tools/wta/locales/sr-Latn-RS.yml
+++ b/tools/wta/locales/sr-Latn-RS.yml
@@ -132,8 +132,25 @@ agents.status.idle: "Neaktivan"
 layout.welcome_hint: "  (Ctrl+Shift+. za prikaz/skrivanje panela agenta • Ctrl+Shift+/ za prikaz/skrivanje sesije agenta)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Pokretanje agenta..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Priprema veze sa agentom..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Ponovno pokretanje agenta..."
 connection.reconnecting: "Ponovno povezivanje..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Povezivanje sa lokalnim koordinatorom..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Inicijalizacija veze sa agentom..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Provera prijave korisnika kod agenta..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Čitanje liste sesija..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Pravljenje sesije agenta..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Postavljanje modela sesije: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (nastavljanje %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Povezivanje sa agentom…"
 connection.lost: "Veza sa agentom je izgubljena. Unesite /restart da biste se ponovo povezali."  # {Locked="/restart"}
 

--- a/tools/wta/locales/sv-SE.yml
+++ b/tools/wta/locales/sv-SE.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Inaktiv"
 layout.welcome_hint: "  (Ctrl+Shift+. för att visa/dölja agentpanelen • Ctrl+Shift+/ för att visa/dölja agentsessionen)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Startar agenten..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Förbereder anslutningen till agenten..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Startar om agenten..."
 connection.reconnecting: "Återansluter..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Ansluter till den lokala samordnaren..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Initierar anslutningen till agenten..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Autentiserar användaren hos agenten..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Läser sessionslistan..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Skapar agentsession..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Ställer in sessionsmodell: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (återupptar %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Ansluter till agenten…"
 connection.lost: "Anslutningen till agenten bröts. Skriv /restart för att återansluta."  # {Locked="/restart"}
 

--- a/tools/wta/locales/ta-IN.yml
+++ b/tools/wta/locales/ta-IN.yml
@@ -136,8 +136,25 @@ agents.status.idle: "செயலற்றது"
 layout.welcome_hint: "  (Ctrl+Shift+. ஏஜெண்ட் பலகத்தைக் காட்டு/மறை • Ctrl+Shift+/ ஏஜெண்ட் அமர்வைக் காட்டு/மறை)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── இணைப்பு நிலை ────────────────────────────────────────────────────────
-connection.starting: "ஏஜெண்ட் தொடங்கப்படுகிறது..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "ஏஜெண்ட் இணைப்பு தயாராகிறது..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "ஏஜெண்ட் மறுதொடக்கம் செய்யப்படுகிறது..."
 connection.reconnecting: "மீண்டும் இணைக்கப்படுகிறது..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "உள்ளூர் ஒருங்கிணைப்பியுடன் இணைக்கப்படுகிறது..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "ஏஜெண்ட் இணைப்பின் தொடக்க அமைவு செய்யப்படுகிறது..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "ஏஜெண்டில் பயனரின் உள்நுழைவு அங்கீகரிக்கப்படுகிறது..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "அமர்வுப் பட்டியல் படிக்கப்படுகிறது..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "ஏஜெண்ட் அமர்வு உருவாக்கப்படுகிறது..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "அமர்வு மாதிரி அமைக்கப்படுகிறது: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} தொடரப்படுகிறது)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "ஏஜெண்டுடன் இணைக்கப்படுகிறது…"
 connection.lost: "ஏஜெண்டுடனான இணைப்பு துண்டிக்கப்பட்டது. மீண்டும் இணைக்க /restart என தட்டச்சு செய்யவும்."  # {Locked="/restart"}
 

--- a/tools/wta/locales/te-IN.yml
+++ b/tools/wta/locales/te-IN.yml
@@ -136,8 +136,25 @@ agents.status.idle: "నిష్క్రియం"
 layout.welcome_hint: "  (Ctrl+Shift+. ఏజెంట్ పేన్ చూపించు/దాచు • Ctrl+Shift+/ ఏజెంట్ సెషన్ చూపించు/దాచు)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── కనెక్షన్ స్థితి ────────────────────────────────────────────────────────
-connection.starting: "ఏజెంట్ ప్రారంభమవుతోంది..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "ఏజెంట్ కనెక్షన్‌ను సిద్ధం చేస్తోంది..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "ఏజెంట్‌ను పునఃప్రారంభిస్తోంది..."
 connection.reconnecting: "మళ్ళీ కనెక్ట్ అవుతోంది..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "స్థానిక సమన్వయకర్తకు కనెక్ట్ అవుతోంది..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "ఏజెంట్ కనెక్షన్‌ను ప్రారంభీకరిస్తోంది..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "ఏజెంట్‌తో వినియోగదారు లాగిన్‌ను ప్రామాణీకరిస్తోంది..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "సెషన్‌ల జాబితాను చదువుతోంది..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "ఏజెంట్ సెషన్‌ను సృష్టిస్తోంది..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "సెషన్ మోడల్‌ను సెట్ చేస్తోంది: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} కొనసాగిస్తోంది)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "ఏజెంట్‌కు కనెక్ట్ అవుతోంది…"
 connection.lost: "ఏజెంట్‌తో కనెక్షన్ కోల్పోయింది. మళ్లీ కనెక్ట్ చేయడానికి /restart అని టైప్ చేయండి."  # {Locked="/restart"}
 

--- a/tools/wta/locales/th-TH.yml
+++ b/tools/wta/locales/th-TH.yml
@@ -123,8 +123,25 @@ agents.status.idle: "ว่าง"
 layout.welcome_hint: "  (Ctrl+Shift+. แสดง/ซ่อนแผงเอเจนต์ • Ctrl+Shift+/ แสดง/ซ่อนเซสชันเอเจนต์)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "กำลังเริ่มเอเจนต์..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "กำลังเตรียมการเชื่อมต่อกับเอเจนต์..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "กำลังเริ่มเอเจนต์ใหม่..."
 connection.reconnecting: "กำลังเชื่อมต่อใหม่..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "กำลังเชื่อมต่อกับตัวประสานงานภายในเครื่อง..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "กำลังเตรียมใช้งานการเชื่อมต่อกับเอเจนต์..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "กำลังรับรองความถูกต้องของการลงชื่อเข้าใช้กับเอเจนต์..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "กำลังอ่านรายการเซสชัน..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "กำลังสร้างเซสชันของเอเจนต์..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "กำลังตั้งค่าโมเดลของเซสชัน: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (กำลังกลับเข้าสู่ %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "กำลังเชื่อมต่อกับเอเจนต์…"
 connection.lost: "การเชื่อมต่อกับเอเจนต์ขาดหายไป พิมพ์ /restart เพื่อเชื่อมต่อใหม่"  # {Locked="/restart"}
 

--- a/tools/wta/locales/tr-TR.yml
+++ b/tools/wta/locales/tr-TR.yml
@@ -136,8 +136,25 @@ agents.status.idle: "Boşta"
 layout.welcome_hint: "  (Ctrl+Shift+. aracı panelini göster/gizle • Ctrl+Shift+/ aracı oturumunu göster/gizle)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Aracı başlatılıyor..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Aracı bağlantısı hazırlanıyor..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Aracı yeniden başlatılıyor..."
 connection.reconnecting: "Yeniden bağlanılıyor..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Yerel koordinatöre bağlanılıyor..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Aracı bağlantısı başlatılıyor..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Aracıda kullanıcı oturumu doğrulanıyor..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Oturum listesi okunuyor..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Aracı oturumu oluşturuluyor..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Oturum modeli ayarlanıyor: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} sürdürülüyor)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Aracıya bağlanılıyor…"
 connection.lost: "Aracı bağlantısı kesildi. Yeniden bağlanmak için /restart yazın."  # {Locked="/restart"}
 

--- a/tools/wta/locales/tt-RU.yml
+++ b/tools/wta/locales/tt-RU.yml
@@ -136,8 +136,25 @@ agents.status.idle: "Буш"
 layout.welcome_hint: "  (Ctrl+Shift+. агент панелен күрсәтү/яшерү • Ctrl+Shift+/ агент сеансын күрсәтү/яшерү)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Агент эшкә кушыла..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Агентка тоташу әзерләнә..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Агент яңадан эшкә кушыла..."
 connection.reconnecting: "Яңадан тоташу..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Җирле координаторга тоташу..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Агентка тоташуны башлангыч көйләү..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Агентка кергән кулланучының чынлыгын тикшерү..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Сеанслар исемлеген уку..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Агент сеансын булдыру..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Сеанс моделен көйләү: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} дәвам ителә)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Агентка тоташу…"
 connection.lost: "Агент белән тоташу югалды. Яңадан тоташу өчен /restart дип языгыз."  # {Locked="/restart"}
 

--- a/tools/wta/locales/ug-CN.yml
+++ b/tools/wta/locales/ug-CN.yml
@@ -143,10 +143,26 @@ agents.status.idle: "بوش"
 layout.welcome_hint: "  (Ctrl+Shift+. AI ئاگېنتى تاختىسىنى كۆرسەت/يوشۇرۇش • Ctrl+Shift+/ AI ئاگېنتى ئوتتۇرىسىنى كۆرسەت/يوشۇرۇش)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────────────────────
-# Status text shown while launching the agent process
-connection.starting: "AI ئاگېنتى ئىشقا چۈشۈرۈلۈۋاتىدۇ..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "AI ئاگېنتىغا ئۇلىنىش تەييارلىنىۋاتىدۇ..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "AI ئاگېنتى قايتا قوزغىتىلىۋاتىدۇ..."
 # Status text shown while re-establishing agent connection
 connection.reconnecting: "قايتا باغلىنىۋاتىدۇ..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "يەرلىك ماسلاشتۇرغۇچىغا ئۇلىنىۋاتىدۇ..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "AI ئاگېنتىغا ئۇلىنىش دەسلەپلەشتۈرۈلۈۋاتىدۇ..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "AI ئاگېنتىغا كىرگەن ئىشلەتكۈچىنىڭ سالاھىيىتى دەلىللىنىۋاتىدۇ..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "ئولتۇرۇش تىزىملىكى ئوقۇلۇۋاتىدۇ..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "AI ئاگېنتى ئولتۇرۇشى قۇرۇلۇۋاتىدۇ..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "ئولتۇرۇش مودېلى تەڭشىلىۋاتىدۇ: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} داۋاملاشتۇرۇلۇۋاتىدۇ)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "AI ئاگېنتىغا باغلىنىۋاتىدۇ…"
 connection.lost: "AI ئاگېنتى بىلەن بولغان باغلىنىش ئۈزۈلدى. قايتا باغلىنىش ئۈچۈن /restart دەپ كىرگۈزۈڭ."  # {Locked="/restart"}
 

--- a/tools/wta/locales/uk-UA.yml
+++ b/tools/wta/locales/uk-UA.yml
@@ -132,8 +132,25 @@ agents.status.idle: "Бездіяльний"
 layout.welcome_hint: "  (Ctrl+Shift+. — показати/сховати панель агента • Ctrl+Shift+/ — показати/сховати сеанс агента)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Стан підключення ────────────────────────────────────────────────────────────
-connection.starting: "Запуск агента..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Підготовка підключення до агента..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Перезапуск агента..."
 connection.reconnecting: "Перепідключення..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Підключення до локального координатора..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Ініціалізація підключення до агента..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Автентифікація користувача в агента..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Читання списку сеансів..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Створення сеансу агента..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Налаштування моделі сеансу: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (відновлення %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Підключення до агента…"
 connection.lost: "Підключення до агента втрачено. Введіть /restart, щоб підключитися знову."  # {Locked="/restart"}
 

--- a/tools/wta/locales/ur-PK.yml
+++ b/tools/wta/locales/ur-PK.yml
@@ -136,8 +136,25 @@ agents.status.idle: "غیر فعال"
 layout.welcome_hint: "  (Ctrl+Shift+. ایجنٹ پین دکھائیں/چھپائیں • Ctrl+Shift+/ ایجنٹ سیشن دکھائیں/چھپائیں)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── کنیکشن حالت ────────────────────────────────────────────────────────
-connection.starting: "ایجنٹ شروع ہو رہا ہے..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "ایجنٹ سے کنکشن کی تیاری ہو رہی ہے..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "ایجنٹ دوبارہ شروع ہو رہا ہے..."
 connection.reconnecting: "دوبارہ جڑ رہا ہے..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "مقامی رابطہ کار سے جڑ رہا ہے..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "ایجنٹ سے کنکشن کی ابتدائی ترتیب ہو رہی ہے..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "ایجنٹ کے ساتھ صارف کے لاگ ان کی توثیق ہو رہی ہے..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "سیشنز کی فہرست پڑھی جا رہی ہے..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "ایجنٹ کا سیشن بنایا جا رہا ہے..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "سیشن کا ماڈل سیٹ ہو رہا ہے: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} بحال ہو رہا ہے)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "ایجنٹ سے جڑ رہا ہے…"
 connection.lost: "ایجنٹ سے کنیکشن ختم ہو گیا۔ دوبارہ جڑنے کے لیے /restart ٹائپ کریں۔"  # {Locked="/restart"}
 

--- a/tools/wta/locales/uz-Latn-UZ.yml
+++ b/tools/wta/locales/uz-Latn-UZ.yml
@@ -136,8 +136,25 @@ agents.status.idle: "Boʻsh"
 layout.welcome_hint: "  (Ctrl+Shift+. agent panelini koʻrsatish/yashirish • Ctrl+Shift+/ agent seansini koʻrsatish/yashirish)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Agent ishga tushirilmoqda..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Agentga ulanish tayyorlanmoqda..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Agent qayta ishga tushirilmoqda..."
 connection.reconnecting: "Qayta ulanilmoqda..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Mahalliy muvofiqlashtiruvchiga ulanilmoqda..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Agentga ulanishning boshlangʻich sozlamalari oʻrnatilmoqda..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Agentga kirgan foydalanuvchi autentifikatsiya qilinmoqda..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Seanslar roʻyxati oʻqilmoqda..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Agent seansi yaratilmoqda..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Seans modeli oʻrnatilmoqda: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (%{session_id} davom ettirilmoqda)"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Agentga ulanilmoqda…"
 connection.lost: "Agent bilan ulanish uzildi. Qayta ulanish uchun /restart deb yozing."  # {Locked="/restart"}
 

--- a/tools/wta/locales/vi-VN.yml
+++ b/tools/wta/locales/vi-VN.yml
@@ -123,8 +123,25 @@ agents.status.idle: "Rảnh"
 layout.welcome_hint: "  (Ctrl+Shift+. để hiện/ẩn bảng tác nhân AI • Ctrl+Shift+/ để hiện/ẩn phiên tác nhân AI)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── Connection state ────────────────────────────────────────────────────────
-connection.starting: "Đang khởi động tác nhân AI..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "Đang chuẩn bị kết nối với tác nhân AI..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "Đang khởi động lại tác nhân AI..."
 connection.reconnecting: "Đang kết nối lại..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "Đang kết nối với bộ điều phối cục bộ..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "Đang khởi tạo kết nối với tác nhân AI..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "Đang xác thực đăng nhập với tác nhân AI..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "Đang đọc danh sách phiên..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "Đang tạo phiên tác nhân AI..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "Đang đặt mô hình cho phiên: %{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage} (đang tiếp tục %{session_id})"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "Đang kết nối với tác nhân AI…"
 connection.lost: "Đã mất kết nối với tác nhân AI. Nhập /restart để kết nối lại."  # {Locked="/restart"}
 

--- a/tools/wta/locales/zh-CN.yml
+++ b/tools/wta/locales/zh-CN.yml
@@ -119,8 +119,25 @@ agents.status.idle: "空闲"
 layout.welcome_hint: "  (Ctrl+Shift+. 显示/隐藏智能体窗格 • Ctrl+Shift+/ 显示/隐藏智能体会话)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── 连接状态 ────────────────────────────────────────────────────────────
-connection.starting: "正在启动智能体..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "正在准备智能体连接..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "正在重启智能体..."
 connection.reconnecting: "正在重新连接..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "正在连接本地协调进程..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "正在初始化智能体连接..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "正在进行登录认证..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "正在读取会话列表..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "正在创建智能体会话..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "正在设置会话模型：%{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage}（恢复 %{session_id}）"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "正在连接智能体…"
 connection.lost: "与智能体的连接已断开。键入 /restart 以重新连接。"  # {Locked="/restart"}
 

--- a/tools/wta/locales/zh-TW.yml
+++ b/tools/wta/locales/zh-TW.yml
@@ -119,8 +119,25 @@ agents.status.idle: "閒置"
 layout.welcome_hint: "  (Ctrl+Shift+. 顯示/隱藏智能體窗格 • Ctrl+Shift+/ 顯示/隱藏智能體工作階段)"  # {Locked="Ctrl+Shift+.","Ctrl+Shift+/"}
 
 # ── 連線狀態 ────────────────────────────────────────────────────────────
-connection.starting: "正在啟動智能體..."
+# Preparing the AI agent connection, including preflight and reuse of a cached agent.
+connection.starting: "正在準備智能體連線..."
+# Retiring old AI agent sessions for /restart, before the next connection phases.
+connection.restarting: "正在重新啟動智能體..."
 connection.reconnecting: "正在重新連線..."
+# Connecting the pane to WTA's local coordinator process, not to an AI model.
+connection.coordinator: "正在連線至本機協調處理程序..."
+# Initializing the helper/coordinator connection, including local preparation and AI agent initialization.
+connection.initializing: "正在初始化智能體連線..."
+# Refreshing the user's authentication with the AI agent after login; not verifying the agent's identity.
+connection.authenticating: "正在進行登入驗證..."
+# Reading the coordinator's registry snapshot, including existing history; not fetching history from the AI agent.
+connection.syncing_sessions: "正在讀取工作階段清單..."
+# Creating the AI agent session, including local registration; internal agent progress is unknown.
+connection.creating_session: "正在建立智能體工作階段..."
+# Applying the requested AI model before the connection is ready. Preserve %{model}.
+connection.selecting_model: "正在設定工作階段模型：%{model}..."  # {Locked="%{model}"}
+# Activity row while connecting to restore a conversation. Keep the actual stage first so narrow panes show it; session_id is shortened to eight characters.
+connection.resuming_stage: "%{stage}（繼續 %{session_id}）"  # {Locked="%{stage}","%{session_id}"}
 connection.connecting_activity: "正在連線到智能體…"
 connection.lost: "與智能體的連線已中斷。輸入 /restart 以重新連線。"  # {Locked="/restart"}
 

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -5881,7 +5881,7 @@ impl App {
     /// CLI pool. Viable panes, ConPTYs, and helpers stay alive and reconnect
     /// over the stable master pipe with clean ACP sessions.
     fn cmd_restart(&mut self) {
-        self.state = ConnectionState::Connecting("Restarting agent...".to_string());
+        self.state = ConnectionState::Connecting(t!("connection.restarting").into_owned());
         self.pending_session_load = None;
         self.session_to_tab.clear();
         self.session_model_configs.clear();

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -12534,20 +12534,135 @@ fn pending_tool_in_completed_turn_keeps_clickable_status_marker() {
     assert_eq!(rendered_marker, Some('●'));
 }
 
-/// Render: while the helper is still connecting, the fixed activity row must
-/// paint the animated "Connecting…" label.
 #[test]
-fn render_chat_connecting_activity_line() {
+fn render_chat_connection_stage_transitions() {
+    let _locale = crate::test_support::lock_locale();
+    rust_i18n::set_locale("en-US");
     let mut app = test_app();
-    app.state = ConnectionState::Connecting("starting".into());
+    let stages = [
+        t!("connection.starting").into_owned(),
+        t!("connection.coordinator").into_owned(),
+        t!("connection.initializing").into_owned(),
+        t!("connection.authenticating").into_owned(),
+        t!("connection.syncing_sessions").into_owned(),
+        t!("connection.creating_session").into_owned(),
+        t!("connection.selecting_model", model = "test-model").into_owned(),
+        t!("connection.restarting").into_owned(),
+        t!("connection.reconnecting").into_owned(),
+    ];
+    let generic = t!("connection.connecting_activity").into_owned();
+    let mut previous: Option<String> = None;
+    for stage in stages {
+        app.handle_event(AppEvent::ConnectionStage(stage.clone()));
+        let text = render_to_text(&mut app, 80, 24);
+        assert!(
+            text.contains(&stage),
+            "the activity row must show {stage:?}; rendered:\n{text}"
+        );
+        assert!(!text.contains(&generic));
+        if let Some(previous) = previous {
+            assert!(!text.contains(&previous));
+        }
+        assert!(matches!(app.state, ConnectionState::Connecting(_)));
+        assert!(app.session_id.is_empty());
+        previous = Some(stage);
+    }
+}
 
+#[test]
+fn render_chat_connection_stage_preserves_draft() {
+    let _locale = crate::test_support::lock_locale();
+    rust_i18n::set_locale("en-US");
+    let mut app = test_app();
+    app.current_tab_mut().input = "keep this draft".into();
+    let stage = t!("connection.creating_session").into_owned();
+    app.handle_event(AppEvent::ConnectionStage(stage.clone()));
     let text = render_to_text(&mut app, 80, 24);
-    let label = t!("connection.connecting_activity").into_owned();
-    let probe: String = label.chars().take(6).collect();
-    assert!(
-        !probe.trim().is_empty() && text.contains(&probe),
-        "chat must paint the connecting activity line ({label:?}); rendered:\n{text}"
-    );
+    assert!(text.contains(&stage));
+    assert!(text.contains("keep this draft"));
+    assert_eq!(app.current_tab().input, "keep this draft");
+}
+
+#[test]
+fn render_chat_connection_stage_disappears_when_not_connecting() {
+    let _locale = crate::test_support::lock_locale();
+    rust_i18n::set_locale("en-US");
+    let mut app = test_app();
+    let stage = t!("connection.creating_session").into_owned();
+    app.handle_event(AppEvent::ConnectionStage(stage.clone()));
+    assert!(render_to_text(&mut app, 80, 24).contains(&stage));
+    for state in [
+        ConnectionState::Connected,
+        ConnectionState::Disconnected,
+        ConnectionState::Failed("startup failed".into()),
+    ] {
+        app.state = state;
+        assert!(!crate::ui::chat::should_show_activity(&app));
+        assert!(!render_to_text(&mut app, 80, 24).contains(&stage));
+    }
+}
+
+#[test]
+fn render_chat_connection_stage_fits_narrow_activity_row() {
+    let _locale = crate::test_support::lock_locale();
+    rust_i18n::set_locale("en-US");
+    let mut app = test_app();
+    for (stage, prefix) in [
+        (t!("connection.initializing").into_owned(), "Initializing"),
+        (t!("connection.creating_session").into_owned(), "Creating"),
+        (
+            t!(
+                "connection.selecting_model",
+                model = "a-very-long-model-identifier"
+            )
+            .into_owned(),
+            "Setting session",
+        ),
+    ] {
+        for resuming in [false, true] {
+            app.state = ConnectionState::Connecting(stage.clone());
+            app.current_tab_mut().loading_session = resuming;
+            app.current_tab_mut().loading_target_session_id =
+                Some("aaaaaaaa-long-session-id".into());
+            let text = buffer_to_text(&render_to_buffer(&mut app, 18, 24));
+            assert!(
+                text.lines()
+                    .any(|line| line.trim_start().starts_with(prefix)),
+                "the stage must remain identifiable even during resume in a narrow pane: {text:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn restart_connection_stage_is_localized_and_preserves_draft() {
+    let _locale = crate::test_support::lock_locale();
+    for (locale, expected) in [
+        ("en-US", "Restarting agent..."),
+        ("zh-CN", "正在重启智能体..."),
+    ] {
+        rust_i18n::set_locale(locale);
+        let (mut app, mut restart_rx) = test_app_with_restart_rx();
+        app.current_tab_mut().input = "keep this draft".into();
+        app.cmd_restart();
+        assert_eq!(app.state, ConnectionState::Connecting(expected.into()));
+        assert!(matches!(
+            restart_rx.try_recv().unwrap(),
+            AgentLifecycleRequest::RestartMaster
+        ));
+        // The text harness includes the empty trailing cells of wide glyphs.
+        let text = render_to_text(&mut app, 80, 24).replace(' ', "");
+        assert!(
+            text.contains(&expected.replace(' ', "")),
+            "{locale}: {text}"
+        );
+        assert_eq!(app.current_tab().input, "keep this draft");
+        let stage = t!("connection.coordinator").into_owned();
+        app.handle_event(AppEvent::ConnectionStage(stage.clone()));
+        let text = render_to_text(&mut app, 80, 24).replace(' ', "");
+        assert!(text.contains(&stage.replace(' ', "")));
+        assert!(!text.contains(&expected.replace(' ', "")));
+    }
 }
 
 /// Render: the first-run welcome hint must paint its title when connected
@@ -12569,29 +12684,91 @@ fn render_chat_welcome_hint() {
 }
 
 #[test]
-fn resuming_pane_paints_resuming_not_connecting() {
-    // A resume runs `session/load` while the helper is still `Connecting`, so
-    // the activity line has to prefer the resume. Testing the connection first
-    // reported "Connecting to agent…" for the whole restore and the resuming
-    // label was unreachable on the one path it exists for.
-    let mut app = test_app();
-    app.state = ConnectionState::Connecting("Connecting...".to_string());
-    app.current_tab_mut().loading_session = true;
-    app.current_tab_mut().loading_target_session_id =
-        Some("aaaaaaaa-1111-2222-3333-444444444444".to_string());
-
-    let text = render_to_text(&mut app, 80, 24);
-    assert!(
-        text.contains("aaaaaaaa"),
-        "the resuming line must name the session being restored; rendered:\n{text}"
-    );
-
-    let connecting = t!("connection.connecting_activity").into_owned();
-    let probe: String = connecting.chars().take(8).collect();
-    assert!(
-        !probe.trim().is_empty() && !text.contains(&probe),
-        "a resuming pane must not fall back to the connecting line ({connecting:?}); rendered:\n{text}"
-    );
+fn resuming_pane_shows_connection_stage_then_resume_until_load_completes() {
+    let _locale = crate::test_support::lock_locale();
+    for locale in ["en-US", "zh-CN"] {
+        rust_i18n::set_locale(locale);
+        for load_succeeds in [true, false] {
+            let (mut app, mut load_rx) = make_app_with_load_session_channel();
+            app.owner_tab_id = Some("OWNER-TAB".into());
+            app.tab_id = Some("OWNER-TAB".into());
+            app.tab_sessions
+                .insert("OWNER-TAB".into(), TabSession::default());
+            let session_id = "aaaaaaaa-1111-2222-3333-444444444444";
+            app.handle_event(AppEvent::WtEvent {
+                method: "load_session".into(),
+                pane_id: String::new(),
+                tab_id: None,
+                params: json!({ "tab_id": "OWNER-TAB", "session_id": session_id }),
+            });
+            assert_eq!(load_rx.try_recv().unwrap().session_id, session_id);
+            app.current_tab_mut().input = "keep this draft".into();
+            let stages = [
+                t!("connection.coordinator").into_owned(),
+                t!("connection.initializing").into_owned(),
+                t!("connection.syncing_sessions").into_owned(),
+                t!("connection.connecting_activity").into_owned(),
+            ];
+            for stage in &stages {
+                app.handle_event(AppEvent::ConnectionStage(stage.clone()));
+                let combined = t!(
+                    "connection.resuming_stage",
+                    stage = stage.as_str(),
+                    session_id = "aaaaaaaa"
+                )
+                .into_owned();
+                assert!(combined.starts_with(stage));
+                let text = render_to_text(&mut app, 100, 24).replace(' ', "");
+                assert!(
+                    text.contains(&combined.replace(' ', "")),
+                    "{locale}: {text}"
+                );
+                assert!(matches!(app.state, ConnectionState::Connecting(_)));
+                assert!(app.current_tab().loading_session);
+                assert!(!text.contains(&t!("connection.creating_session").replace(' ', "")));
+            }
+            app.handle_event(AppEvent::AgentConnected {
+                name: "Copilot".into(),
+                model: None,
+                version: None,
+                session_id: session_id.into(),
+                available_models: Vec::new(),
+                current_model_id: None,
+                load_session_supported: true,
+                image_supported: false,
+                session_capabilities_ready: false,
+            });
+            let resume = t!("system.resuming_session", session_id = "aaaaaaaa").into_owned();
+            assert_eq!(app.state, ConnectionState::Connected);
+            assert!(app.current_tab().loading_session);
+            let text = render_to_text(&mut app, 100, 24).replace(' ', "");
+            assert!(text.contains(&resume.replace(' ', "")));
+            for stage in &stages {
+                assert!(!text.contains(&stage.replace(' ', "")));
+            }
+            if load_succeeds {
+                app.handle_event(AppEvent::SessionAttached {
+                    tab_id: "OWNER-TAB".into(),
+                    session_id: session_id.into(),
+                    prompt_id: None,
+                    available_models: Vec::new(),
+                    current_model_id: None,
+                });
+            } else {
+                app.handle_event(AppEvent::TabError {
+                    tab_id: "OWNER-TAB".into(),
+                    message: "restore failed".into(),
+                });
+            }
+            assert!(!app.current_tab().loading_session);
+            let text = render_to_text(&mut app, 100, 24).replace(' ', "");
+            assert!(!text.contains(&resume.replace(' ', "")));
+            for stage in &stages {
+                assert!(!text.contains(&stage.replace(' ', "")));
+            }
+            assert_eq!(app.current_tab().input, "keep this draft");
+        }
+    }
 }
 
 #[test]

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -2822,7 +2822,7 @@ pub async fn run_acp_client_over_pipe(
     // pipe. Retry-with-backoff until master is ready or we give up
     // (spec Z-R6).
     let _ = event_tx.send(AppEvent::ConnectionStage(
-        "Connecting to wta-master...".to_string(),
+        t!("connection.coordinator").into_owned(),
     ));
     startup_probe.log(&format!("opening master pipe: {}", pipe_name));
     const ERROR_FILE_NOT_FOUND: i32 = 2;
@@ -3052,7 +3052,9 @@ pub async fn run_acp_client_over_pipe(
     // npx adapter cold start). Clean cloud discovery runs asynchronously
     // after that initialize and is delivered later, so it never consumes
     // this timeout budget. Subsequent inits are cached replays.
-    let _ = event_tx.send(AppEvent::ConnectionStage("Initializing ACP...".to_string()));
+    let _ = event_tx.send(AppEvent::ConnectionStage(
+        t!("connection.initializing").into_owned(),
+    ));
     startup_probe.log("Initializing ACP (over pipe)");
     let init_started = std::time::Instant::now();
     let supplied_cloud_models = if matches!(&agent_source, crate::agent_source::AgentSource::Host) {
@@ -3206,6 +3208,9 @@ pub async fn run_acp_client_over_pipe(
     if post_login_reconnect {
         let auth_method_id = init_resp.auth_methods.first().map(|m| m.id().clone());
         if let Some(method_id) = auth_method_id {
+            let _ = event_tx.send(AppEvent::ConnectionStage(
+                t!("connection.authenticating").into_owned(),
+            ));
             tracing::info!(
                 target: "helper",
                 method_id = %method_id.0,
@@ -3283,6 +3288,9 @@ pub async fn run_acp_client_over_pipe(
     // older master without `unstable_session_list`) the alive mirror
     // just stays empty and `alive_loaded` stays false, which keeps
     // session management routing on the legacy path.
+    let _ = event_tx.send(AppEvent::ConnectionStage(
+        t!("connection.syncing_sessions").into_owned(),
+    ));
     match conn
         .list_sessions(acp::schema::v1::ListSessionsRequest::new())
         .await
@@ -3347,10 +3355,11 @@ pub async fn run_acp_client_over_pipe(
                 "skipping bootstrap session/new (initial_load_session_id={} set)",
                 load_sid,
             ));
-            // The connection stage stays neutral; the pane's own
-            // "Resuming session …" indicator (driven by `loading_session`)
-            // is what tells the user a conversation is being restored.
-            let _ = event_tx.send(AppEvent::ConnectionStage("Connecting...".to_string()));
+            // No session/new runs here. Use a neutral connection stage until
+            // AgentConnected; the activity row retains the queued resume context.
+            let _ = event_tx.send(AppEvent::ConnectionStage(
+                t!("connection.connecting_activity").into_owned(),
+            ));
             (
                 acp::schema::v1::SessionId::new(load_sid.to_string()),
                 Vec::<AcpModelInfo>::new(),
@@ -3359,7 +3368,9 @@ pub async fn run_acp_client_over_pipe(
                 false,
             )
         } else {
-            let _ = event_tx.send(AppEvent::ConnectionStage("Creating session...".to_string()));
+            let _ = event_tx.send(AppEvent::ConnectionStage(
+                t!("connection.creating_session").into_owned(),
+            ));
             startup_probe.log("Creating session (over pipe)");
             let mut new_session_req = acp::schema::v1::NewSessionRequest::new(cwd.clone());
             inject_wta_pane_meta(&mut new_session_req.meta, proposal_commands_supported);
@@ -3456,10 +3467,13 @@ pub async fn run_acp_client_over_pipe(
     // it before the load completes would race the load itself.
     if has_bootstrap {
         if let Some(requested_model) = acp_model_override.filter(|s| !s.trim().is_empty()) {
-            let _ = event_tx.send(AppEvent::ConnectionStage(format!(
-                "Selecting model {}...",
-                requested_model
-            )));
+            let _ = event_tx.send(AppEvent::ConnectionStage(
+                t!(
+                    "connection.selecting_model",
+                    model = requested_model.as_str()
+                )
+                .into_owned(),
+            ));
             startup_probe.log(&format!(
                 "Setting ACP session model to {} (over pipe)",
                 requested_model

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -1451,13 +1451,9 @@ fn build_completed_turn_lines_with_geometry<'a>(
 
 pub fn render_activity(frame: &mut Frame, app: &App, area: Rect) {
     let tab = app.current_tab();
-    // A resume outranks the connecting line. Restoring a pane runs
-    // `session/load` while the helper is still in `Connecting`, so testing
-    // the connection first would report "Connecting to agent…" for the whole
-    // resume and the user would never learn a conversation was coming back.
-    //
-    // Both shimmers read the app-level `activity_frame`: the per-tab counter
-    // only advances during a turn, and a resume has none in flight.
+    // A queued restore spans connection setup and session/load. Keep its
+    // context without hiding setup stages; put the stage first for narrow panes.
+    // Both shimmers use the app counter because no turn is in flight.
     if tab.loading_session {
         let short_id: String = tab
             .loading_target_session_id
@@ -1466,21 +1462,29 @@ pub fn render_activity(frame: &mut Frame, app: &App, area: Rect) {
             .chars()
             .take(8)
             .collect();
-        let label = t!("system.resuming_session", session_id = short_id).into_owned();
+        let label = if let crate::app::ConnectionState::Connecting(stage) = &app.state {
+            t!(
+                "connection.resuming_stage",
+                stage = stage.as_str(),
+                session_id = short_id.as_str()
+            )
+            .into_owned()
+        } else {
+            t!("system.resuming_session", session_id = short_id).into_owned()
+        };
         let line = Line::from(shimmer::shimmer_spans(&label, app.activity_frame as usize));
         frame.render_widget(Paragraph::new(line), area);
         return;
     }
     // While the helper is still establishing its connection to the agent,
-    // show an animated "Connecting to agent…" line (F7). The handshake
+    // show its current observable stage. The handshake
     // (pipe connect → ACP init → session/new) can take tens of seconds on a
     // cold start; without an animated indicator the pane looked frozen. Uses
     // the app-level `activity_frame`, which is advanced on Tick while the
     // state is `Connecting` (see handle_event). Takes precedence over the
     // turn spinner because no turn can be in flight before we're connected.
-    if matches!(app.state, crate::app::ConnectionState::Connecting(_)) {
-        let label = t!("connection.connecting_activity").into_owned();
-        let line = Line::from(shimmer::shimmer_spans(&label, app.activity_frame as usize));
+    if let crate::app::ConnectionState::Connecting(stage) = &app.state {
+        let line = Line::from(shimmer::shimmer_spans(stage, app.activity_frame as usize));
         frame.render_widget(Paragraph::new(line), area);
         return;
     }


### PR DESCRIPTION
## Summary
- Show WTA's actual connection stage in the animated chat activity row instead of a generic Connecting label: preparation, local coordinator connection, initialization, post-login authentication, session-list reading, session creation, and session-model selection.
- Describe observable helper/coordinator operations without attributing all waiting to the upstream agent, inventing internal progress, changing readiness, or claiming a startup speedup.
- Keep the current stage first during session restore, followed by short resume context; retain the resume indicator until loading completes. Preserve a distinct localized restart stage while old sessions retire.
- Update all 89 locale resources and document the stage boundaries. Most changed files are translations.

## Validation
- Targeted stage/resume regressions: 7 passed, covering stage transitions, narrow panes, draft preservation, localized restart, and successful/failed restore.
- Full explicit-Windows-target WTA suite: 2082 passed, 1 ignored.
- Explicit-target Debug WTA build completed; deployed the Debug binary with a matching wtcli and confirmed helper event subscription.
- Rust formatting, locale parity, and diff checks passed. Independent localization QA completed; native-speaker review remains advisable for lower-confidence locales, and RTL visual rendering has not been exercised.

No C++ source, dependency, or package-registration changes. The connection remains unavailable until the existing readiness conditions are met.