### PR TITLE
Defer automatic WSL installation and skip repeated commandlines

### DIFF
--- a/src/cascadia/TerminalApp/AgentPaneLog.h
+++ b/src/cascadia/TerminalApp/AgentPaneLog.h
@@ -42,8 +42,22 @@ namespace winrt::TerminalApp::implementation
         return ::IntelligentTerminal::LogDirVersioned();
     }
 
-    inline void _agentPaneLog(const std::string& msg)
+    enum class AgentPaneLogLevel
     {
+        Info,
+        Debug,
+    };
+
+    inline void _agentPaneLog(const std::string& msg, AgentPaneLogLevel level = AgentPaneLogLevel::Info)
+    {
+#if !defined(_DEBUG)
+        if (level == AgentPaneLogLevel::Debug)
+        {
+            return;
+        }
+#else
+        (void)level;
+#endif
         std::filesystem::path logDir = _intelligentTerminalLogDir();
         if (logDir.empty())
         {

--- a/src/cascadia/TerminalApp/AppActionHandlers.cpp
+++ b/src/cascadia/TerminalApp/AppActionHandlers.cpp
@@ -1971,12 +1971,9 @@ namespace winrt::TerminalApp::implementation
         const auto weak = get_weak();
         const auto dispatcher = Dispatcher();
 
-        // Snapshot WSL profile commandlines AND which non-WSL shells the user has
-        // profiles for, on the UI thread BEFORE we go background.
-        // _settings.AllProfiles() is an observable vector; iterating it
-        // concurrently with a settings reload would be unsafe.
-        const auto wslCommandlines = ShellIntegrationSweep::SnapshotWslCommandlines(_settings);
-        const auto shellPresence = ShellIntegrationSweep::SnapshotShellPresence(_settings);
+        const auto installShellIntegration = ShellIntegrationSweep::PrepareInstall(
+            _settings,
+            ShellIntegrationSweep::InstallTargets::All);
 
         co_await winrt::resume_background();
 
@@ -2017,7 +2014,7 @@ namespace winrt::TerminalApp::implementation
                 // Skipped shells are reported as success-already-installed
                 // so the all-installed / any-failure UI verdict below
                 // doesn't flag a missing shell as a failure.
-                const auto results = ShellIntegrationSweep::RunInstall(shellPresence, wslCommandlines);
+                const auto results = installShellIntegration();
 
                 // Aggregate verdict across ALL four flavors (pwsh, WinPS,
                 // bash, every WSL distro). The earlier two-flavor version
@@ -2056,15 +2053,15 @@ namespace winrt::TerminalApp::implementation
 
                 allAlreadyInstalled = true; // becomes false on first non-alreadyInstalled below
 
-                if (shellPresence.pwsh)
+                if (results.shellPresence.pwsh)
                 {
                     consider(results.pwsh, L"PowerShell");
                 }
-                if (shellPresence.windowsPowerShell)
+                if (results.shellPresence.windowsPowerShell)
                 {
                     consider(results.windowsPowerShell, L"Windows PowerShell");
                 }
-                if (shellPresence.bash)
+                if (results.shellPresence.bash)
                 {
                     consider(results.bash, L"bash");
                 }
@@ -2204,7 +2201,8 @@ namespace winrt::TerminalApp::implementation
             // profile for. A user keeping only "Developer PowerShell
             // for VS" (which uses Windows PowerShell) and no pwsh
             // profile must not get pwsh integration written.
-            (void)ShellIntegrationSweep::RunInstall(shellPresence, wslCommandlines);
+            // GH#613: startup/settings reloads leave WSL to the lazy new-tab path.
+            (void)ShellIntegrationSweep::RunInstall(shellPresence, {}, ShellIntegrationSweep::InstallTargets::WindowsShells);
         }
         else
         {

--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -1833,12 +1833,9 @@ namespace winrt::TerminalApp::implementation
             _BeginProgressStep(ProgressStep::ErrorDetection);
             _agentPaneLog("[FRE] Installing shell integration");
 
-            // Snapshot WSL distros AND non-WSL shell presence on the UI
-            // thread BEFORE resuming on a background thread —
-            // _settings.AllProfiles() is an observable vector and
-            // iterating it concurrently with a settings reload is unsafe.
-            const auto wslCommandlines = ShellIntegrationSweep::SnapshotWslCommandlines(_settings);
-            const auto shellPresence = ShellIntegrationSweep::SnapshotShellPresence(_settings);
+            const auto installShellIntegration = ShellIntegrationSweep::PrepareInstall(
+                _settings,
+                ShellIntegrationSweep::InstallTargets::All);
 
             co_await winrt::resume_background();
             // Profile-gated install: a user keeping only "Developer
@@ -1847,7 +1844,7 @@ namespace winrt::TerminalApp::implementation
             // RunInstall reports a skipped shell as
             // success-already-installed so the FRE failure verdict
             // (below) doesn't flag a missing shell as a failure.
-            const auto results = ShellIntegrationSweep::RunInstall(shellPresence, wslCommandlines);
+            const auto results = installShellIntegration();
             const auto& pwsh7Result = results.pwsh;
             const auto& windowsPsResult = results.windowsPowerShell;
             const auto& bashResult = results.bash;

--- a/src/cascadia/TerminalApp/ShellIntegrationSweep.h
+++ b/src/cascadia/TerminalApp/ShellIntegrationSweep.h
@@ -3,18 +3,19 @@
 //
 // ShellIntegrationSweep.h
 //
-// Shared profile snapshot + install/uninstall sweep used by all three
+// Shared profile snapshot + install/uninstall sweep used by the
 // shell-integration entry points:
 //   • FreOverlay::Save           — FRE wizard "Install" button
 //   • TerminalPage::_InitShellIntegration — Settings UI "Install" button
 //   • TerminalPage::_ReconcileShellIntegration — startup + settings reload
+//   • QueueNewTabWslInstallWork  — lazy new-tab WSL install
 //
-// All three need the same two-phase pattern:
+// The sweep callers need the same two-phase pattern:
 //
 //   1. Snapshot the live `_settings.AllProfiles()` ON THE UI THREAD
 //      (the observable vector races with settings reload). The
 //      snapshot is two cheap copies:
-//        - WSL distro names (deduped, malformed entries dropped)
+//        - WSL profile commandlines (deduped by exact string)
 //        - non-WSL ShellPresence bitset (pwsh / WinPS / Git Bash)
 //
 //   2. Run the install OR uninstall sweep on a background thread,
@@ -34,11 +35,22 @@
 // then toggles off — the X block in their HOME survives. This matches
 // the install-time policy (profile presence is the gate), and the
 // next reconcile after re-adding the X profile will sweep it.
+//
+// GH#613: startup omits WSL only from the shared INSTALL path by selecting a
+// native-shell target set. Explicit one-time setup (FRE / Settings "Install")
+// and the new-tab path share the same low-level WSL installer, keyed once per
+// exact commandline for the life of the process.
 
 #pragma once
 
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <optional>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "../inc/ShellIntegration.h"
@@ -51,6 +63,7 @@ namespace winrt::TerminalApp::implementation::ShellIntegrationSweep
 {
     namespace SI = ::Microsoft::Terminal::ShellIntegration;
     using CascadiaSettings = ::winrt::Microsoft::Terminal::Settings::Model::CascadiaSettings;
+    using GlobalAppSettings = ::winrt::Microsoft::Terminal::Settings::Model::GlobalAppSettings;
     using Profile = ::winrt::Microsoft::Terminal::Settings::Model::Profile;
 
     // Bitset of "user has at least one profile for this shell".
@@ -61,6 +74,34 @@ namespace winrt::TerminalApp::implementation::ShellIntegrationSweep
         bool windowsPowerShell{ false };
         bool bash{ false };
     };
+
+    enum class InstallTargets : uint8_t
+    {
+        None = 0x00,
+        Pwsh = 0x01,
+        WindowsPowerShell = 0x02,
+        Bash = 0x04,
+        Wsl = 0x08,
+        WindowsShells = 0x07, // Pwsh | WindowsPowerShell | Bash (Git Bash)
+        All = 0xFF,
+    };
+
+    constexpr InstallTargets operator|(InstallTargets lhs, InstallTargets rhs) noexcept
+    {
+        return static_cast<InstallTargets>(static_cast<uint8_t>(lhs) | static_cast<uint8_t>(rhs));
+    }
+
+    constexpr bool HasInstallTarget(InstallTargets set, InstallTargets flag) noexcept
+    {
+        return (static_cast<uint8_t>(set) & static_cast<uint8_t>(flag)) == static_cast<uint8_t>(flag);
+    }
+
+    static_assert(HasInstallTarget(InstallTargets::Pwsh, InstallTargets::Pwsh));
+    static_assert(HasInstallTarget(InstallTargets::Pwsh | InstallTargets::Bash, InstallTargets::Bash));
+    static_assert(!HasInstallTarget(InstallTargets::None, InstallTargets::Pwsh));
+    static_assert(!HasInstallTarget(InstallTargets::WindowsShells, InstallTargets::Wsl));
+    static_assert(HasInstallTarget(InstallTargets::All, static_cast<InstallTargets>(0x10)));
+    static_assert(!HasInstallTarget(InstallTargets::WindowsShells, static_cast<InstallTargets>(0x10)));
 
     // Return the profile's launch commandline IF it is a WSL profile
     // (else empty). Uses the pure SI::IsWslProfile predicate (unit-tested in
@@ -88,13 +129,7 @@ namespace winrt::TerminalApp::implementation::ShellIntegrationSweep
         return std::wstring{ cmd };
     }
 
-    // Snapshot the user's distinct WSL profile commandlines. MUST be called
-    // on the UI thread — settings.AllProfiles() is an observable vector and
-    // iterating concurrently with a reload is unsafe. Deduped by commandline
-    // (two profiles launching the identical command touch the distro once;
-    // two profiles for the SAME distro via different commands are probed
-    // separately but converge on the same \\wsl$ path, which the installer
-    // handles idempotently).
+    // Uninstall retains its commandline-deduplicated snapshot.
     inline std::vector<std::wstring> SnapshotWslCommandlines(const CascadiaSettings& settings)
     {
         std::vector<std::wstring> out;
@@ -106,11 +141,7 @@ namespace winrt::TerminalApp::implementation::ShellIntegrationSweep
         for (const auto& profile : settings.AllProfiles())
         {
             auto cmd = WslProfileCommandline(profile);
-            if (cmd.empty())
-            {
-                continue;
-            }
-            if (seen.insert(cmd).second)
+            if (!cmd.empty() && seen.insert(cmd).second)
             {
                 out.emplace_back(std::move(cmd));
             }
@@ -159,19 +190,33 @@ namespace winrt::TerminalApp::implementation::ShellIntegrationSweep
     // without Git Bash / running WSL shouldn't see a false-alarm).
     struct InstallSweepResults
     {
+        ShellPresence shellPresence;
         SI::InstallResult pwsh{ true, true, {}, false };       // skipped → already-installed
         SI::InstallResult windowsPowerShell{ true, true, {}, false };
         SI::InstallResult bash{ true, true, {}, false };
         std::vector<std::pair<std::wstring, SI::InstallResult>> wsl;
     };
 
+    inline void LogWslInstallDiagnostic(std::wstring_view commandline, std::string_view event) noexcept
+    try
+    {
+        _agentPaneLog("[ShellIntegration][debug][WSL] install event=" + std::string{ event } +
+                      " pid=" + std::to_string(GetCurrentProcessId()) +
+                      " commandline=" + winrt::to_string(winrt::hstring{ commandline }),
+                      AgentPaneLogLevel::Debug);
+    }
+    CATCH_LOG()
+
     // Run the install sweep using the provided snapshot. Touches only
-    // shells the user has a profile for; touches each WSL distro once.
+    // shells the user has a profile for; touches each distinct WSL commandline
+    // at most once.
     // Synchronous — call from a background thread.
     inline InstallSweepResults RunInstall(const ShellPresence& shellPresence,
-                                          const std::vector<std::wstring>& wslCommandlines)
+                                          const std::vector<std::wstring>& wslCommandlines,
+                                          InstallTargets targets = InstallTargets::All)
     {
         InstallSweepResults r{};
+        r.shellPresence = shellPresence;
         // PowerShell hosts: the $PROFILE WRITE is profile-gated, but the
         // execution-policy VERDICT is unconditional — a Restricted / AllSigned
         // policy must stop FRE / Save even when the user has no Windows
@@ -211,30 +256,52 @@ namespace winrt::TerminalApp::implementation::ShellIntegrationSweep
                           " -> " + (blocked ? "BLOCKED" : "not-blocked"));
             return blocked;
         };
-        r.pwsh = SI::ResolvePowerShellHostInstall(
-            shellPresence.pwsh,
-            probeExecutionPolicyBlocked(SI::Target::Pwsh, "pwsh"),
-            [&] { return installSkippingPolicyProbe(SI::Target::Pwsh); });
-        r.windowsPowerShell = SI::ResolvePowerShellHostInstall(
-            shellPresence.windowsPowerShell,
-            probeExecutionPolicyBlocked(SI::Target::WindowsPowerShell, "winPs"),
-            [&] { return installSkippingPolicyProbe(SI::Target::WindowsPowerShell); });
-        if (shellPresence.bash)
+        if (HasInstallTarget(targets, InstallTargets::Pwsh))
+        {
+            r.pwsh = SI::ResolvePowerShellHostInstall(
+                shellPresence.pwsh,
+                probeExecutionPolicyBlocked(SI::Target::Pwsh, "pwsh"),
+                [&] { return installSkippingPolicyProbe(SI::Target::Pwsh); });
+        }
+        if (HasInstallTarget(targets, InstallTargets::WindowsPowerShell))
+        {
+            r.windowsPowerShell = SI::ResolvePowerShellHostInstall(
+                shellPresence.windowsPowerShell,
+                probeExecutionPolicyBlocked(SI::Target::WindowsPowerShell, "winPs"),
+                [&] { return installSkippingPolicyProbe(SI::Target::WindowsPowerShell); });
+        }
+        if (HasInstallTarget(targets, InstallTargets::Bash) && shellPresence.bash)
         {
             r.bash = SI::InstallForTarget(SI::Target::Bash);
         }
-        r.wsl.reserve(wslCommandlines.size());
-        for (const auto& cmd : wslCommandlines)
+        if (HasInstallTarget(targets, InstallTargets::Wsl))
         {
-            const auto res = SI::InstallWslBash(cmd);
-            // Label the result by the distro name the install probe resolved
-            // (cache-only read — no extra spawn), so error dialogs show e.g.
-            // "WSL bash (Ubuntu)" rather than the raw launch commandline.
-            // Falls back to the commandline when the probe never succeeded.
-            auto name = SI::Wsl::ProbedDistroName(cmd);
-            r.wsl.emplace_back(name.empty() ? cmd : std::move(name), res);
+            r.wsl.reserve(wslCommandlines.size());
+            for (const auto& cmd : wslCommandlines)
+            {
+                const auto res = SI::Wsl::Install(cmd, &LogWslInstallDiagnostic);
+                auto name = SI::Wsl::ProbedDistroName(cmd);
+                r.wsl.emplace_back(name.empty() ? cmd : std::move(name), res);
+            }
         }
         return r;
+    }
+
+    // Snapshot on the UI thread; the returned callable uses only copied data
+    // and must run on a background thread. TerminalPage callers additionally
+    // hold their reconcile lock to serialize against settings changes.
+    inline auto PrepareInstall(const CascadiaSettings& settings, InstallTargets targets = InstallTargets::All)
+    {
+        const auto shellPresence = SnapshotShellPresence(settings);
+        auto wslCommandlines = std::vector<std::wstring>{};
+        if (HasInstallTarget(targets, InstallTargets::Wsl))
+        {
+            wslCommandlines = SnapshotWslCommandlines(settings);
+        }
+
+        return [shellPresence, wslCommandlines = std::move(wslCommandlines), targets]() {
+            return RunInstall(shellPresence, wslCommandlines, targets);
+        };
     }
 
     // Run the uninstall sweep using the provided snapshot. Mirrors
@@ -261,4 +328,81 @@ namespace winrt::TerminalApp::implementation::ShellIntegrationSweep
             (void)SI::UninstallWslBash(cmd);
         }
     }
+
+    template<typename InstallFn>
+    inline safe_void_coroutine EnsureWslInstalledForNewTab(winrt::hstring actualCommandline,
+                                                           InstallFn install)
+    {
+        if (actualCommandline.empty() || !SI::IsWslProfile(std::wstring_view{ actualCommandline }))
+        {
+            co_return;
+        }
+
+        co_await winrt::resume_background();
+
+        const auto result = install(std::wstring_view{ actualCommandline });
+        if (result && !result->success)
+        {
+            _agentPaneLog("[ShellIntegration] WSL new-tab install FAILED for " +
+                          winrt::to_string(actualCommandline) +
+                          (result->errorMessage.empty() ? std::string{} : " error=" + winrt::to_string(winrt::hstring{ result->errorMessage })));
+        }
+    }
+
+    template<typename TerminalContent, typename PaneType, typename OwnerLifetime>
+    inline void QueueNewTabWslInstallWork(const GlobalAppSettings& globals,
+                                          const std::shared_ptr<PaneType>& pane,
+                                          OwnerLifetime ownerLifetime,
+                                          std::atomic<bool>& desiredEnabledState,
+                                          std::mutex& reconcileMutex) noexcept
+    try
+    {
+        if (!pane || !globals.HasAutoErrorDetectionEnabled() || !globals.EffectiveAutoErrorDetectionEnabled())
+        {
+            return;
+        }
+
+        // Publish the current UI-thread enabled intent before queuing; FRE direct-settings
+        // saves also reach this path, but the state here reflects the present enabled request.
+        desiredEnabledState.store(true, std::memory_order_release);
+
+        const auto install = [ownerLifetime = std::move(ownerLifetime), &desiredEnabledState, &reconcileMutex](std::wstring_view commandline) -> std::optional<SI::InstallResult> {
+            (void)ownerLifetime;
+            if (!desiredEnabledState.load(std::memory_order_acquire))
+            {
+                return std::nullopt;
+            }
+            // The common commandline gate runs before this potentially long lock.
+            const auto performInstall = [&](std::wstring_view selectedCommandline) -> SI::InstallResult {
+                std::lock_guard<std::mutex> guard{ reconcileMutex };
+                if (!desiredEnabledState.load(std::memory_order_acquire))
+                {
+                    return { true, true, {} };
+                }
+                return SI::Wsl::details::InstallShellIntegration(selectedCommandline);
+            };
+            return SI::Wsl::Install(commandline, performInstall, &LogWslInstallDiagnostic);
+        };
+
+        pane->WalkTree([&](const std::shared_ptr<PaneType>& leaf) noexcept {
+            try
+            {
+                const auto terminal = leaf->GetContent().template try_as<TerminalContent>();
+                if (!terminal)
+                {
+                    return;
+                }
+                const auto control = terminal.GetTermControl();
+                if (!control)
+                {
+                    return;
+                }
+
+                EnsureWslInstalledForNewTab(control.Settings().Commandline(), install);
+            }
+            CATCH_LOG()
+        });
+    }
+    CATCH_LOG()
+
 }

--- a/src/cascadia/TerminalApp/TabManagement.cpp
+++ b/src/cascadia/TerminalApp/TabManagement.cpp
@@ -19,6 +19,7 @@
 
 #include "AgentPaneContent.h"
 #include "AgentPaneLog.h"
+#include "ShellIntegrationSweep.h"
 #include "SharedWta.h"
 #include "TabRowControl.h"
 #include "DebugTapConnection.h"
@@ -368,6 +369,12 @@ namespace winrt::TerminalApp::implementation
                     CATCH_LOG()
                 }
             });
+            ShellIntegrationSweep::QueueNewTabWslInstallWork<winrt::TerminalApp::TerminalPaneContent>(
+                _settings.GlobalSettings(),
+                pane,
+                get_strong(),
+                _shellIntegrationDesiredEnabled,
+                _shellIntegrationReconcileMutex);
             auto newTabImpl = winrt::make_self<Tab>(pane);
             if (_receivingContentTransfer)
             {

--- a/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
+++ b/src/cascadia/UnitTests_TerminalCore/ShellIntegrationTests.cpp
@@ -10,12 +10,16 @@
 
 #include "pch.h"
 #include <WexTestClass.h>
-
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <string>
 #include <string_view>
+#include <thread>
+#include <vector>
 
 #include "../inc/ShellIntegration.h"
 
@@ -30,6 +34,60 @@ namespace TerminalCoreUnitTests
     class ShellIntegrationTests;
 };
 using namespace TerminalCoreUnitTests;
+
+namespace
+{
+    struct WslInstallObserverEvent
+    {
+        std::wstring commandline;
+        std::string event;
+    };
+
+    std::mutex g_wslInstallObserverMutex;
+    std::vector<WslInstallObserverEvent> g_wslInstallObserverEvents;
+
+    void ObserveWslInstall(std::wstring_view commandline, std::string_view event) noexcept
+    {
+        std::lock_guard lock{ g_wslInstallObserverMutex };
+        g_wslInstallObserverEvents.emplace_back(WslInstallObserverEvent{
+            std::wstring{ commandline },
+            std::string{ event },
+        });
+    }
+
+    size_t WslInstallObserverEventCount()
+    {
+        std::lock_guard lock{ g_wslInstallObserverMutex };
+        return g_wslInstallObserverEvents.size();
+    }
+
+    std::vector<std::string> WslInstallObserverEventsSince(std::wstring_view commandline, size_t startIndex)
+    {
+        std::vector<std::string> events;
+        std::lock_guard lock{ g_wslInstallObserverMutex };
+        for (size_t i = startIndex; i < g_wslInstallObserverEvents.size(); ++i)
+        {
+            const auto& observed = g_wslInstallObserverEvents[i];
+            if (observed.commandline == commandline)
+            {
+                events.emplace_back(observed.event);
+            }
+        }
+        return events;
+    }
+
+    void VerifyWslInstallObserverEvents(std::wstring_view commandline,
+                                        size_t startIndex,
+                                        const std::vector<std::string>& expected)
+    {
+        const auto actual = WslInstallObserverEventsSince(commandline, startIndex);
+        VERIFY_ARE_EQUAL(expected.size(), actual.size());
+        for (size_t i = 0; i < expected.size(); ++i)
+        {
+            VERIFY_ARE_EQUAL(expected[i], actual[i]);
+        }
+    }
+}
 
 class TerminalCoreUnitTests::ShellIntegrationTests final
 {
@@ -143,7 +201,7 @@ class TerminalCoreUnitTests::ShellIntegrationTests final
 
     TEST_METHOD(Bash_InstallUninstallInstall_RoundTrip);
 
-    // ─── WSL flavor (helpers only — Install/UninstallWslBash requires real WSL) ──
+    // ─── WSL flavor (helpers only — InstallWslBash requires real WSL) ──
     TEST_METHOD(Wsl_IsSafeDistroName_AcceptsCommonNames);
     TEST_METHOD(Wsl_IsSafeDistroName_RejectsInjection);
     TEST_METHOD(Wsl_IsSafeDistroName_RejectsEmptyAndOverlong);
@@ -153,6 +211,12 @@ class TerminalCoreUnitTests::ShellIntegrationTests final
     TEST_METHOD(Wsl_UncPath_BuildsExpectedFormat);
     TEST_METHOD(Wsl_StripExecTail_StripsExistingExecCommand);
     TEST_METHOD(Wsl_QualifyBareLauncher_QualifiesBareWslBash);
+
+    TEST_METHOD(Wsl_Install_DuplicateCommandlineSkipsAfterCompletion);
+    TEST_METHOD(Wsl_Install_DuplicateCommandlineSkipsWhileInFlight);
+    TEST_METHOD(Wsl_Install_DistinctCommandlinesInstallIndependently);
+    TEST_METHOD(Wsl_Install_FailureAndExceptionConsumeAttempt);
+    TEST_METHOD(Wsl_Install_DiagnosticObserver_TracksDecision);
 
     // Profile-presence gate (ShellIntegrationProfileGate.h)
     TEST_METHOD(ProfileGate_PwshSourceMatches);
@@ -265,6 +329,28 @@ private:
             }
         }
         return n;
+    }
+
+    static std::wstring _UniqueWslInstallCommandline()
+    {
+        static std::atomic<uint64_t> counter{ 0 };
+        return L"wsl.exe -d shell-integration-test-" + std::to_wstring(counter.fetch_add(1, std::memory_order_relaxed));
+    }
+
+    static InstallResult _SuccessfulWslInstall(const bool alreadyInstalled = false)
+    {
+        InstallResult result;
+        result.success = true;
+        result.alreadyInstalled = alreadyInstalled;
+        return result;
+    }
+
+    static InstallResult _FailedWslInstall(std::wstring_view message)
+    {
+        InstallResult result;
+        result.success = false;
+        result.errorMessage = std::wstring{ message };
+        return result;
     }
 };
 
@@ -1720,7 +1806,7 @@ void ShellIntegrationTests::Bash_InstallUninstallInstall_RoundTrip()
 // ═════════════════════════════════════════════════════════════════════════════
 // WSL flavor
 //
-// Install/UninstallWslBash require a real running WSL distro on the host —
+// InstallWslBash requires a real running WSL distro on the host —
 // we cover only the pure-function helpers here. The shared UNC-mediated
 // write path is already covered by the Bash_* tests; once
 // QueryWslIdentityRaw returns successfully the implementation IS
@@ -1889,6 +1975,286 @@ void ShellIntegrationTests::Wsl_QualifyBareLauncher_QualifiesBareWslBash()
     VERIFY_ARE_EQUAL(std::wstring{ L"\"C:\\X\\wsl.exe\" -d Ubuntu" },
                      QualifyBareLauncher(L"\"C:\\X\\wsl.exe\" -d Ubuntu"));
     VERIFY_ARE_EQUAL(std::wstring{ L"cmd.exe /c wsl" }, QualifyBareLauncher(L"cmd.exe /c wsl"));
+}
+
+// ───────────────────────────────────────────────────────────────────
+// Wsl::Install (GH#613) — exact-commandline gate shared by explicit install
+// flows and the lazy new-tab reconcile. Non-WSL filtering stays at the
+// callers; IsWslProfile tests below cover that recognizer.
+// ───────────────────────────────────────────────────────────────────
+
+void ShellIntegrationTests::Wsl_Install_DuplicateCommandlineSkipsAfterCompletion()
+{
+    using Microsoft::Terminal::ShellIntegration::Wsl::Install;
+
+    const auto commandline = _UniqueWslInstallCommandline();
+    size_t installCalls = 0;
+
+    const auto firstResult = Install(
+        commandline,
+        [&](std::wstring_view actualCommandline) {
+            ++installCalls;
+            VERIFY_ARE_EQUAL(commandline, std::wstring{ actualCommandline });
+            return _SuccessfulWslInstall();
+        },
+        nullptr);
+
+    const auto secondResult = Install(
+        commandline,
+        [&](std::wstring_view) {
+            ++installCalls;
+            return _SuccessfulWslInstall();
+        },
+        nullptr);
+
+    VERIFY_IS_TRUE(firstResult.success);
+    VERIFY_IS_TRUE(secondResult.success);
+    VERIFY_ARE_EQUAL(static_cast<size_t>(1), installCalls);
+    VERIFY_IS_FALSE(firstResult.alreadyInstalled);
+    VERIFY_IS_TRUE(secondResult.alreadyInstalled);
+}
+
+void ShellIntegrationTests::Wsl_Install_DuplicateCommandlineSkipsWhileInFlight()
+{
+    using Microsoft::Terminal::ShellIntegration::Wsl::Install;
+
+    const auto commandline = _UniqueWslInstallCommandline();
+    std::mutex releaseMutex;
+    std::condition_variable releaseCv;
+    bool releaseFirst{ false };
+    std::atomic<size_t> firstCalls{ 0 };
+    std::atomic<size_t> secondCalls{ 0 };
+    std::promise<void> firstEnteredPromise;
+    auto firstEnteredFuture = firstEnteredPromise.get_future();
+    std::promise<InstallResult> firstResultPromise;
+    auto firstResultFuture = firstResultPromise.get_future();
+    std::promise<InstallResult> secondResultPromise;
+    auto secondResultFuture = secondResultPromise.get_future();
+
+    std::thread firstCaller{ [&]() {
+        try
+        {
+            firstResultPromise.set_value(Install(
+                commandline,
+                [&](std::wstring_view) {
+                    ++firstCalls;
+                    firstEnteredPromise.set_value();
+                    std::unique_lock lock{ releaseMutex };
+                    releaseCv.wait(lock, [&]() noexcept { return releaseFirst; });
+                    return _SuccessfulWslInstall();
+                },
+                nullptr));
+        }
+        catch (...)
+        {
+            firstResultPromise.set_exception(std::current_exception());
+        }
+    } };
+    std::thread secondCaller;
+    const auto joinThreads = wil::scope_exit([&]() noexcept {
+        {
+            std::lock_guard lock{ releaseMutex };
+            releaseFirst = true;
+        }
+        releaseCv.notify_all();
+        if (firstCaller.joinable())
+        {
+            firstCaller.join();
+        }
+        if (secondCaller.joinable())
+        {
+            secondCaller.join();
+        }
+    });
+
+    VERIFY_ARE_EQUAL(std::future_status::ready, firstEnteredFuture.wait_for(std::chrono::seconds{ 5 }));
+
+    secondCaller = std::thread{ [&]() {
+        try
+        {
+            secondResultPromise.set_value(Install(
+                commandline,
+                [&](std::wstring_view) {
+                    ++secondCalls;
+                    return _SuccessfulWslInstall();
+                },
+                nullptr));
+        }
+        catch (...)
+        {
+            secondResultPromise.set_exception(std::current_exception());
+        }
+    } };
+
+    VERIFY_ARE_EQUAL(std::future_status::ready, secondResultFuture.wait_for(std::chrono::seconds{ 5 }));
+    const auto secondResult = secondResultFuture.get();
+
+    {
+        std::lock_guard lock{ releaseMutex };
+        releaseFirst = true;
+    }
+    releaseCv.notify_all();
+
+    VERIFY_ARE_EQUAL(std::future_status::ready, firstResultFuture.wait_for(std::chrono::seconds{ 5 }));
+    const auto firstResult = firstResultFuture.get();
+
+    VERIFY_IS_TRUE(firstResult.success);
+    VERIFY_IS_TRUE(secondResult.success);
+    VERIFY_ARE_EQUAL(static_cast<size_t>(1), firstCalls.load());
+    VERIFY_ARE_EQUAL(static_cast<size_t>(0), secondCalls.load());
+    VERIFY_IS_TRUE(secondResult.alreadyInstalled);
+}
+
+void ShellIntegrationTests::Wsl_Install_DistinctCommandlinesInstallIndependently()
+{
+    using Microsoft::Terminal::ShellIntegration::Wsl::Install;
+
+    const auto baseCommandline = _UniqueWslInstallCommandline();
+    const auto alternateCommandline = baseCommandline + L" -e bash";
+    std::vector<std::wstring> invokedCommandlines;
+
+    const auto firstResult = Install(
+        baseCommandline,
+        [&](std::wstring_view commandline) {
+            invokedCommandlines.emplace_back(commandline);
+            return _SuccessfulWslInstall();
+        },
+        nullptr);
+
+    const auto secondResult = Install(
+        alternateCommandline,
+        [&](std::wstring_view commandline) {
+            invokedCommandlines.emplace_back(commandline);
+            return _SuccessfulWslInstall();
+        },
+        nullptr);
+
+    VERIFY_IS_TRUE(firstResult.success);
+    VERIFY_IS_TRUE(secondResult.success);
+    VERIFY_ARE_EQUAL(static_cast<size_t>(2), invokedCommandlines.size());
+    VERIFY_ARE_EQUAL(baseCommandline, invokedCommandlines[0]);
+    VERIFY_ARE_EQUAL(alternateCommandline, invokedCommandlines[1]);
+}
+
+void ShellIntegrationTests::Wsl_Install_FailureAndExceptionConsumeAttempt()
+{
+    using Microsoft::Terminal::ShellIntegration::Wsl::Install;
+
+    const auto failedCommandline = _UniqueWslInstallCommandline();
+    size_t failedCalls = 0;
+
+    const auto failedResult = Install(
+        failedCommandline,
+        [&](std::wstring_view) {
+            ++failedCalls;
+            return _FailedWslInstall(L"boom");
+        },
+        nullptr);
+
+    const auto failedRetryResult = Install(
+        failedCommandline,
+        [&](std::wstring_view) {
+            ++failedCalls;
+            return _SuccessfulWslInstall();
+        },
+        nullptr);
+
+    VERIFY_IS_FALSE(failedResult.success);
+    VERIFY_ARE_EQUAL(std::wstring{ L"boom" }, failedResult.errorMessage);
+    VERIFY_IS_TRUE(failedRetryResult.alreadyInstalled);
+    VERIFY_ARE_EQUAL(static_cast<size_t>(1), failedCalls);
+
+    const auto thrownCommandline = _UniqueWslInstallCommandline();
+    size_t thrownCalls = 0;
+    bool threw = false;
+
+    try
+    {
+        (void)Install(
+            thrownCommandline,
+            [&](std::wstring_view) -> InstallResult {
+                ++thrownCalls;
+                throw std::runtime_error{ "boom" };
+            },
+            nullptr);
+    }
+    catch (const std::exception&)
+    {
+        threw = true;
+    }
+
+    const auto thrownRetryResult = Install(
+        thrownCommandline,
+        [&](std::wstring_view) {
+            ++thrownCalls;
+            return _SuccessfulWslInstall();
+        },
+        nullptr);
+
+    VERIFY_IS_TRUE(threw);
+    VERIFY_IS_TRUE(thrownRetryResult.alreadyInstalled);
+    VERIFY_ARE_EQUAL(static_cast<size_t>(1), thrownCalls);
+}
+
+void ShellIntegrationTests::Wsl_Install_DiagnosticObserver_TracksDecision()
+{
+    using Microsoft::Terminal::ShellIntegration::Wsl::Install;
+
+    const auto completedCommandline = _UniqueWslInstallCommandline();
+    const auto noChangeCommandline = _UniqueWslInstallCommandline();
+    const auto failedCommandline = _UniqueWslInstallCommandline();
+    const auto thrownCommandline = _UniqueWslInstallCommandline();
+    const auto startIndex = WslInstallObserverEventCount();
+
+    const auto completedResult = Install(
+        completedCommandline,
+        [](std::wstring_view) {
+            return _SuccessfulWslInstall();
+        },
+        &ObserveWslInstall);
+    const auto skippedResult = Install(
+        completedCommandline,
+        [](std::wstring_view) {
+            return _SuccessfulWslInstall();
+        },
+        &ObserveWslInstall);
+    const auto noChangeResult = Install(
+        noChangeCommandline,
+        [](std::wstring_view) {
+            return _SuccessfulWslInstall(true);
+        },
+        &ObserveWslInstall);
+    const auto failedResult = Install(
+        failedCommandline,
+        [](std::wstring_view) {
+            return _FailedWslInstall(L"boom");
+        },
+        &ObserveWslInstall);
+
+    bool threw = false;
+    try
+    {
+        (void)Install(
+            thrownCommandline,
+            [](std::wstring_view) -> InstallResult {
+                throw std::runtime_error{ "boom" };
+            },
+            &ObserveWslInstall);
+    }
+    catch (const std::exception&)
+    {
+        threw = true;
+    }
+
+    VERIFY_IS_TRUE(completedResult.success);
+    VERIFY_IS_TRUE(skippedResult.alreadyInstalled);
+    VERIFY_IS_TRUE(noChangeResult.alreadyInstalled);
+    VERIFY_IS_FALSE(failedResult.success);
+    VERIFY_IS_TRUE(threw);
+    VerifyWslInstallObserverEvents(completedCommandline, startIndex, { "attempt-started", "completed", "skip-already-attempted" });
+    VerifyWslInstallObserverEvents(noChangeCommandline, startIndex, { "attempt-started", "no-change" });
+    VerifyWslInstallObserverEvents(failedCommandline, startIndex, { "attempt-started", "failed" });
+    VerifyWslInstallObserverEvents(thrownCommandline, startIndex, { "attempt-started", "thrown" });
 }
 
 // ───────────────────────────────────────────────────────────────────

--- a/src/cascadia/inc/WslShellIntegration.h
+++ b/src/cascadia/inc/WslShellIntegration.h
@@ -25,12 +25,16 @@
 
 #pragma once
 
+#include <mutex>
+#include <set>
+
 #include "ShellIntegrationCommon.h"
 #include "BashShellIntegration.h"
-#include "ShellIntegrationProfileGate.h"
 
 namespace Microsoft::Terminal::ShellIntegration::Wsl
 {
+    using InstallDiagnosticObserver = void (*)(std::wstring_view launchCommandline, std::string_view event) noexcept;
+
     namespace details
     {
         // True for distro names that are safe to embed verbatim in a
@@ -555,6 +559,37 @@ namespace Microsoft::Terminal::ShellIntegration::Wsl
             }
             return id;
         }
+
+        inline std::mutex& InstallAttemptedCommandlinesMutex() noexcept
+        {
+            static std::mutex mutex;
+            return mutex;
+        }
+
+        inline std::set<std::wstring, std::less<>>& InstallAttemptedCommandlines() noexcept
+        {
+            static std::set<std::wstring, std::less<>> commandlines;
+            return commandlines;
+        }
+
+        inline std::string_view InstallOutcomeEvent(const InstallResult& result) noexcept
+        {
+            if (!result.success)
+            {
+                return "failed";
+            }
+            return result.alreadyInstalled ? "no-change" : "completed";
+        }
+
+        inline void NotifyInstallDiagnostic(InstallDiagnosticObserver observer,
+                                            std::wstring_view launchCommandline,
+                                            std::string_view event) noexcept
+        {
+            if (observer)
+            {
+                observer(launchCommandline, event);
+            }
+        }
     }
 
     // Returns the distro name a prior Install/Uninstall already resolved for
@@ -660,17 +695,61 @@ namespace Microsoft::Terminal::ShellIntegration::Wsl
     // `C:\Windows\system32\wsl.exe --distribution-id {GUID}`,
     // `wsl.exe -d Ubuntu`, or `C:\Windows\System32\bash.exe`).
     //
-    // Synchronous — call from a background thread. The first call for each
-    // commandline can block up to 30s on a cold-start; subsequent calls
-    // return immediately from the cache.
-    inline InstallResult Install(const std::wstring& launchCommandline)
+    // Synchronous — call from a background thread. Each exact commandline gets
+    // one attempt per process, which can block up to 30s on a cold-start.
+    // Repeated calls return without waiting or retrying, even if the first
+    // attempt is still running or failed; they never reach the identity probe.
+    template<typename InstallFn>
+    inline InstallResult Install(std::wstring_view launchCommandline,
+                                 InstallFn&& install,
+                                 InstallDiagnosticObserver diagnosticObserver)
     {
-        WslBashFlavor flavor{ launchCommandline };
-        if (!flavor.Valid())
+        bool started;
         {
-            return { false, false, std::wstring{ flavor.ErrorMessage() } };
+            std::lock_guard<std::mutex> guard{ details::InstallAttemptedCommandlinesMutex() };
+            started = details::InstallAttemptedCommandlines().emplace(launchCommandline).second;
         }
-        return orchestrator::Install(flavor);
+        if (!started)
+        {
+            details::NotifyInstallDiagnostic(diagnosticObserver, launchCommandline, "skip-already-attempted");
+            return { true, true, {} };
+        }
+
+        details::NotifyInstallDiagnostic(diagnosticObserver, launchCommandline, "attempt-started");
+
+        try
+        {
+            const auto result = install(launchCommandline);
+            details::NotifyInstallDiagnostic(diagnosticObserver, launchCommandline, details::InstallOutcomeEvent(result));
+            return result;
+        }
+        catch (...)
+        {
+            details::NotifyInstallDiagnostic(diagnosticObserver, launchCommandline, "thrown");
+            throw;
+        }
+    }
+
+    namespace details
+    {
+        inline InstallResult InstallShellIntegration(std::wstring_view commandline)
+        {
+            WslBashFlavor flavor{ std::wstring{ commandline } };
+            if (!flavor.Valid())
+            {
+                return { false, false, std::wstring{ flavor.ErrorMessage() } };
+            }
+            return orchestrator::Install(flavor);
+        }
+    }
+
+    inline InstallResult Install(const std::wstring& launchCommandline,
+                                 InstallDiagnosticObserver diagnosticObserver = nullptr)
+    {
+        return Install(
+            std::wstring_view{ launchCommandline },
+            details::InstallShellIntegration,
+            diagnosticObserver);
     }
 
     inline InstallResult Uninstall(const std::wstring& launchCommandline)
@@ -686,4 +765,5 @@ namespace Microsoft::Terminal::ShellIntegration::Wsl
         }
         return orchestrator::Uninstall(flavor);
     }
+
 }


### PR DESCRIPTION
## Goal
Avoid starting WSL distros solely to install shell integration during automatic Terminal startup. Reuse the existing WSL installer and skip repeated installation attempts for the same commandline.

## Behavior
- Automatic startup installation runs for PowerShell, Windows PowerShell, and Git Bash only.
- First-run setup and explicit Settings installation still request all supported shells, including WSL.
- Opening a WSL tab schedules installation asynchronously without blocking tab startup.
- All WSL installation paths share one process-wide set of exact commandlines. Once a command is recorded, subsequent calls skip immediately, even while its first attempt is running. Restarting the app resets the set; failed attempts are not retried within the same process.
- Attempt/outcome/skip diagnostics use Debug level; installation failures remain Info level.
- Uninstall behavior is unchanged. Ordinary splits do not trigger the new-tab installation hook.

## Files
| File | Change |
|---|---|
| `TerminalApp/AgentPaneLog.h` | Add an optional log level and suppress Debug entries in Release builds. |
| `TerminalApp/AppActionHandlers.cpp` | Select Windows-shell installation at startup and use the prepared installation result in Settings. |
| `TerminalApp/FreOverlay.cpp` | Request installation for all supported shells through the shared preparation helper. |
| `TerminalApp/ShellIntegrationSweep.h` | Select shell targets, prepare existing profile snapshots, and schedule new-tab WSL installation. |
| `TerminalApp/TabManagement.cpp` | Call the shared helper at the existing new-tab creation boundary. |
| `inc/WslShellIntegration.h` | Record exact commandlines before installation and skip duplicate attempts while retaining the existing probe/write implementation. |
| `UnitTests_TerminalCore/ShellIntegrationTests.cpp` | Add focused tests for the shared installer and its diagnostic events. |

Paths are relative to `src/cascadia/`.

## Tests
- Targeted TerminalApp and TerminalCore unit-test builds passed.
- Five focused tests passed: duplicate after completion, duplicate while in flight, distinct commandlines, failure/exception handling, and diagnostic events.
- Manual dev testing covered first-run setup followed by WSL tabs, repeated Ubuntu/Debian tabs, and app restart. Logs showed one attempt per exact commandline per process and subsequent skips; Bash integration markers were confirmed.

Related to #613.