### PR TITLE
Align first-run dropdowns with Settings

### DIFF
--- a/src/cascadia/TerminalApp/FreOverlay.cpp
+++ b/src/cascadia/TerminalApp/FreOverlay.cpp
@@ -666,30 +666,9 @@ namespace winrt::TerminalApp::implementation
         measureDescription(SessionDescriptionText());
         measureDescription(TokenUsageDescriptionText());
 
-        TextBlock optionProbe;
-        optionProbe.FontSize(errorDetectionComboBox.FontSize());
-        double longestOptionWidth = 0;
-        const auto measureOption = [&](const winrt::hstring& text) {
-            optionProbe.Text(text);
-            optionProbe.Measure(unconstrained);
-            longestOptionWidth = std::max(
-                longestOptionWidth,
-                static_cast<double>(optionProbe.DesiredSize().Width));
-        };
-        measureOption(RS_(L"FreOverlay_ErrorDetectionDetectOption/Content"));
-        measureOption(RS_(L"FreOverlay_ErrorDetectionAutoFixOption/Content"));
-        measureOption(RS_(L"FreOverlay_ErrorDetectionOffOption/Content"));
-
-        // Reserve enough room for the longest localized option plus the
-        // ComboBox padding and drop-down glyph when calculating the form width.
-        // The ComboBox itself keeps its XAML MinWidth and follows the selected
-        // option's natural width.
-        constexpr double comboBoxChromeWidth = 48;
-        const double errorDetectionWidth = longestOptionWidth + comboBoxChromeWidth;
-
         double longestControlWidth = AgentComboBox().MinWidth();
         longestControlWidth = std::max(longestControlWidth, PanePositionComboBox().MinWidth());
-        longestControlWidth = std::max(longestControlWidth, errorDetectionWidth);
+        longestControlWidth = std::max(longestControlWidth, errorDetectionComboBox.Width());
 
         constexpr double cardHorizontalPadding = 32;
         constexpr double columnSpacing = 24;

--- a/src/cascadia/TerminalApp/FreOverlay.xaml
+++ b/src/cascadia/TerminalApp/FreOverlay.xaml
@@ -30,6 +30,11 @@
             <x:Double x:Key="StandardControlMaxWidth">1000</x:Double>
             <!--  Welcome page has two side-by-side cards (1.5× the standard width)  -->
             <x:Double x:Key="WelcomeContentMaxWidth">1500</x:Double>
+
+            <DataTemplate x:Key="FreErrorDetectionOptionTemplate">
+                <TextBlock Text="{Binding}"
+                           TextWrapping="WrapWholeWords" />
+            </DataTemplate>
         </ResourceDictionary>
     </UserControl.Resources>
 
@@ -256,10 +261,11 @@
                                                Visibility="Collapsed"
                                                AutomationProperties.LiveSetting="Polite" />
                                 </StackPanel>
-                                <ComboBox x:Name="AgentComboBox" Grid.Column="1"
-                                          MinWidth="220"
-                                          VerticalAlignment="Center"
-                                          SelectionChanged="_OnAgentSelectionChanged">
+                                <ComboBox x:Name="AgentComboBox"
+                                          Grid.Column="1"
+                                          AutomationProperties.AccessibilityView="Content"
+                                          SelectionChanged="_OnAgentSelectionChanged"
+                                          Style="{StaticResource ComboBoxSettingStyle}">
                                     <ComboBox.ItemTemplate>
                                         <DataTemplate x:DataType="local:FreAgentEntry">
                                             <TextBlock Text="{x:Bind DisplayLabel}" />
@@ -298,9 +304,10 @@
                                                FontSize="12" Foreground="#99FFFFFF"
                                                TextWrapping="Wrap" />
                                 </StackPanel>
-                                <ComboBox x:Name="PanePositionComboBox" Grid.Column="1"
-                                          MinWidth="120"
-                                          VerticalAlignment="Center" />
+                                <ComboBox x:Name="PanePositionComboBox"
+                                          Grid.Column="1"
+                                          AutomationProperties.AccessibilityView="Content"
+                                          Style="{StaticResource ComboBoxSettingStyle}" />
                             </Grid>
                         </Border>
 
@@ -332,12 +339,16 @@
                                 </StackPanel>
                                 <ComboBox x:Name="ErrorDetectionComboBox"
                                           Grid.Column="1"
-                                          MinWidth="120"
-                                          VerticalAlignment="Center">
-                                    <ComboBoxItem x:Uid="FreOverlay_ErrorDetectionDetectOption" />
+                                          AutomationProperties.AccessibilityView="Content"
+                                          Style="{StaticResource ComboBoxSettingStyle}"
+                                          Width="{StaticResource StandardBoxMinWidth}">
+                                    <ComboBoxItem x:Uid="FreOverlay_ErrorDetectionDetectOption"
+                                                  ContentTemplate="{StaticResource FreErrorDetectionOptionTemplate}" />
                                     <ComboBoxItem x:Name="ErrorDetectionAutoFixOption"
-                                                  x:Uid="FreOverlay_ErrorDetectionAutoFixOption" />
-                                    <ComboBoxItem x:Uid="FreOverlay_ErrorDetectionOffOption" />
+                                                  x:Uid="FreOverlay_ErrorDetectionAutoFixOption"
+                                                  ContentTemplate="{StaticResource FreErrorDetectionOptionTemplate}" />
+                                    <ComboBoxItem x:Uid="FreOverlay_ErrorDetectionOffOption"
+                                                  ContentTemplate="{StaticResource FreErrorDetectionOptionTemplate}" />
                                 </ComboBox>
                             </Grid>
                         </Border>


### PR DESCRIPTION
## Summary

- use the shared Settings ComboBox style for the first-run Agent, Agent position, and Error detection dropdowns
- standardize dropdown sizing with the Settings UI
- keep the Error detection dropdown at a stable width and wrap long localized options
- update the FRE form-width calculation to match the fixed dropdown sizing
- preserve the existing options, defaults, policy handling, and saved values

## Validation

- built TerminalApp successfully
- verified the updated dropdown appearance and alignment in the first-run experience
- checked selection and dropdown behavior for all three controls