### PR TITLE
Fix deep scroll test locale race

### DIFF
--- a/tools/wta/src/app_tests.rs
+++ b/tools/wta/src/app_tests.rs
@@ -15334,6 +15334,8 @@ fn render_large_mixed_chat_keeps_latest_content_and_width_correct() {
 
 #[test]
 fn repeated_deep_scroll_reuses_intermediate_turn_heights() {
+    let _locale = crate::test_support::lock_locale();
+    rust_i18n::set_locale("en-US");
     let mut app = test_app();
     app.state = ConnectionState::Connected;
     for index in 0..200 {


### PR DESCRIPTION
## Summary

- serialize the deep-scroll render test with other locale-sensitive tests
- pin the test locale to en-US so parallel tests cannot change the rendered placeholder between frames

## Testing

- cargo test --target x86_64-pc-windows-msvc --manifest-path tools/wta/Cargo.toml