### PR TITLE
Expand live Search queries and tool results

### DIFF
--- a/tools/wta/README.md
+++ b/tools/wta/README.md
@@ -130,7 +130,13 @@ click that row to inspect each call. While a turn is in flight, ACP thought
 chunks update a temporary **Think** row alongside visible answers; when the
 provider is silent, the row remains as `Think · …` until the turn ends.
 Expanded Edit details show bounded line-level `+`/`-` hunks computed from ACP
-snapshots.
+snapshots. Tool headers and groups can be expanded during the active turn as well
+as in history. Expanded Search details wrap the provider's `rawInput.query`
+(or its title when no query is supplied) and any returned text results. WTA
+does not reconstruct queries or results omitted by the provider. Queries retain
+the first 4,000 Unicode characters, all scrollable when expanded. Text results show
+up to 12 wrapped lines, with `…` for omitted text. Expansion follows the tool
+into completed history.
 
 | Key | Action |
 |-----|--------|
@@ -138,8 +144,8 @@ snapshots.
 | Ctrl+C | Copy selected text; otherwise cancel streaming / quit |
 | Up / Down | Browse prompt input history |
 | Mouse wheel | Scroll chat (hold Alt to scroll one line) |
-| Click a completed tool header | Expand or collapse that tool's details |
-| Ctrl+O | Expand or collapse all completed tool details |
+| Click a tool header | Expand or collapse that tool's details, live or completed |
+| Ctrl+O | Expand or collapse all live and completed tool details |
 | Mouse drag | Select a continuous text range |
 | Double / triple click | Select a word / line |
 | PageUp / PageDown | Scroll chat |

--- a/tools/wta/src/app.rs
+++ b/tools/wta/src/app.rs
@@ -4820,6 +4820,13 @@ pub(crate) enum CompletedTurnHitKind {
     ToolCall {
         detail_index: usize,
     },
+    ActiveToolCall {
+        detail_index: usize,
+    },
+    ActiveToolGroup {
+        first_detail_index: usize,
+        detail_count: usize,
+    },
     ToolGroup {
         first_detail_index: usize,
         detail_count: usize,
@@ -4845,6 +4852,7 @@ impl CompletedTurnHitRegion {
 pub(crate) struct PressedCompletedTurn {
     pub(crate) tab_id: String,
     pub(crate) hit: CompletedTurnHitRegion,
+    pub(crate) active_tool_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tools/wta/src/app/tab_state.rs
+++ b/tools/wta/src/app/tab_state.rs
@@ -87,6 +87,9 @@ pub enum ChatMessage {
         status: String,
         #[serde(default)]
         kind: ToolCallKind,
+        /// Bounded, verbatim search input, independent of the provider's short title.
+        #[serde(default)]
+        query: Option<ToolCallOutput>,
         /// Concise path/command hint pulled from the ACP tool call's
         /// `locations` or summarized `raw_input`. `None` when no useful
         /// target was reported or the title already states it verbatim.
@@ -548,6 +551,7 @@ pub struct TabSession {
     pub completed_turns: Vec<CompletedTurn>,
     /// UI-only disclosure state keyed by the ACP session's tool-call IDs.
     pub(crate) expanded_completed_tool_calls: HashSet<String>,
+    pub(crate) active_tool_viewport_anchor: Option<(String, u16)>,
     pub(crate) completed_turn_layout: CompletedTurnLayoutState,
     /// Latched after the first prompt or session/load. A pre-warmed session/new
     /// alone must not become resumable; `/clear` keeps the same session resumable.
@@ -816,6 +820,7 @@ impl TabSession {
     pub(crate) fn clear_completed_turns(&mut self) {
         self.completed_turns.clear();
         self.expanded_completed_tool_calls.clear();
+        self.active_tool_viewport_anchor = None;
         self.completed_turn_layout = CompletedTurnLayoutState::default();
     }
 
@@ -897,6 +902,7 @@ impl TabSession {
             .completed_turns
             .iter()
             .flat_map(|turn| &turn.details)
+            .chain(&self.messages)
             .filter_map(|message| match message {
                 ChatMessage::ToolCall { id, .. } => Some(id.clone()),
                 _ => None,
@@ -922,6 +928,31 @@ impl TabSession {
             self.expanded_completed_tool_calls.clear();
         }
         self.completed_turn_layout.height_cache.get_mut().clear();
+        true
+    }
+
+    pub(crate) fn toggle_active_tool_group(&mut self, start: usize, count: usize) -> bool {
+        let ids = self
+            .messages
+            .iter()
+            .skip(start)
+            .take(count)
+            .filter_map(|message| match message {
+                ChatMessage::ToolCall { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        if ids.is_empty() || ids.len() != count {
+            return false;
+        }
+        let expand = ids.iter().any(|id| !self.completed_tool_call_expanded(id));
+        for id in ids {
+            if expand {
+                self.expanded_completed_tool_calls.insert(id);
+            } else {
+                self.expanded_completed_tool_calls.remove(&id);
+            }
+        }
         true
     }
 

--- a/tools/wta/src/app_contracts/event.rs
+++ b/tools/wta/src/app_contracts/event.rs
@@ -179,6 +179,7 @@ pub enum AppEvent {
         title: String,
         status: String,
         kind: crate::app::ToolCallKind,
+        query: Option<crate::app::ToolCallOutput>,
         /// See `ChatMessage::ToolCall::location`.
         location: Option<String>,
         /// See `ChatMessage::ToolCall::location_is_command`.
@@ -195,6 +196,8 @@ pub enum AppEvent {
         title: Option<String>,
         status: Option<String>,
         kind: Option<crate::app::ToolCallKind>,
+        /// Omitted input leaves the retained query unchanged.
+        query: Option<crate::app::ToolCallOutput>,
         /// `Some` only when the agent's `tool_call_update` actually
         /// reported new `locations`/`raw_input` — `None` means "no
         /// change", so the existing card's location hint (if any) is

--- a/tools/wta/src/app_events.rs
+++ b/tools/wta/src/app_events.rs
@@ -204,6 +204,27 @@ impl App {
             .find(|hit| hit.contains(column, row))
     }
 
+    fn active_tool_hit_ids(&self, hit: CompletedTurnHitRegion) -> Vec<String> {
+        let (start, count) = match hit.kind {
+            CompletedTurnHitKind::ActiveToolCall { detail_index } => (detail_index, 1),
+            CompletedTurnHitKind::ActiveToolGroup {
+                first_detail_index,
+                detail_count,
+            } => (first_detail_index, detail_count),
+            _ => return Vec::new(),
+        };
+        self.current_tab()
+            .messages
+            .iter()
+            .skip(start)
+            .take(count)
+            .filter_map(|message| match message {
+                ChatMessage::ToolCall { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
     fn active_mouse_tab_id(&self) -> String {
         self.tab_id
             .clone()
@@ -489,6 +510,7 @@ impl App {
                         .completed_turn_hit_at(mouse.column, mouse.row)
                         .map(|hit| PressedCompletedTurn {
                             tab_id: self.active_mouse_tab_id(),
+                            active_tool_ids: self.active_tool_hit_ids(hit),
                             hit,
                         });
                 }
@@ -513,6 +535,7 @@ impl App {
                     self.text_selection.handle_mouse(mouse);
                     if let Some(pressed) = pressed.filter(|pressed| {
                         pressed.tab_id == active_tab_id
+                            && pressed.active_tool_ids == self.active_tool_hit_ids(pressed.hit)
                             && released.is_some_and(|hit| {
                                 hit.turn_index == pressed.hit.turn_index
                                     && hit.kind == pressed.hit.kind
@@ -520,6 +543,27 @@ impl App {
                     }) {
                         let tab = self.current_tab_mut();
                         match pressed.hit.kind {
+                            CompletedTurnHitKind::ActiveToolCall { detail_index } => {
+                                if tab.toggle_active_tool_group(detail_index, 1) {
+                                    tab.active_tool_viewport_anchor = pressed
+                                        .active_tool_ids
+                                        .first()
+                                        .map(|id| (id.clone(), pressed.hit.row));
+                                }
+                                return;
+                            }
+                            CompletedTurnHitKind::ActiveToolGroup {
+                                first_detail_index,
+                                detail_count,
+                            } => {
+                                if tab.toggle_active_tool_group(first_detail_index, detail_count) {
+                                    tab.active_tool_viewport_anchor = pressed
+                                        .active_tool_ids
+                                        .first()
+                                        .map(|id| (id.clone(), pressed.hit.row));
+                                }
+                                return;
+                            }
                             CompletedTurnHitKind::ToolCall { detail_index } => {
                                 tab.toggle_completed_tool_call(
                                     pressed.hit.turn_index,
@@ -1700,6 +1744,7 @@ impl App {
                 title,
                 status,
                 kind,
+                query,
                 location,
                 location_is_command,
                 cwd,
@@ -1737,6 +1782,7 @@ impl App {
                     title,
                     status,
                     kind,
+                    query,
                     location,
                     location_is_command,
                     cwd,
@@ -1753,6 +1799,7 @@ impl App {
                 title,
                 status,
                 kind,
+                query,
                 location,
                 location_is_command,
                 output,
@@ -1774,6 +1821,7 @@ impl App {
                         title: ref mut current_title,
                         status: ref mut s,
                         kind: ref mut current_kind,
+                        query: ref mut current_query,
                         location: ref mut loc,
                         location_is_command: ref mut loc_is_cmd,
                         cwd: ref mut current_cwd,
@@ -1793,6 +1841,9 @@ impl App {
                             }
                             if let Some(kind) = kind {
                                 *current_kind = kind;
+                            }
+                            if let Some(query) = &query {
+                                *current_query = Some(query.clone());
                             }
                             // Only overwrite when the update actually carried
                             // a fresh location — `None` means "unchanged",

--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -2547,6 +2547,7 @@ get time"#
         ChatMessage::User("list files".to_string()),
         ChatMessage::ToolCall {
             id: "t1".to_string(),
+            query: None,
             title: "ls".to_string(),
             status: "done".to_string(),
             kind: ToolCallKind::Other,
@@ -9704,6 +9705,7 @@ fn streamed_prose_and_tool_calls_preserve_acp_arrival_order() {
     app.current_tab_mut().reveal_chars = 12;
     app.handle_event(AppEvent::ToolCall {
         session_id: DEFAULT_TAB_ID.into(),
+        query: None,
         id: "tool-1".into(),
         title: "apply_patch".into(),
         status: "InProgress".into(),
@@ -9744,6 +9746,7 @@ fn tool_only_turn_commits_the_ordered_tool_transcript() {
     submit_test_prompt(&mut app, "inspect");
     app.handle_event(AppEvent::ToolCall {
         session_id: DEFAULT_TAB_ID.into(),
+        query: None,
         id: "tool-1".into(),
         title: "Find files".into(),
         status: "Completed".into(),
@@ -10107,6 +10110,7 @@ fn render_tool_call_card_in_chat() {
     app.state = ConnectionState::Connected;
     app.current_tab_mut().messages.push(ChatMessage::ToolCall {
         id: "mock-tool-1".into(),
+        query: None,
         title: "Run: echo TOOL_XYZ".into(),
         status: "Pending".into(),
         kind: ToolCallKind::Execute,
@@ -12737,6 +12741,7 @@ fn clicking_completed_tool_header_toggles_only_that_tool() {
         details: vec![
             ChatMessage::ToolCall {
                 id: "first-tool".into(),
+                query: None,
                 title: "Read first".into(),
                 status: "Completed".into(),
                 kind: ToolCallKind::Other,
@@ -12753,6 +12758,7 @@ fn clicking_completed_tool_header_toggles_only_that_tool() {
             },
             ChatMessage::ToolCall {
                 id: "second-tool".into(),
+                query: None,
                 title: "Read second".into(),
                 status: "Completed".into(),
                 kind: ToolCallKind::Other,
@@ -12812,6 +12818,7 @@ fn adjacent_successful_reads_render_as_one_compact_group() {
     .enumerate()
     .map(|(index, path)| ChatMessage::ToolCall {
         id: format!("read-{index}"),
+        query: None,
         title: format!("Viewing {path}"),
         status: "Completed".into(),
         kind: ToolCallKind::Read,
@@ -12843,6 +12850,7 @@ fn generic_read_group_lists_visible_targets_and_remaining_count() {
         .enumerate()
         .map(|(index, path)| ChatMessage::ToolCall {
             id: format!("read-{index}"),
+            query: None,
             title: "Read file".into(),
             status: "Completed".into(),
             kind: ToolCallKind::Read,
@@ -12872,6 +12880,7 @@ fn clicking_completed_read_group_expands_every_member() {
         .enumerate()
         .map(|(index, path)| ChatMessage::ToolCall {
             id: format!("read-{index}"),
+            query: None,
             title: format!("Viewing {path}"),
             status: "Completed".into(),
             kind: ToolCallKind::Read,
@@ -12937,6 +12946,7 @@ fn pending_tool_in_completed_turn_keeps_clickable_status_marker() {
         prompt: "Interrupted turn".into(),
         details: vec![ChatMessage::ToolCall {
             id: "pending-tool".into(),
+            query: None,
             title: "Pending operation".into(),
             status: "Pending".into(),
             kind: ToolCallKind::Other,
@@ -13295,6 +13305,7 @@ fn render_large_mixed_chat_keeps_latest_content_and_width_correct() {
                 ChatMessage::Agent(format!("old response {index}")),
                 ChatMessage::ToolCall {
                     id: format!("old-tool-{index}"),
+                    query: None,
                     title: "Read old file".into(),
                     status: "Completed".into(),
                     kind: ToolCallKind::Read,
@@ -13322,6 +13333,7 @@ fn render_large_mixed_chat_keeps_latest_content_and_width_correct() {
             ),
             ChatMessage::ToolCall {
                 id: "latest-read".into(),
+                query: None,
                 title: "Read latest file".into(),
                 status: "Completed".into(),
                 kind: ToolCallKind::Read,
@@ -13338,6 +13350,7 @@ fn render_large_mixed_chat_keeps_latest_content_and_width_correct() {
             },
             ChatMessage::ToolCall {
                 id: "latest-execute".into(),
+                query: None,
                 title: "Run latest tests".into(),
                 status: "Completed".into(),
                 kind: ToolCallKind::Execute,
@@ -13354,6 +13367,7 @@ fn render_large_mixed_chat_keeps_latest_content_and_width_correct() {
             },
             ChatMessage::ToolCall {
                 id: "latest-edit".into(),
+                query: None,
                 title: "Edit latest source".into(),
                 status: "Completed".into(),
                 kind: ToolCallKind::Edit,
@@ -13881,6 +13895,7 @@ fn completed_tool_output_update_invalidates_cached_turn_height() {
         prompt: "TERMINAL_CACHE_PROMPT".into(),
         details: vec![ChatMessage::ToolCall {
             id: "terminal-cache-tool".into(),
+            query: None,
             title: "Run cached command".into(),
             status: "Completed".into(),
             kind: ToolCallKind::Execute,
@@ -14312,6 +14327,7 @@ fn running_tool_replaces_thinking_until_tool_completes() {
     app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "Choosing files");
     app.handle_event(AppEvent::ToolCall {
         session_id: DEFAULT_TAB_ID.into(),
+        query: None,
         id: "tool".into(),
         title: "Find files".into(),
         status: "InProgress".into(),
@@ -14336,6 +14352,7 @@ fn running_tool_replaces_thinking_until_tool_completes() {
 
     app.handle_event(AppEvent::ToolCallUpdate {
         session_id: DEFAULT_TAB_ID.into(),
+        query: None,
         id: "tool".into(),
         title: None,
         status: Some("Completed".into()),
@@ -14354,6 +14371,305 @@ fn running_tool_replaces_thinking_until_tool_completes() {
     );
 }
 
+fn search_tool_message(id: &str, status: &str, query: &str) -> ChatMessage {
+    ChatMessage::ToolCall {
+        id: id.into(),
+        title: "Searching for 'As of September...'".into(),
+        status: status.into(),
+        kind: ToolCallKind::Search,
+        query: Some(ToolCallOutput {
+            text: query.into(),
+            truncated: false,
+        }),
+        location: None,
+        location_is_command: false,
+        cwd: None,
+        output: Some(ToolCallOutput {
+            text: format!("RESULT_{id}"),
+            truncated: false,
+        }),
+        exit_code: None,
+        content: Vec::new(),
+        locations: Vec::new(),
+    }
+}
+
+fn click_tool_hit(app: &mut App, hit: CompletedTurnHitRegion) {
+    use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+    app.text_selection.clear();
+    for kind in [
+        MouseEventKind::Down(MouseButton::Left),
+        MouseEventKind::Up(MouseButton::Left),
+    ] {
+        app.handle_event(AppEvent::Mouse(MouseEvent {
+            kind,
+            column: hit.end_column - 1,
+            row: hit.row,
+            modifiers: KeyModifiers::NONE,
+        }));
+    }
+}
+
+#[test]
+fn active_tool_query_wraps_retains_updates_and_follows_tool_into_history() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    submit_test_prompt(&mut app, "search");
+    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "");
+    let query = format!(
+        "QUERY_START {} QUERY_END",
+        "provider supplied words ".repeat(10)
+    );
+    app.current_tab_mut()
+        .messages
+        .push(search_tool_message("search", "InProgress", &query));
+    if let Some(ChatMessage::ToolCall {
+        content,
+        output: Some(output),
+        ..
+    }) = app.current_tab_mut().messages.last_mut()
+    {
+        content.push(ToolCallContent::Text(output.clone()));
+    }
+    let compact = render_to_text(&mut app, 48, 40);
+    assert!(!compact.contains("QUERY_END"));
+    let hit = *app
+        .completed_turn_hits
+        .iter()
+        .find(|hit| matches!(hit.kind, CompletedTurnHitKind::ActiveToolCall { .. }))
+        .unwrap();
+    click_tool_hit(&mut app, hit);
+    let expanded = render_to_text(&mut app, 48, 40);
+    assert!(
+        expanded.contains("QUERY_START") && expanded.contains("QUERY_END"),
+        "{expanded}"
+    );
+    assert!(expanded.contains("RESULT_search"));
+    assert!(app.current_tab().completed_tool_call_expanded("search"));
+
+    app.handle_event(AppEvent::ToolCallUpdate {
+        session_id: DEFAULT_TAB_ID.into(),
+        id: "search".into(),
+        title: Some("Searching for 'As of...'".into()),
+        status: Some("Completed".into()),
+        kind: None,
+        query: None,
+        location: None,
+        location_is_command: false,
+        output: Some(ToolCallOutput {
+            text: "FINAL_RESULT".into(),
+            truncated: false,
+        }),
+        content: None,
+        locations: Some(Vec::new()),
+        cwd: None,
+        exit_code: None,
+    });
+    let completed = render_to_text(&mut app, 48, 40);
+    assert!(completed.contains("QUERY_END") && completed.contains("FINAL_RESULT"));
+    assert!(!completed.contains("RESULT_search"));
+    assert!(app
+        .completed_turn_hits
+        .iter()
+        .any(|hit| matches!(hit.kind, CompletedTurnHitKind::ActiveToolCall { .. })));
+    app.handle_event(AppEvent::AgentMessageEnd {
+        session_id: DEFAULT_TAB_ID.into(),
+    });
+    let history = render_to_text(&mut app, 48, 40);
+    assert!(
+        history.contains("QUERY_END") && history.contains("FINAL_RESULT"),
+        "{history}"
+    );
+    assert!(app
+        .completed_turn_hits
+        .iter()
+        .any(|hit| matches!(hit.kind, CompletedTurnHitKind::ToolCall { .. })));
+    assert!(!app
+        .completed_turn_hits
+        .iter()
+        .any(|hit| matches!(hit.kind, CompletedTurnHitKind::ActiveToolCall { .. })));
+    let encoded = serde_json::to_string(&app.current_tab().completed_turns[0].details).unwrap();
+    let decoded: Vec<ChatMessage> = serde_json::from_str(&encoded).unwrap();
+    assert!(decoded.iter().any(|message| matches!(message,
+        ChatMessage::ToolCall { query: Some(value), .. } if value.text == query)));
+}
+
+#[test]
+fn active_tool_groups_expand_and_ctrl_o_updates_active_and_cached_history() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    submit_test_prompt(&mut app, "search");
+    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "");
+    app.current_tab_mut().messages.extend([
+        search_tool_message("one", "Completed", "FIRST_QUERY"),
+        search_tool_message("two", "Completed", "SECOND_QUERY"),
+    ]);
+    render_to_text(&mut app, 60, 40);
+    let hit = *app
+        .completed_turn_hits
+        .iter()
+        .find(|hit| {
+            matches!(
+                hit.kind,
+                CompletedTurnHitKind::ActiveToolGroup {
+                    detail_count: 2,
+                    ..
+                }
+            )
+        })
+        .unwrap();
+    click_tool_hit(&mut app, hit);
+    let expanded = render_to_text(&mut app, 60, 40);
+    for text in ["FIRST_QUERY", "SECOND_QUERY", "RESULT_one", "RESULT_two"] {
+        assert!(expanded.contains(text), "{expanded}");
+    }
+    assert_eq!(
+        app.completed_turn_hits
+            .iter()
+            .filter(|hit| matches!(hit.kind, CompletedTurnHitKind::ActiveToolCall { .. }))
+            .count(),
+        2
+    );
+    app.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
+    assert!(!render_to_text(&mut app, 60, 40).contains("FIRST_QUERY"));
+    app.handle_event(AppEvent::AgentMessageEnd {
+        session_id: DEFAULT_TAB_ID.into(),
+    });
+    render_to_text(&mut app, 60, 40);
+    submit_test_prompt(&mut app, "next search");
+    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "");
+    app.current_tab_mut()
+        .messages
+        .push(search_tool_message("three", "InProgress", "THIRD_QUERY"));
+    app.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
+    let expanded = render_to_text(&mut app, 60, 40);
+    for text in ["FIRST_QUERY", "SECOND_QUERY", "THIRD_QUERY"] {
+        assert!(expanded.contains(text), "{expanded}");
+    }
+    app.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
+    assert!(!render_to_text(&mut app, 60, 40).contains("THIRD_QUERY"));
+}
+
+#[test]
+fn active_tool_disclosure_anchors_header_and_can_scroll_wrapped_details() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    submit_test_prompt(&mut app, "search");
+    app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "");
+    let query = format!("QUERY_START {}", "long search ".repeat(100));
+    app.current_tab_mut()
+        .messages
+        .push(search_tool_message("one", "Completed", &query));
+    render_to_text(&mut app, 42, 20);
+    let hit = *app
+        .completed_turn_hits
+        .iter()
+        .find(|hit| matches!(hit.kind, CompletedTurnHitKind::ActiveToolCall { .. }))
+        .unwrap();
+    click_tool_hit(&mut app, hit);
+    render_to_text(&mut app, 42, 20);
+    let expanded_hit = *app
+        .completed_turn_hits
+        .iter()
+        .find(|candidate| candidate.kind == hit.kind)
+        .unwrap();
+    assert_eq!(hit.row, expanded_hit.row);
+    assert!(app.current_tab().chat_scroll.offset > 0);
+    app.current_tab_mut().scroll_to_bottom();
+    let bottom = render_to_text(&mut app, 42, 20);
+    assert!(bottom.contains("RESULT_one"), "{bottom}");
+    assert!(bottom.contains('…'), "{bottom}");
+    app.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
+    assert!(!app.current_tab().completed_tool_call_expanded("one"));
+}
+
+#[test]
+fn active_tool_geometry_does_not_create_completed_turn_controls() {
+    let mut app = test_app();
+    app.state = ConnectionState::Connected;
+    submit_test_prompt(&mut app, "search");
+    app.current_tab_mut().messages.push(search_tool_message(
+        "active",
+        "InProgress",
+        "PROVIDER_QUERY",
+    ));
+    render_to_text(&mut app, 60, 30);
+    assert!(app.current_tab().completed_turns.is_empty());
+    assert_eq!(app.completed_turn_hits.len(), 1);
+    let hit = app.completed_turn_hits[0];
+    assert!(matches!(
+        hit.kind,
+        CompletedTurnHitKind::ActiveToolCall { .. }
+    ));
+    click_tool_hit(&mut app, hit);
+    assert!(render_to_text(&mut app, 60, 30).contains("PROVIDER_QUERY"));
+    assert!(app.current_tab().completed_turns.is_empty());
+    assert!(app.current_tab().selected_completed_turn_idx.is_none());
+    assert!(app.current_tab().completed_turn_viewport_anchor().is_none());
+}
+
+#[test]
+fn active_tool_disclosure_rejects_drag_tab_switch_and_replaced_row() {
+    use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+    for action in ["drag", "tab", "hide", "finish", "outside"] {
+        let mut app = test_app();
+        app.state = ConnectionState::Connected;
+        submit_test_prompt(&mut app, "search");
+        app.turn_observe_chunk(DEFAULT_TAB_ID, ChunkKind::Thought, "");
+        app.current_tab_mut().messages.extend([
+            search_tool_message("one", "InProgress", "FIRST_QUERY"),
+            search_tool_message("two", "InProgress", "SECOND_QUERY"),
+        ]);
+        render_to_text(&mut app, 60, 40);
+        let hit = *app
+            .completed_turn_hits
+            .iter()
+            .find(|hit| matches!(hit.kind, CompletedTurnHitKind::ActiveToolCall { .. }))
+            .unwrap();
+        let mouse = |kind, column| {
+            AppEvent::Mouse(MouseEvent {
+                kind,
+                column,
+                row: hit.row,
+                modifiers: KeyModifiers::NONE,
+            })
+        };
+        app.handle_event(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            hit.start_column,
+        ));
+        match action {
+            "drag" => app.handle_event(mouse(
+                MouseEventKind::Drag(MouseButton::Left),
+                hit.start_column + 1,
+            )),
+            "tab" => {
+                app.switch_tab_session("other".into());
+                app.switch_tab_session(DEFAULT_TAB_ID.into());
+            }
+            "hide" => app.handle_event(AppEvent::HideToolCall {
+                session_id: DEFAULT_TAB_ID.into(),
+                id: "one".into(),
+            }),
+            "finish" => app.handle_event(AppEvent::AgentMessageEnd {
+                session_id: DEFAULT_TAB_ID.into(),
+            }),
+            _ => {}
+        }
+        render_to_text(&mut app, 60, 40);
+        let column = if action == "outside" {
+            59
+        } else {
+            hit.start_column
+        };
+        app.handle_event(mouse(MouseEventKind::Up(MouseButton::Left), column));
+        assert!(
+            app.current_tab().expanded_completed_tool_calls.is_empty(),
+            "{action}"
+        );
+    }
+}
+
 #[test]
 fn tool_call_partial_update_preserves_status_and_replaces_reported_output() {
     let mut app = test_app();
@@ -14361,6 +14677,7 @@ fn tool_call_partial_update_preserves_status_and_replaces_reported_output() {
     submit_test_prompt(&mut app, "inspect");
     app.handle_event(AppEvent::ToolCall {
         session_id: DEFAULT_TAB_ID.into(),
+        query: None,
         id: "tool".into(),
         title: "Preparing command".into(),
         status: "InProgress".into(),
@@ -14375,6 +14692,7 @@ fn tool_call_partial_update_preserves_status_and_replaces_reported_output() {
     });
     app.handle_event(AppEvent::ToolCallUpdate {
         session_id: DEFAULT_TAB_ID.into(),
+        query: None,
         id: "tool".into(),
         title: Some("bash".into()),
         status: Some("Completed".into()),
@@ -14423,6 +14741,7 @@ fn tool_call_update_replaces_and_clears_standard_collections() {
     submit_test_prompt(&mut app, "inspect");
     app.handle_event(AppEvent::ToolCall {
         session_id: DEFAULT_TAB_ID.into(),
+        query: None,
         id: "tool".into(),
         title: "Edit source".into(),
         status: "InProgress".into(),
@@ -14443,6 +14762,7 @@ fn tool_call_update_replaces_and_clears_standard_collections() {
     });
     app.handle_event(AppEvent::ToolCallUpdate {
         session_id: DEFAULT_TAB_ID.into(),
+        query: None,
         id: "tool".into(),
         title: None,
         status: None,
@@ -14476,6 +14796,7 @@ fn terminal_output_updates_only_the_tool_call_referencing_the_terminal() {
     submit_test_prompt(&mut app, "run");
     app.handle_event(AppEvent::ToolCall {
         session_id: DEFAULT_TAB_ID.into(),
+        query: None,
         id: "tool-call-1".into(),
         title: "Run command".into(),
         status: "InProgress".into(),
@@ -14494,6 +14815,7 @@ fn terminal_output_updates_only_the_tool_call_referencing_the_terminal() {
     });
     app.handle_event(AppEvent::ToolCall {
         session_id: DEFAULT_TAB_ID.into(),
+        query: None,
         id: "tool-call-2".into(),
         title: "Run another command".into(),
         status: "InProgress".into(),
@@ -14604,6 +14926,7 @@ fn completed_tool_call_defaults_compact_and_expands_independently() {
         prompt: "Update source".into(),
         details: vec![ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Edit source".into(),
             status: "Completed".into(),
             kind: ToolCallKind::Edit,
@@ -14685,6 +15008,7 @@ fn failed_completed_tool_keeps_bounded_diagnostic_preview() {
         prompt: "Run checks".into(),
         details: vec![ChatMessage::ToolCall {
             id: "failed-tool".into(),
+            query: None,
             title: "Run checks".into(),
             status: "Failed: tests failed".into(),
             kind: ToolCallKind::Execute,
@@ -14722,6 +15046,7 @@ fn ctrl_o_toggles_all_completed_tool_details_without_folding_turns() {
         details: (0..2)
             .map(|index| ChatMessage::ToolCall {
                 id: format!("tool-{index}"),
+                query: None,
                 title: format!("Read file {index}"),
                 status: "Completed".into(),
                 kind: ToolCallKind::Read,
@@ -14767,6 +15092,7 @@ fn completed_tool_expansion_preserves_its_header_row_and_rebuilds_height() {
         details: vec![
             ChatMessage::ToolCall {
                 id: "anchored-tool".into(),
+                query: None,
                 title: "Run anchored command".into(),
                 status: "Completed".into(),
                 kind: ToolCallKind::Execute,
@@ -14833,6 +15159,7 @@ fn completed_tool_disclosures_anchor_visible_headers_below_clipped_prompts() {
                 .enumerate()
                 .map(|(index, path)| ChatMessage::ToolCall {
                     id: format!("grouped-tool-{index}"),
+                    query: None,
                     title: format!("Viewing {path}"),
                     status: "Completed".into(),
                     kind: ToolCallKind::Read,
@@ -14854,6 +15181,7 @@ fn completed_tool_disclosures_anchor_visible_headers_below_clipped_prompts() {
         } else {
             vec![ChatMessage::ToolCall {
                 id: "individual-tool".into(),
+                query: None,
                 title: "Run INDIVIDUAL_ANCHORED_TOOL".into(),
                 status: "Completed".into(),
                 kind: ToolCallKind::Execute,
@@ -16300,6 +16628,7 @@ fn direct_proposal_defers_history_until_tool_updates_finish() {
     submit_proposal_prompt(&mut app, session_id);
     app.handle_event(AppEvent::ToolCall {
         session_id: session_id.into(),
+        query: None,
         id: "tool-1".into(),
         title: "Inspect files".into(),
         status: "Running".into(),
@@ -16327,6 +16656,7 @@ fn direct_proposal_defers_history_until_tool_updates_finish() {
 
     app.handle_event(AppEvent::ToolCallUpdate {
         session_id: session_id.into(),
+        query: None,
         id: "tool-1".into(),
         title: None,
         status: Some("Completed".into()),

--- a/tools/wta/src/protocol/acp/client.rs
+++ b/tools/wta/src/protocol/acp/client.rs
@@ -959,6 +959,32 @@ fn tool_call_cwd(raw_input: Option<&serde_json::Value>) -> Option<String> {
         .map(str::to_string)
 }
 
+fn tool_call_query(
+    kind: Option<&acp::schema::v1::ToolKind>,
+    raw_input: Option<&serde_json::Value>,
+) -> Option<crate::app::ToolCallOutput> {
+    if kind.is_some_and(|kind| {
+        !matches!(
+            kind,
+            acp::schema::v1::ToolKind::Search | acp::schema::v1::ToolKind::Other
+        )
+    }) {
+        return None;
+    }
+    // Initial calls default to Other and updates can omit kind; Search may arrive later.
+    // Retain only the named query, never arbitrary input JSON.
+    let query = raw_input?.get("query")?.as_str()?;
+    if query.trim().is_empty() {
+        return None;
+    }
+    let mut chars = query.chars();
+    let text = chars.by_ref().take(TOOL_CALL_OUTPUT_MAX_CHARS).collect();
+    Some(crate::app::ToolCallOutput {
+        text,
+        truncated: chars.next().is_some(),
+    })
+}
+
 fn tool_call_exit_code(raw_output: Option<&serde_json::Value>) -> Option<i64> {
     let object = raw_output?.as_object()?;
     ["exitCode", "exit_code"]
@@ -1666,6 +1692,7 @@ impl WtaClient {
                     title: tool_call.title.clone(),
                     status: format!("{:?}", tool_call.status),
                     kind: tool_call_kind(tool_call.kind),
+                    query: tool_call_query(Some(&tool_call.kind), tool_call.raw_input.as_ref()),
                     location,
                     location_is_command,
                     cwd: tool_call_cwd(tool_call.raw_input.as_ref()),
@@ -1759,6 +1786,10 @@ impl WtaClient {
                         (None, false)
                     };
                 let cwd = tool_call_cwd(update.fields.raw_input.as_ref());
+                let query = tool_call_query(
+                    update.fields.kind.as_ref(),
+                    update.fields.raw_input.as_ref(),
+                );
                 let exit_code = tool_call_exit_code(update.fields.raw_output.as_ref());
                 let content = update.fields.content.as_deref().map(tool_call_content);
                 let locations = update.fields.locations.as_deref().map(tool_call_locations);
@@ -1771,6 +1802,7 @@ impl WtaClient {
                     || exit_code.is_some()
                     || content.is_some()
                     || locations.is_some()
+                    || query.is_some()
                 {
                     let _ = self.state.event_tx.send(AppEvent::ToolCallUpdate {
                         session_id: sid,
@@ -1778,6 +1810,7 @@ impl WtaClient {
                         title: update.fields.title,
                         status,
                         kind: update.fields.kind.map(tool_call_kind),
+                        query,
                         location,
                         location_is_command,
                         output,
@@ -1910,6 +1943,7 @@ impl WtaClient {
                     title,
                     status: "running".to_string(),
                     kind: crate::app::ToolCallKind::Execute,
+                    query: None,
                     location,
                     location_is_command: false,
                     cwd: None,
@@ -1972,6 +2006,7 @@ impl WtaClient {
                     title: None,
                     status: Some(format!("exited ({})", code)),
                     kind: None,
+                    query: None,
                     location: None,
                     location_is_command: false,
                     output: None,

--- a/tools/wta/src/protocol/acp/mock_agent_tests.rs
+++ b/tools/wta/src/protocol/acp/mock_agent_tests.rs
@@ -5614,6 +5614,137 @@ async fn session_notification_hides_proposal_tool_call_before_permission() {
 }
 
 #[tokio::test]
+async fn session_notification_tool_query_survives_abbreviated_title_and_deferred_kind() {
+    use acp::schema::v1::{
+        SessionUpdate, ToolCall, ToolCallId, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
+    };
+    let (client, mut rx) = bare_client();
+    let query = format!(
+        "  As of September 9, 2026, {} 完整查询 END  ",
+        "search terms ".repeat(30)
+    );
+    client
+        .session_notification(notif(
+            "s1",
+            SessionUpdate::ToolCall(
+                ToolCall::new(ToolCallId::new("search"), "Searching for 'As of...'").raw_input(
+                    Some(serde_json::json!({"query": query, "unrelated": "DO_NOT_DISPLAY"})),
+                ),
+            ),
+        ))
+        .await
+        .unwrap();
+    assert!(matches!(rx.try_recv(), Ok(AppEvent::ToolCall {
+        kind: crate::app::ToolCallKind::Other,
+        query: Some(reported), location: None, output: None, ..
+    }) if reported.text == query && !reported.truncated));
+
+    let mut fields = ToolCallUpdateFields::new();
+    fields.kind = Some(ToolKind::Search);
+    client
+        .session_notification(notif(
+            "s1",
+            SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(ToolCallId::new("search"), fields)),
+        ))
+        .await
+        .unwrap();
+    assert!(matches!(
+        rx.try_recv(),
+        Ok(AppEvent::ToolCallUpdate {
+            kind: Some(crate::app::ToolCallKind::Search),
+            query: None,
+            ..
+        })
+    ));
+
+    client
+        .session_notification(notif(
+            "s1",
+            SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                ToolCallId::new("search"),
+                ToolCallUpdateFields::new()
+                    .raw_input(Some(serde_json::json!({"query": "replacement query"}))),
+            )),
+        ))
+        .await
+        .unwrap();
+    assert!(matches!(rx.try_recv(), Ok(AppEvent::ToolCallUpdate {
+        kind: None, query: Some(reported), ..
+    }) if reported.text == "replacement query"));
+
+    client
+        .session_notification(notif(
+            "s1",
+            SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(
+                ToolCallId::new("search"),
+                ToolCallUpdateFields::new().content(vec!["Provider search result".into()]),
+            )),
+        ))
+        .await
+        .unwrap();
+    assert!(matches!(rx.try_recv(), Ok(AppEvent::ToolCallUpdate {
+        query: None, output: Some(output), ..
+    }) if output.text == "Provider search result"));
+}
+
+#[tokio::test]
+async fn session_notification_tool_query_is_bounded_and_never_dumps_raw_input() {
+    use acp::schema::v1::{SessionUpdate, ToolCall, ToolCallId, ToolKind};
+    let (client, mut rx) = bare_client();
+    for (kind, input, expected) in [
+        (
+            ToolKind::Search,
+            serde_json::json!({"query": format!("START{}", "界".repeat(4100))}),
+            Some(true),
+        ),
+        (
+            ToolKind::Search,
+            serde_json::json!({"query": "  exact query  "}),
+            Some(false),
+        ),
+        (
+            ToolKind::Search,
+            serde_json::json!({"query": {"secret": "not text"}}),
+            None,
+        ),
+        (
+            ToolKind::Search,
+            serde_json::json!({"unrelated": "not a query"}),
+            None,
+        ),
+        (ToolKind::Search, serde_json::json!({"query": " \n "}), None),
+        (
+            ToolKind::Edit,
+            serde_json::json!({"query": "not search input"}),
+            None,
+        ),
+    ] {
+        client
+            .session_notification(notif(
+                "s1",
+                SessionUpdate::ToolCall(
+                    ToolCall::new(ToolCallId::new("search"), "Short title")
+                        .kind(kind)
+                        .raw_input(Some(input)),
+                ),
+            ))
+            .await
+            .unwrap();
+        let Ok(AppEvent::ToolCall { query, .. }) = rx.try_recv() else {
+            panic!("expected tool call");
+        };
+        assert_eq!(query.as_ref().map(|value| value.truncated), expected);
+        if expected == Some(true) {
+            let query = query.unwrap();
+            assert_eq!(query.text.chars().count(), 4000);
+            assert!(query.text.starts_with("START"));
+        } else if expected == Some(false) {
+            assert_eq!(query.unwrap().text, "  exact query  ");
+        }
+    }
+}
+
+#[tokio::test]
 async fn session_notification_hides_only_bound_session_mcp_tool_call() {
     let own_server = "intellterm_0123456789abcdef";
     for server_name in [None, Some(own_server), Some("intellterm_9876543210987654")] {

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -242,16 +242,17 @@ fn tool_output_lines(output: &ToolCallOutput) -> Vec<String> {
 }
 
 fn full_output_lines(output: &ToolCallOutput, prefix: &str, wrap_width: usize) -> Vec<String> {
-    let mut lines = wrapped_tool_text_lines(&output.text, prefix, wrap_width, usize::MAX, false);
+    let mut lines = if output.text.is_empty() {
+        Vec::new()
+    } else {
+        wrapped_tool_text_lines(&output.text, prefix, wrap_width, usize::MAX, false)
+    };
     let omitted = output.truncated || lines.len() > MAX_TOOL_DETAIL_OUTPUT_LINES;
     if lines.len() > MAX_TOOL_DETAIL_OUTPUT_LINES {
         lines.drain(..lines.len() - MAX_TOOL_DETAIL_OUTPUT_LINES);
     }
     if omitted {
         lines.insert(0, format!("{prefix}…"));
-    }
-    if lines.is_empty() {
-        lines.push(prefix.trim_end().to_string());
     }
     lines
 }
@@ -2401,6 +2402,25 @@ mod tests {
         assert!(lines
             .iter()
             .all(|line| line.width() <= 12 && !line.contains('\r')));
+    }
+
+    #[test]
+    fn empty_expanded_tool_output_has_no_placeholder_but_preserves_truncation() {
+        let mut output = ToolCallOutput {
+            text: String::new(),
+            truncated: false,
+        };
+        assert!(full_output_lines(&output, "    │ ", 40).is_empty());
+        assert!(tool_detail_lines_with_width(
+            [ToolCallContent::Text(output.clone())].iter(),
+            &[],
+            true,
+            40
+        )
+        .is_empty());
+
+        output.truncated = true;
+        assert_eq!(full_output_lines(&output, "    │ ", 40), ["    │ …"]);
     }
 
     #[test]

--- a/tools/wta/src/ui/chat.rs
+++ b/tools/wta/src/ui/chat.rs
@@ -88,21 +88,26 @@ fn compact_group_kind(message: &ChatMessage, expanded: bool) -> Option<ToolCallK
     (groupable_kind && ToolPhase::from_status(status).is_successful()).then_some(*kind)
 }
 
+#[cfg(test)]
 fn previous_message_group_start(messages: &[ChatMessage], end: usize) -> usize {
+    previous_message_group_start_with_expansion(messages, end, |_| false)
+}
+
+fn previous_message_group_start_with_expansion(
+    messages: &[ChatMessage],
+    end: usize,
+    expanded: impl Fn(&str) -> bool,
+) -> usize {
+    let group_kind = |message: &ChatMessage| {
+        let is_expanded = matches!(message, ChatMessage::ToolCall { id, .. } if expanded(id));
+        compact_group_kind(message, is_expanded)
+    };
     let last = end.saturating_sub(1);
-    let Some(kind) = messages
-        .get(last)
-        .and_then(|message| compact_group_kind(message, false))
-    else {
+    let Some(kind) = messages.get(last).and_then(group_kind) else {
         return last;
     };
     let mut start = last;
-    while start > 0
-        && messages
-            .get(start - 1)
-            .and_then(|message| compact_group_kind(message, false))
-            == Some(kind)
-    {
+    while start > 0 && messages.get(start - 1).and_then(group_kind) == Some(kind) {
         start -= 1;
     }
     start
@@ -236,25 +241,43 @@ fn tool_output_lines(output: &ToolCallOutput) -> Vec<String> {
     lines
 }
 
-fn full_output_lines(output: &ToolCallOutput, prefix: &str) -> Vec<String> {
-    let mut source = output.text.lines().rev();
-    let mut lines: Vec<String> = source
-        .by_ref()
-        .take(MAX_TOOL_DETAIL_OUTPUT_LINES)
-        .map(|line| {
-            let mut chars = line.chars();
-            let head: String = chars.by_ref().take(MAX_TOOL_OUTPUT_LINE_CHARS).collect();
-            let suffix = if chars.next().is_some() { "…" } else { "" };
-            format!("{prefix}{head}{suffix}")
-        })
-        .collect();
-    let omitted = output.truncated || source.next().is_some();
-    lines.reverse();
+fn full_output_lines(output: &ToolCallOutput, prefix: &str, wrap_width: usize) -> Vec<String> {
+    let mut lines = wrapped_tool_text_lines(&output.text, prefix, wrap_width, usize::MAX, false);
+    let omitted = output.truncated || lines.len() > MAX_TOOL_DETAIL_OUTPUT_LINES;
+    if lines.len() > MAX_TOOL_DETAIL_OUTPUT_LINES {
+        lines.drain(..lines.len() - MAX_TOOL_DETAIL_OUTPUT_LINES);
+    }
     if omitted {
         lines.insert(0, format!("{prefix}…"));
     }
     if lines.is_empty() {
         lines.push(prefix.trim_end().to_string());
+    }
+    lines
+}
+
+fn wrapped_tool_text_lines(
+    text: &str,
+    prefix: &str,
+    wrap_width: usize,
+    max_lines: usize,
+    truncated: bool,
+) -> Vec<String> {
+    let width = wrap_width.saturating_sub(prefix.width()).max(1);
+    let mut lines = Vec::new();
+    let mut omitted = truncated;
+    'source: for paragraph in text.split('\n') {
+        let pieces = textwrap::wrap(paragraph, width);
+        for piece in pieces {
+            if lines.len() == max_lines {
+                omitted = true;
+                break 'source;
+            }
+            lines.push(format!("{prefix}{piece}"));
+        }
+    }
+    if omitted {
+        lines.push(format!("{prefix}…"));
     }
     lines
 }
@@ -357,10 +380,20 @@ fn diff_detail_lines(
     lines
 }
 
+#[cfg(test)]
 fn tool_detail_lines(
     content: &[ToolCallContent],
     locations: &[ToolCallLocation],
     detailed: bool,
+) -> Vec<ToolDetailLine> {
+    tool_detail_lines_with_width(content, locations, detailed, MAX_TOOL_OUTPUT_LINE_CHARS + 6)
+}
+
+fn tool_detail_lines_with_width<'a>(
+    content: impl IntoIterator<Item = &'a ToolCallContent>,
+    locations: &[ToolCallLocation],
+    detailed: bool,
+    wrap_width: usize,
 ) -> Vec<ToolDetailLine> {
     #[cfg(test)]
     TOOL_DETAIL_BUILD_COUNT.with(|count| count.set(count.get() + 1));
@@ -388,7 +421,7 @@ fn tool_detail_lines(
             ToolCallContent::Text(output) => {
                 if detailed {
                     lines.extend(
-                        full_output_lines(output, "    │ ")
+                        full_output_lines(output, "    │ ", wrap_width)
                             .into_iter()
                             .map(ToolDetailLine::dim),
                     );
@@ -423,7 +456,7 @@ fn tool_detail_lines(
                 if detailed {
                     if let Some(output) = output {
                         lines.extend(
-                            full_output_lines(output, "    │ ")
+                            full_output_lines(output, "    │ ", wrap_width)
                                 .into_iter()
                                 .map(ToolDetailLine::dim),
                         );
@@ -509,19 +542,11 @@ pub fn estimated_block_height(app: &App, area_width: u16, max_height: u16) -> u1
             end = index;
             continue;
         }
-        let start = previous_message_group_start(&tab.messages, end);
-        let message_lines = if end - start > 1 {
-            build_compact_tool_group_lines(&tab.messages[start..end])
-        } else {
-            build_message_lines(
-                &tab.messages[index],
-                end == tab.messages.len(),
-                tab.turn.is_streaming(),
-                permission_tool_call_id,
-                tab.activity_frame,
-                wrap_width,
-            )
-        };
+        let start = previous_message_group_start_with_expansion(&tab.messages, end, |id| {
+            tab.completed_tool_call_expanded(id)
+        });
+        let (message_lines, _) =
+            build_active_message_group(tab, start, end, permission_tool_call_id, wrap_width);
         height = height.saturating_add(rendered_lines_height(&message_lines, wrap_width));
         if height >= max_height {
             return max_height as u16;
@@ -657,7 +682,7 @@ fn breathing_dot(frame: usize) -> &'static str {
 const CHAT_RENDER_MARGIN_ROWS: usize = 32;
 
 struct CompletedTurnHitOffset {
-    turn_index: usize,
+    turn_index: Option<usize>,
     rows_below: usize,
     turn_height: usize,
     expanded: bool,
@@ -671,6 +696,60 @@ struct ToolRowGeometry {
     header_width: usize,
     expanded: bool,
     marker: &'static str,
+}
+
+fn build_active_message_group<'a>(
+    tab: &'a crate::app::TabSession,
+    start: usize,
+    end: usize,
+    permission_tool_call_id: Option<&str>,
+    wrap_width: usize,
+) -> (Vec<Line<'a>>, Option<ToolRowGeometry>) {
+    let message = &tab.messages[start];
+    let expanded =
+        matches!(message, ChatMessage::ToolCall { id, .. } if tab.completed_tool_call_expanded(id));
+    let grouped = end - start > 1;
+    let lines = if grouped {
+        build_compact_tool_group_lines(&tab.messages[start..end])
+    } else {
+        build_message_lines_with_details(
+            message,
+            end == tab.messages.len(),
+            tab.turn.is_streaming(),
+            permission_tool_call_id,
+            tab.activity_frame,
+            wrap_width,
+            ToolDisplay::Completed { expanded },
+        )
+    };
+    let geometry = if let Some(presentation) = tool_presentation_from_message(message) {
+        Some(ToolRowGeometry {
+            hit_kind: if grouped {
+                crate::app::CompletedTurnHitKind::ActiveToolGroup {
+                    first_detail_index: start,
+                    detail_count: end - start,
+                }
+            } else {
+                crate::app::CompletedTurnHitKind::ActiveToolCall {
+                    detail_index: start,
+                }
+            },
+            row_offset: 0,
+            header_width: lines
+                .first()
+                .map_or(1, |line| line.width().min(wrap_width))
+                .max(1),
+            expanded,
+            marker: rendered_tool_call_marker(
+                presentation.phase,
+                matches!(message, ChatMessage::ToolCall { id, .. } if permission_tool_call_id == Some(id.as_str())),
+                tab.activity_frame,
+            ),
+        })
+    } else {
+        None
+    };
+    (lines, geometry)
 }
 
 struct PlannedCompletedTurn {
@@ -833,6 +912,8 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
         .flatten()
         .filter(|index| *index < app.current_tab().completed_turns.len());
     let viewport_anchor = app.current_tab().completed_turn_viewport_anchor();
+    let active_anchor = app.current_tab_mut().active_tool_viewport_anchor.take();
+    let mut active_anchor_applied = false;
     let mut effective_offset = app.current_tab().chat_scroll.offset;
     let mut requested_rows = visible_height
         .saturating_add(effective_offset)
@@ -858,24 +939,40 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
             end = idx;
             continue;
         }
-        let start = previous_message_group_start(&tab.messages, end);
-        let mut message_lines = if end - start > 1 {
-            build_compact_tool_group_lines(&tab.messages[start..end])
-        } else {
-            build_message_lines(
-                &tab.messages[idx],
-                end == tab.messages.len(),
-                tab.turn.is_streaming(),
-                permission_tool_call_id,
-                tab.activity_frame,
-                wrap_width,
-            )
-        };
-        newer_rows = newer_rows.saturating_add(rendered_lines_height(&message_lines, wrap_width));
+        let start = previous_message_group_start_with_expansion(&tab.messages, end, |id| {
+            tab.completed_tool_call_expanded(id)
+        });
+        let (mut message_lines, geometry) =
+            build_active_message_group(tab, start, end, permission_tool_call_id, wrap_width);
+        let message_height = rendered_lines_height(&message_lines, wrap_width);
+        if let Some((id, row)) = &active_anchor {
+            if tab.messages[start..end].iter().any(|message| {
+                matches!(message, ChatMessage::ToolCall { id: tool_id, .. } if tool_id == id)
+            }) {
+                effective_offset = newer_rows.saturating_add(message_height)
+                    .saturating_add(row.saturating_sub(inner_area.y) as usize)
+                    .saturating_sub(visible_height);
+                requested_rows = visible_height.saturating_add(effective_offset)
+                    .saturating_add(CHAT_RENDER_MARGIN_ROWS);
+                active_anchor_applied = true;
+            }
+        }
+        if let Some(geometry) = geometry {
+            turn_hit_offsets.push(CompletedTurnHitOffset {
+                turn_index: None,
+                rows_below: newer_rows,
+                turn_height: message_height,
+                expanded: false,
+                prompt_rows: Vec::new(),
+                tool_rows: vec![geometry],
+            });
+        }
+        newer_rows = newer_rows.saturating_add(message_height);
         reversed_lines.extend(message_lines.drain(..).rev());
         if newer_rows >= requested_rows
             && selection_target_idx.is_none()
             && viewport_anchor.is_none()
+            && (active_anchor.is_none() || active_anchor_applied)
         {
             truncated = true;
             break;
@@ -895,6 +992,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
         );
         if plan.skip_base_lines {
             reversed_lines.clear();
+            turn_hit_offsets.clear();
         }
         let tab = app.current_tab();
         for planned in plan.turns {
@@ -907,7 +1005,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
                 wrap_width,
             );
             turn_hit_offsets.push(CompletedTurnHitOffset {
-                turn_index: planned.index,
+                turn_index: Some(planned.index),
                 rows_below: planned.rows_below,
                 turn_height: planned.height,
                 expanded: turn.expanded,
@@ -965,10 +1063,11 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
         } = hit_offset;
         let header_from_top = total_lines.saturating_sub(rows_below.saturating_add(turn_height));
         let mut visible_anchor = None;
-        if let Some(header_row) = header_from_top
-            .checked_sub(scroll)
-            .filter(|row| *row < visible_height)
-        {
+        if let Some((turn_index, header_row)) = turn_index.zip(
+            header_from_top
+                .checked_sub(scroll)
+                .filter(|row| *row < visible_height),
+        ) {
             visible_anchor = Some(crate::app::CompletedTurnViewportAnchor {
                 index: turn_index,
                 row: header_row,
@@ -994,6 +1093,9 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
         }
 
         for prompt_row in prompt_rows {
+            let Some(turn_index) = turn_index else {
+                continue;
+            };
             let Some(visible_row) = header_from_top
                 .saturating_add(prompt_row.row_offset)
                 .checked_sub(scroll)
@@ -1038,11 +1140,13 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
             if visible_row >= visible_height {
                 continue;
             }
-            visible_anchor.get_or_insert(crate::app::CompletedTurnViewportAnchor {
-                index: turn_index,
-                row: visible_row,
-                row_offset: tool_row.row_offset,
-            });
+            if let Some(turn_index) = turn_index {
+                visible_anchor.get_or_insert(crate::app::CompletedTurnViewportAnchor {
+                    index: turn_index,
+                    row: visible_row,
+                    row_offset: tool_row.row_offset,
+                });
+            }
             let row = inner_area.y.saturating_add(visible_row as u16);
             if let Some((start_column, end_column)) = tool_header_hit_columns(
                 buffer,
@@ -1055,7 +1159,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
                     start_column,
                     end_column,
                     row,
-                    turn_index,
+                    turn_index: turn_index.unwrap_or(0),
                     kind: tool_row.hit_kind,
                 });
                 app.completed_turn_action_links.push(
@@ -1080,7 +1184,7 @@ pub fn render(frame: &mut Frame, app: &mut App, area: Rect, scrollbar_area: Rect
     app.current_tab_mut()
         .finish_completed_turn_layout(visible_completed_turn_anchors);
 
-    if selection_pending {
+    if selection_pending || active_anchor_applied {
         let tab = app.current_tab_mut();
         tab.chat_scroll.offset = effective_offset;
         tab.completed_turn_selection_visible_pending = false;
@@ -1401,9 +1505,15 @@ fn build_completed_turn_lines_with_geometry<'a>(
             }
 
             let tool_geometry = match msg {
-                ChatMessage::ToolCall { id, status, .. } => Some((
+                ChatMessage::ToolCall { id, .. } => Some((
                     tool_expanded(id),
-                    rendered_tool_call_marker(ToolPhase::from_status(status), false, 0),
+                    rendered_tool_call_marker(
+                        tool_presentation_from_message(msg)
+                            .expect("tool call presentation")
+                            .phase,
+                        false,
+                        0,
+                    ),
                 )),
                 _ => None,
             };
@@ -1572,6 +1682,7 @@ fn build_pending_stream_lines<'a>(app: &App, wrap_width: usize) -> Vec<Line<'a>>
     lines
 }
 
+#[cfg(test)]
 fn build_message_lines<'a>(
     msg: &'a ChatMessage,
     is_last_message: bool,
@@ -1642,6 +1753,7 @@ fn build_message_lines_with_details<'a>(
             title,
             status,
             kind,
+            query,
             location,
             location_is_command,
             cwd,
@@ -1749,19 +1861,29 @@ fn build_message_lines_with_details<'a>(
                     }
                 }
             }
-            let has_text_content = content
-                .iter()
-                .any(|item| matches!(item, ToolCallContent::Text(_)));
+            // A raw-output-only update can supersede an earlier text progress block.
+            let prefer_search_output = *kind == ToolCallKind::Search && output.is_some();
+            let visible_content = || {
+                content.iter().filter(|item| {
+                    !prefer_search_output || !matches!(item, ToolCallContent::Text(_))
+                })
+            };
+            let has_text_content =
+                visible_content().any(|item| matches!(item, ToolCallContent::Text(_)));
             let mut detail_lines = match detail_level {
                 ToolDetailLevel::Compact => Vec::new(),
-                ToolDetailLevel::Preview => tool_detail_lines(content, locations, false),
-                ToolDetailLevel::Detailed => tool_detail_lines(content, locations, true),
+                ToolDetailLevel::Preview => {
+                    tool_detail_lines_with_width(visible_content(), locations, false, wrap_width)
+                }
+                ToolDetailLevel::Detailed => {
+                    tool_detail_lines_with_width(visible_content(), locations, true, wrap_width)
+                }
             };
             if !has_text_content && detail_level != ToolDetailLevel::Compact {
                 if let Some(output) = output {
                     if detail_level == ToolDetailLevel::Detailed {
                         detail_lines.extend(
-                            full_output_lines(output, "    │ ")
+                            full_output_lines(output, "    │ ", wrap_width)
                                 .into_iter()
                                 .map(ToolDetailLine::dim),
                         );
@@ -1775,6 +1897,25 @@ fn build_message_lines_with_details<'a>(
                 }
             }
             cap_tool_detail_lines(&mut detail_lines);
+            if detail_level == ToolDetailLevel::Detailed && *kind == ToolCallKind::Search {
+                // Queries are already bounded at ingestion. Keep every retained line scrollable.
+                let text = query.as_ref().map_or_else(
+                    || truncate_render_text(title),
+                    |query| Cow::Borrowed(query.text.as_str()),
+                );
+                let mut query_lines = wrapped_tool_text_lines(
+                    &text,
+                    "    │ ",
+                    wrap_width,
+                    usize::MAX,
+                    query.as_ref().is_some_and(|query| query.truncated),
+                )
+                .into_iter()
+                .map(ToolDetailLine::dim)
+                .collect::<Vec<_>>();
+                query_lines.append(&mut detail_lines);
+                detail_lines = query_lines;
+            }
             restyle_tool_detail_lines(&mut detail_lines, rendered_command || rendered_output);
             let rendered_details = !detail_lines.is_empty();
             for line in detail_lines {
@@ -2042,12 +2183,129 @@ mod tests {
     }
 
     #[test]
+    fn expanded_search_tool_wraps_exact_query_and_returned_result_instead_of_clipping() {
+        let query = format!("QUERY_START {} QUERY_END", "路径\\full/terms ".repeat(180));
+        let result = "RESULT_START returned text RESULT_END".to_string();
+        let mut message = ChatMessage::ToolCall {
+            id: "search".into(),
+            title: "Searching for 'QUERY_START...'".into(),
+            status: "Completed".into(),
+            kind: ToolCallKind::Search,
+            query: Some(ToolCallOutput {
+                text: query,
+                truncated: false,
+            }),
+            location: None,
+            location_is_command: false,
+            cwd: None,
+            output: None,
+            exit_code: None,
+            content: vec![ToolCallContent::Text(ToolCallOutput {
+                text: result,
+                truncated: false,
+            })],
+            locations: Vec::new(),
+        };
+        for status in ["InProgress", "Completed"] {
+            if let ChatMessage::ToolCall {
+                status: current, ..
+            } = &mut message
+            {
+                *current = status.into();
+            }
+            let compact = build_message_lines(&message, true, true, None, 0, 24);
+            assert!(!compact
+                .iter()
+                .any(|line| line.to_string().contains("QUERY_END")));
+            let lines = build_message_lines_with_details(
+                &message,
+                true,
+                true,
+                None,
+                0,
+                24,
+                ToolDisplay::Completed { expanded: true },
+            );
+            let text = lines
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n");
+            for expected in [
+                "QUERY_START",
+                "QUERY_END",
+                "RESULT_START",
+                "RESULT_END",
+                "full/terms",
+                "路",
+                "径",
+            ] {
+                assert!(text.contains(expected), "{text}");
+            }
+            assert!(lines.len() > MAX_TOOL_DETAIL_LINES);
+            assert!(lines.iter().skip(1).all(|line| line.width() <= 24));
+        }
+    }
+
+    #[test]
+    fn expanded_search_tool_falls_back_to_provider_title_without_inventing_results() {
+        let title = format!("Searching {} TITLE_END", "provider title ".repeat(20));
+        let message = ChatMessage::ToolCall {
+            id: "search".into(),
+            title: title.clone(),
+            status: "Completed".into(),
+            kind: ToolCallKind::Search,
+            query: None,
+            location: None,
+            location_is_command: false,
+            cwd: None,
+            output: None,
+            exit_code: None,
+            content: Vec::new(),
+            locations: Vec::new(),
+        };
+        let lines = build_message_lines_with_details(
+            &message,
+            false,
+            false,
+            None,
+            0,
+            48,
+            ToolDisplay::Completed { expanded: true },
+        );
+        let text = lines
+            .iter()
+            .skip(1)
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("TITLE_END"));
+        assert!(!text.contains("result"));
+        assert!(lines.iter().skip(1).all(|line| line.width() <= 48));
+    }
+
+    #[test]
+    fn wrapped_tool_text_preserves_unicode_and_marks_both_input_and_visual_limits() {
+        let text = "界".repeat(4000);
+        let lines =
+            wrapped_tool_text_lines(&text, "    │ ", 30, MAX_TOOL_DETAIL_OUTPUT_LINES, false);
+        assert_eq!(lines.len(), MAX_TOOL_DETAIL_OUTPUT_LINES + 1);
+        assert_eq!(lines.last().unwrap(), "    │ …");
+        assert!(lines.iter().all(|line| line.width() <= 30));
+        assert_eq!(
+            wrapped_tool_text_lines("retained", "    │ ", 40, 12, true),
+            ["    │ retained", "    │ …"]
+        );
+    }
+
+    #[test]
     fn completed_tool_geometry_scans_rendered_lines_linearly() {
         let turn = CompletedTurn {
             prompt: "tools".into(),
             details: (0..100)
                 .map(|index| ChatMessage::ToolCall {
                     id: format!("tool-{index}"),
+                    query: None,
                     title: format!("Read file {index}"),
                     status: "Completed".into(),
                     kind: ToolCallKind::Read,
@@ -2135,6 +2393,7 @@ mod tests {
                 "compact tool call",
                 vec![ChatMessage::ToolCall {
                     id: "tool".into(),
+                    query: None,
                     title: "Read source".into(),
                     status: "Completed".into(),
                     kind: ToolCallKind::Read,
@@ -2151,6 +2410,7 @@ mod tests {
                 "command tool call",
                 vec![ChatMessage::ToolCall {
                     id: "tool".into(),
+                    query: None,
                     title: "Run tests".into(),
                     status: "Completed".into(),
                     kind: ToolCallKind::Execute,
@@ -2218,6 +2478,7 @@ mod tests {
     ) {
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Run: cargo test".into(),
             status: status.into(),
             kind: ToolCallKind::Other,
@@ -2249,6 +2510,7 @@ mod tests {
     fn tool_call_renders_location_hint_between_title_and_status_detail() {
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Access paths outside trusted directories".into(),
             status: "Pending".into(),
             kind: ToolCallKind::Other,
@@ -2283,6 +2545,7 @@ mod tests {
     fn tool_call_command_location_renders_as_separate_code_line() {
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Run command".into(),
             status: "Pending".into(),
             kind: ToolCallKind::Execute,
@@ -2323,6 +2586,7 @@ mod tests {
     fn tool_call_multi_statement_command_renders_one_line_per_statement() {
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Check installed PowerToys and Foundry Local packages".into(),
             status: "Running".into(),
             kind: ToolCallKind::Execute,
@@ -2364,6 +2628,7 @@ mod tests {
         let cwd = concat!("C:", "\\", "repo");
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "bash".into(),
             status: "Running".into(),
             kind: ToolCallKind::Execute,
@@ -2395,6 +2660,7 @@ mod tests {
         let cwd = concat!("C:", "\\", "repo");
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Run tests".into(),
             status: "Completed".into(),
             kind: ToolCallKind::Execute,
@@ -2422,6 +2688,7 @@ mod tests {
     fn successful_long_command_stays_out_of_compact_header() {
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Resolve cargo in active terminal context".into(),
             status: "Completed".into(),
             kind: ToolCallKind::Execute,
@@ -2452,6 +2719,7 @@ mod tests {
         let path = r"C:\Users\kaitao\codes\rust-app\src\main.rs";
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: format!("Viewing {path}"),
             status: "Completed".into(),
             kind: ToolCallKind::Read,
@@ -2479,6 +2747,7 @@ mod tests {
     fn successful_search_compacts_workspace_subject() {
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Finding files matching **/*.rs".into(),
             status: "Completed".into(),
             kind: ToolCallKind::Search,
@@ -2506,6 +2775,7 @@ mod tests {
     fn successful_edit_does_not_treat_snapshots_as_line_counts() {
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Update source".into(),
             status: "Completed".into(),
             kind: ToolCallKind::Edit,
@@ -2564,6 +2834,7 @@ mod tests {
     fn failed_active_tool_call_keeps_diagnostic_preview() {
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Run tests".into(),
             status: "Failed".into(),
             kind: ToolCallKind::Execute,
@@ -2593,6 +2864,7 @@ mod tests {
     fn nonzero_completed_command_keeps_output_preview() {
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Run integration command".into(),
             status: "Completed".into(),
             kind: ToolCallKind::Execute,
@@ -2623,6 +2895,7 @@ mod tests {
     fn successful_truncated_tool_call_stays_compact_until_expanded() {
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Locate project directory".into(),
             status: "Completed".into(),
             kind: ToolCallKind::Execute,
@@ -2675,6 +2948,7 @@ mod tests {
         let messages = (0..4)
             .map(|index| ChatMessage::ToolCall {
                 id: format!("read-{index}"),
+                query: None,
                 title: "Read project".into(),
                 status: "Completed".into(),
                 kind: ToolCallKind::Read,
@@ -2711,6 +2985,7 @@ mod tests {
             .enumerate()
             .map(|(index, (path, status))| ChatMessage::ToolCall {
                 id: format!("mutation-{index}"),
+                query: None,
                 title: "Mutate file".into(),
                 status: status.into(),
                 kind,
@@ -2740,6 +3015,7 @@ mod tests {
             .enumerate()
             .map(|(index, status)| ChatMessage::ToolCall {
                 id: format!("edit-{index}"),
+                query: None,
                 title: "Edit file".into(),
                 status: status.into(),
                 kind: ToolCallKind::Edit,
@@ -2761,6 +3037,7 @@ mod tests {
         let location = concat!("C:", "\\", "repo", "\\", "large.txt");
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Read file".into(),
             status: "Running".into(),
             kind: ToolCallKind::Read,
@@ -2957,6 +3234,7 @@ mod tests {
             .collect::<Vec<_>>();
         let message = ChatMessage::ToolCall {
             id: "tool".into(),
+            query: None,
             title: "Update source".into(),
             status: "Completed".into(),
             kind: ToolCallKind::Edit,
@@ -3144,6 +3422,7 @@ mod tests {
     fn permission_animates_only_its_matching_tool_call() {
         let matching = ChatMessage::ToolCall {
             id: "tool-2".into(),
+            query: None,
             title: "Read Cargo.toml".into(),
             status: "Completed".into(),
             kind: ToolCallKind::Read,
@@ -3157,6 +3436,7 @@ mod tests {
         };
         let other = ChatMessage::ToolCall {
             id: "tool-1".into(),
+            query: None,
             title: "Find files".into(),
             status: "Completed".into(),
             kind: ToolCallKind::Search,
@@ -3181,6 +3461,7 @@ mod tests {
         for status in ["Pending", "InProgress", "running"] {
             let message = ChatMessage::ToolCall {
                 id: "tool".into(),
+                query: None,
                 title: "Find files".into(),
                 status: status.into(),
                 kind: ToolCallKind::Search,


### PR DESCRIPTION
## Summary

Search/tool-disclosure change based directly on `main`. The thinking UI is already merged via https://github.com/microsoft/intelligent-terminal/pull/899; this PR adds only Search/tool details and preserves the existing thinking behavior.

- Expand tool headers and grouped tool rows during the active turn as well as in completed history; support Ctrl+O and preserve safe click/drag behavior.
- Retain provider-supplied `rawInput.query` independently of abbreviated titles, including initial calls without a kind and subsequent partial updates.
- Wrap and scroll through all retained query text (up to 4,000 Unicode characters). Show bounded provider result text with explicit truncation markers; never invent missing queries or results.
- Preserve disclosure across turn completion and anchor the viewport when expanding live details.

## Validation

- `cargo fmt --manifest-path tools\wta\Cargo.toml`
- `cargo test --target x86_64-pc-windows-msvc --manifest-path tools\wta\Cargo.toml`: 2,165 passed, 1 ignored.
- Regression coverage for query retention, deferred tool kinds, partial updates, long-query wrapping, result replacement, live/completed disclosure, grouped hits, drag/stale-click safety, and scrolled viewport geometry.
<img width="2257" height="127" alt="image" src="https://github.com/user-attachments/assets/7e8d6e94-5b24-423a-9848-a5fc81171138" />
<img width="2293" height="498" alt="image" src="https://github.com/user-attachments/assets/f1aa269e-7f6b-486a-a24c-9ff816250288" />