### PR TITLE
Fix crash when detaching the last terminal from an agent tab

### DIFF
--- a/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
+++ b/src/cascadia/LocalTests_TerminalApp/TabTests.cpp
@@ -330,6 +330,8 @@ namespace TerminalAppLocalTests
         TEST_METHOD(ContentTransferReviewClosedAgentSuppressionMovesWithTab);
         TEST_METHOD(ContentTransferReviewSinglePaneKeepsDestinationSuppression);
         TEST_METHOD(ContentTransferReviewSinglePaneKeepsSuppressedDestination);
+        TEST_METHOD(DetachLastTerminalPaneClosesAgentOnlyTab);
+        TEST_METHOD(DetachTerminalPanePreservesRemainingFocus);
         TEST_METHOD(ClosingAgentPaneSuppressesPrewarm);
         TEST_METHOD(AgentPaneTeardownAllowsSynchronousRecreation);
         TEST_METHOD(AgentPaneLifetimeMovesAndDestroysRealCoresOnce);
@@ -3823,6 +3825,78 @@ namespace TerminalAppLocalTests
                 winrt::hresult_error,
                 [](const winrt::hresult_error& error) { return error.code() == E_ILLEGAL_METHOD_CALL; });
             VERIFY_ARE_EQUAL(contentId, finalReceive->GetTerminalControl().ContentId());
+        });
+    }
+
+    void TabTests::DetachLastTerminalPaneClosesAgentOnlyTab()
+    {
+        for (const bool hidden : { false, true })
+        {
+            auto fixture = _createContentTransferFixture(false, hidden, false, true);
+            const auto cleanup = wil::scope_exit([&]() {
+                RunOnUIThread([&]() {
+                    _closeContentTransferFixture(*fixture, false);
+                    fixture.reset();
+                });
+            });
+            TestOnUIThread([&]() {
+                const auto tab = fixture->original.tab;
+                const auto selected = tab->GetActivePane();
+                const auto contentId = selected->GetTerminalControl().ContentId();
+                VERIFY_IS_FALSE(selected->IsAgentPane());
+                VERIFY_ARE_EQUAL(hidden, tab->HasStashedAgentPane());
+                unsigned int closed = 0;
+                const auto token = tab->Closed([&](auto&&, auto&&) { ++closed; });
+                const auto revoke = wil::scope_exit([&]() { tab->Closed(token); });
+
+                const auto detached = tab->DetachPane(selected);
+                VERIFY_IS_TRUE(detached == selected);
+                VERIFY_ARE_EQUAL(1u, closed);
+                VERIFY_ARE_EQUAL(0u, fixture->source->_tabs.Size());
+                VERIFY_IS_TRUE(tab->GetRootPane()->GetActivePane() == nullptr);
+                VERIFY_IS_NULL(tab->FindAgentPaneContent());
+                VERIFY_IS_NULL(fixture->source->_manager.TryLookupCore(fixture->agentContentId));
+                VERIFY_IS_NOT_NULL(fixture->source->_manager.TryLookupCore(contentId));
+                VERIFY_ARE_EQUAL(contentId, detached->GetTerminalControl().ContentId());
+
+                detached->Shutdown();
+                _closeContentTransferFixture(*fixture, true);
+            });
+        }
+    }
+
+    void TabTests::DetachTerminalPanePreservesRemainingFocus()
+    {
+        auto fixture = _createContentTransferFixture(false, false);
+        const auto cleanup = wil::scope_exit([&]() {
+            RunOnUIThread([&]() {
+                _closeContentTransferFixture(*fixture, false);
+                fixture.reset();
+            });
+        });
+        TestOnUIThread([&]() {
+            const auto tab = fixture->original.tab;
+            fixture->source->_TeardownAgentPane(tab);
+            const auto selected = tab->GetActivePane();
+            const auto contentId = selected->GetTerminalControl().ContentId();
+            const auto remaining = std::find_if(fixture->original.leaves.begin(), fixture->original.leaves.end(), [&](const auto& leaf) {
+                return leaf.contentId != fixture->agentContentId && leaf.contentId != contentId;
+            });
+            VERIFY_IS_TRUE(remaining != fixture->original.leaves.end());
+
+            const auto detached = tab->DetachPane(selected);
+            VERIFY_IS_TRUE(detached == selected);
+            VERIFY_ARE_EQUAL(1u, fixture->source->_tabs.Size());
+            VERIFY_ARE_EQUAL(1, tab->GetLeafPaneCount());
+            VERIFY_IS_TRUE(tab->GetActivePane() != nullptr);
+            VERIFY_IS_TRUE(tab->GetRootPane()->GetActivePane() == tab->GetActivePane());
+            VERIFY_ARE_EQUAL(remaining->contentId, tab->GetActiveTerminalControl().ContentId());
+            VERIFY_IS_TRUE(tab->GetActiveTerminalControl().Connection() == remaining->connection);
+            VERIFY_ARE_EQUAL(0u, remaining->closed->load());
+            VERIFY_IS_NOT_NULL(fixture->source->_manager.TryLookupCore(contentId));
+
+            detached->Shutdown();
+            _closeContentTransferFixture(*fixture, true);
         });
     }
 

--- a/src/cascadia/TerminalApp/Tab.cpp
+++ b/src/cascadia/TerminalApp/Tab.cpp
@@ -822,8 +822,12 @@ namespace winrt::TerminalApp::implementation
         // Attempt to remove the active pane from the tree
         if (const auto pane = _rootPane->DetachPane(selectedPane))
         {
-            // Just make sure that the remaining pane is marked active
-            _UpdateActivePane(_rootPane->GetActivePane());
+            // Detaching the last terminal can close the remaining agent-only
+            // subtree, leaving no active pane while Closed removes the tab.
+            if (const auto activePane = _rootPane->GetActivePane())
+            {
+                _UpdateActivePane(activePane);
+            }
 
             return pane;
         }


### PR DESCRIPTION
## Summary of the Pull Request

Fix a null-pointer crash when detaching the last normal terminal pane from a tab whose remaining content is an agent pane.

## References and Relevant Issues

Found while investigating a cross-window pane-transfer integration failure. No linked issue.

This addresses the confirmed business-logic crash during an **allowed** transfer. It does not claim to fix the separate production WIL exception-conversion crash observed during a **rejected** transfer.

## Detailed Description of the Pull Request / Additional comments

`Pane::_CloseChild` intentionally closes an agent-only remainder, clears its children, and raises `Closed`. After that operation, `Tab::DetachPane` previously called `_UpdateActivePane(_rootPane->GetActivePane())` unconditionally. The result can be empty, leading to `Pane::SetActive(this=nullptr)`.

Only update focus if the remaining tree actually has an active pane. Keep the existing tab-close notifications, agent retirement, and ordinary remaining-pane focus behavior unchanged.

Add native regression coverage for:

- Detaching the last terminal with either a visible or hidden agent: the source tab closes once, agent content retires, and the detached terminal remains alive until explicitly shut down.
- Detaching from an ordinary multi-pane tab: the surviving pane retains focus and its connection identity, with no premature resource closure.

The PR is intentionally limited to these two C++ files. Broader E2E harness and oracle corrections from the investigation remain outside this PR.

## Validation Steps Performed

On the original development worktree with this exact fix:

- Built the x64 Debug LocalTests, TestHostApp, and Dev package using MSVC 14.51.
- Passed all five targeted native tests: the two new detach tests, both `ContentTransferReviewSinglePane*` tests, and `AgentPaneTeardownAllowsSynchronousRecreation`.
- Passed all 10 AgentPaneLifetime integration cases with no failures or skips on the rebuilt Dev package. The rejection/rollback and subsequent allowed-move control completed in the original process, with shell identities and the destination helper/session preserved.
- Observed no Terminal crash events during that run. Store was not redeployed; Dev and Store settings/state were preserved.

The integration run used the separate local E2E harness corrections noted above; those changes are not included here.

This branch was then created from `main` at `9842f5b6b`. Both touched files were identical between the original validation base and that main revision, and the focused patch was transferred unchanged. The complete build/integration run has not been repeated on the new main-based worktree.

## PR Checklist

- [x] Native regression tests added and passed.
- [x] Focused product fix only; unrelated worktree changes excluded.
- [x] No settings-schema or public documentation changes required.
