### PR TITLE
Hide workspace button until general availability

### DIFF
--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2066,7 +2066,7 @@
           "$ref": "#/$defs/ThemeColor"
         },
         "showWorkspacesButton": {
-          "description": "When set to true, the workspaces button will be shown in the tab row.",
+          "description": "Controls visibility of the workspaces button in the tab row. Currently ignored: the button is hidden until the workspace feature is generally available.",
           "type": "boolean",
           "default": true
         }

--- a/doc/cascadia/profiles.schema.json
+++ b/doc/cascadia/profiles.schema.json
@@ -2066,7 +2066,7 @@
           "$ref": "#/$defs/ThemeColor"
         },
         "showWorkspacesButton": {
-          "description": "Controls visibility of the workspaces button in the tab row. Currently ignored: the button is hidden until the workspace feature is generally available.",
+          "description": "Currently ignored. The workspaces button remains hidden until the workspace feature is generally available.",
           "type": "boolean",
           "default": true
         }

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -55,7 +55,7 @@
                           Glyph="&#xEA18;"
                           Visibility="{x:Bind ShowElevationShield, Mode=OneWay}" />
 
-                <!--  Keep the workspace entry point hidden until the feature is generally available.  -->
+                <!--  Keep this button collapsed regardless of showWorkspacesButton until the workspace feature is generally available.  -->
                 <Button x:Name="WorkspaceDropdown"
                         x:Uid="WorkspaceDropdown"
                         Margin="4,0,0,4"

--- a/src/cascadia/TerminalApp/TabRowControl.xaml
+++ b/src/cascadia/TerminalApp/TabRowControl.xaml
@@ -55,7 +55,7 @@
                           Glyph="&#xEA18;"
                           Visibility="{x:Bind ShowElevationShield, Mode=OneWay}" />
 
-                <!--  Workspace/windows button  -->
+                <!--  Keep the workspace entry point hidden until the feature is generally available.  -->
                 <Button x:Name="WorkspaceDropdown"
                         x:Uid="WorkspaceDropdown"
                         Margin="4,0,0,4"
@@ -63,7 +63,7 @@
                         VerticalAlignment="Stretch"
                         Background="Transparent"
                         BorderThickness="0"
-                        Visibility="{x:Bind ShowWorkspacesButton, Mode=OneWay}">
+                        Visibility="Collapsed">
                     <Button.Content>
                         <StackPanel Orientation="Horizontal"
                                     Spacing="8">


### PR DESCRIPTION
## Summary of the Pull Request
Hide the workspace button until the workspace feature is generally available.

## References and Relevant Issues
None.

## Detailed Description of the Pull Request / Additional comments
- Set the workspace button visibility to `Collapsed`, so it is hidden and takes no layout space.
- Preserve existing workspace functionality and flyout wiring for future enablement.
- Document that `showWorkspacesButton` is temporarily ignored, including when explicitly set to `true`.

## Validation Steps Performed
- Verified the XAML keeps `WorkspaceDropdown` collapsed and retains `WorkspaceFlyout`.
- Parsed the settings schema and ran `git diff --check`.
- Built TerminalApp Debug and the x64 Debug package successfully (existing warnings remain).
- Deployed the Debug package and verified the updated application opened and was responsive. Visual acceptance testing is left to the user.

## PR Checklist
- [x] Documentation updated (fork-specific schema description)
- [x] Schema updated
- [x] Debug build and deployment completed
- [x] Manual visual acceptance testing completed
<img width="1145" height="72" alt="image" src="https://github.com/user-attachments/assets/a4d2bf71-ccf9-423a-a9c3-e05a736fe1f3" />
