### PR TITLE
Clarify automatic approval policy description

### DIFF
--- a/policies/en-US/IntelligentTerminal.adml
+++ b/policies/en-US/IntelligentTerminal.adml
@@ -44,9 +44,9 @@ If you enable this policy or do not configure it, users can add custom agent com
 
 If you enable this policy or do not configure it, users can toggle auto-fix in settings. If you disable this policy, auto-fix is forced off regardless of the user setting.</string>
       <string id="AllowAutomaticApproval">Allow Automatic Approval</string>
-      <string id="AllowAutomaticApprovalText">Controls whether users can ask an AI agent provider to enable its advertised allow-all mode. Each provider defines the resulting confirmation behavior, permissions, sandbox, file access, and network access.
+      <string id="AllowAutomaticApprovalText">Controls whether users can configure their own AI agent provider to enable its advertised allow-all mode. Each provider defines the resulting confirmation behavior, permissions, sandboxing, file access, and network access.
 
-If you enable this policy or do not configure it, users can enable automatic approval in Settings. Providers without a supported ACP allow-all mode continue to ask for permission. Disabling this policy will never allow users to run their agent providers in allow-all mode.</string>
+Disabling this policy prevents users from configuring, and the feature is disabled.</string>
       <string id="AllowAgentSessionHooks">Allow Agent Session Hooks</string>
       <string id="AllowAgentSessionHooksText">Controls whether agent session tracking hooks can be installed in Intelligent Terminal. Hooks integrate with agents (GitHub Copilot, Claude, Gemini) to track sessions across tools.
 


### PR DESCRIPTION
## Summary of the Pull Request

Update the description of the Allow Automatic Approval Group Policy. Use revised wording for provider-specific allow-all configuration and the disabled-policy description. Policy behavior and all other text remain unchanged.

## References and Relevant Issues

## Detailed Description of the Pull Request / Additional comments

This policy resource currently ships only in en-US; no translated counterparts exist.

## Validation Steps Performed

After publication, validated XML parsing for ADML/ADMX, the exact supplied description and paragraph break, unchanged policy references and string keys, UTF-8/BOM/line-ending preservation, and byte-for-byte preservation outside the description. The committed diff contains only the intended ADML resource and passes the whitespace check. No translated counterparts exist. No build, deployment or runtime changes were needed for this wording-only update.

## PR Checklist
- [x] For #326
- [x] Scope limited to the policy description
- [x] Local resource validation completed
