### PR TITLE
Fix auth render test locale race

### DIFF
--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -11278,6 +11278,8 @@ fn copilot_login_failure_without_reason_shows_generic_message() {
 /// guidance. Regression guard for the "error on the first line" report.
 #[test]
 fn render_auth_copilot_failure_shows_reason_and_guidance_at_bottom() {
+    let _locale = crate::test_support::lock_locale();
+    rust_i18n::set_locale("en-US");
     let mut app = test_app();
     app.mode = AppMode::Auth;
     app.auth = Some(AuthState {


### PR DESCRIPTION
## Summary
- serialize the Copilot auth render test with the shared locale lock
- pin the test to en-US so parallel localization tests cannot inject wide-character output

## Testing
- cargo test --target i686-pc-windows-msvc --manifest-path tools/wta/Cargo.toml render_auth_copilot_failure_shows_reason_and_guidance_at_bottom