### PR TITLE
[DO NOT MERGE] P0 localization fork fixture: RESW addition + WTA update

### DIFF
--- a/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
+++ b/src/cascadia/CascadiaPackage/Resources/en-US/Resources.resw
@@ -197,4 +197,8 @@
     <value>Open in &amp;Intelligent Terminal</value>
     <comment>This is a menu item that will be displayed in the Windows File Explorer that launches Intelligent Terminal. Please mark one of the characters to be an accelerator key.</comment>
   </data>
+  <data name="ShellExtension_OpenInTerminalMenuItem_NewWindowDescription" xml:space="preserve">
+    <value>Open a new Intelligent Terminal window</value>
+    <comment>{Locked="Intelligent Terminal"} This is a short File Explorer description for the shell extension action. "Open a new" means launch another app window, not a new tab.</comment>
+  </data>
 </root>

--- a/tools/wta/locales/en-US.yml
+++ b/tools/wta/locales/en-US.yml
@@ -240,7 +240,8 @@ connection.lost: "Connection to the agent was lost. Type /restart to reconnect."
 # Shown as a one-line hint when the user presses Ctrl+C once with empty input — the second press closes the pane.
 # {Locked="Ctrl+C"} - key name, do not translate
 system.close_pane_hint: "Press Ctrl+C again to close pane"
-system.selection_copied: "Copied"  # Brief hint shown after selected terminal text is copied
+# Brief toast shown after selected terminal text is copied.
+system.selection_copied: "Selection copied"
 system.cancelled: "Cancelled."
 system.no_prompt_in_flight: "No prompt in flight."
 system.authentication_failed: "Authentication failed"


### PR DESCRIPTION
## Disposable localization P0 workflow fixture

DO NOT MERGE.

This fork PR intentionally makes the same source-only English localization changes as the official same-repo fixture so the merged fork guidance path can be observed on a real fork PR.

Fixture scope:
- RESW addition: `ShellExtension_OpenInTerminalMenuItem_NewWindowDescription`
- WTA YAML update: `system.selection_copied`

Expected behavior under test:
- fork path inspects all matching locale counterparts for both files
- fork path stays read-only against the fork branch
- fork path reports actionable missing/updated locale guidance without mutating fork head

No workflow, permission, or settings changes are included.